### PR TITLE
#22 Hook up the mouse input events for X11

### DIFF
--- a/windowing/shared_mem.go
+++ b/windowing/shared_mem.go
@@ -10,6 +10,14 @@ const (
 	sharedMemQuit  = 0xFF
 )
 
+const (
+	nativeMouseButtonLeft   = 0
+	nativeMouseButtonMiddle = 1
+	nativeMouseButtonRight  = 2
+	nativeMouseButtonX1     = 3
+	nativeMouseButtonX2     = 4
+)
+
 const evtSharedMemSize = 256
 
 type evtMem [evtSharedMemSize]byte
@@ -20,9 +28,9 @@ type baseEvent struct {
 
 type mouseEvent struct {
 	baseEvent
-	mouseX       int32
-	mouseY       int32
-	mouseXButton int32
+	mouseX        int32
+	mouseY        int32
+	mouseButtonId int32
 }
 
 type keyboardEvent struct {

--- a/windowing/win32.go
+++ b/windowing/win32.go
@@ -12,8 +12,8 @@ import (
 */
 import "C"
 
-func toEventType(nativeType uint32) eventType {
-	switch nativeType {
+func (e evtMem) toEventType() eventType {
+	switch e.EventType() {
 	case 512:
 		return evtMouseMove
 	case 513:

--- a/windowing/win32.h
+++ b/windowing/win32.h
@@ -31,8 +31,8 @@ InputEvent setMouseEvent(MSG msg, int buttonId) {
 	InputEvent ie;
 	ie.mouseX = GET_X_LPARAM(msg.lParam);
 	ie.mouseY = GET_Y_LPARAM(msg.lParam);
-	ie.mouseButtonId = buttonId
-	return ie
+	ie.mouseButtonId = buttonId;
+	return ie;
 }
 
 void window_main(const wchar_t* windowTitle, void* evtSharedMem, int size) {
@@ -98,9 +98,9 @@ void window_main(const wchar_t* windowTitle, void* evtSharedMem, int size) {
 						break;
 					case WM_XBUTTONDOWN:
 					case WM_XBUTTONUP:
-						if (msg.wParam & 0x0020) {
+						if (msg.wParam & 0x0010000) {
 							ie = setMouseEvent(msg, MOUSE_BUTTON_X1);
-						} else if (msg.wParam & 0x0040) {
+						} else if (msg.wParam & 0x0020000) {
 							ie = setMouseEvent(msg, MOUSE_BUTTON_X2);
 						}
 						break;

--- a/windowing/win32.h
+++ b/windowing/win32.h
@@ -27,6 +27,14 @@ LRESULT CALLBACK window_proc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
     return DefWindowProc(hwnd, uMsg, wParam, lParam);
 }
 
+InputEvent setMouseEvent(MSG msg, int buttonId) {
+	InputEvent ie;
+	ie.mouseX = GET_X_LPARAM(msg.lParam);
+	ie.mouseY = GET_Y_LPARAM(msg.lParam);
+	ie.mouseButtonId = buttonId
+	return ie
+}
+
 void window_main(const wchar_t* windowTitle, void* evtSharedMem, int size) {
 	char* esm = evtSharedMem;
 	// Register the window class.
@@ -74,21 +82,26 @@ void window_main(const wchar_t* windowTitle, void* evtSharedMem, int size) {
 				InputEvent ie;
 				switch (msg.message) {
 					case WM_MOUSEMOVE:
+						ie = setMouseEvent(msg, -1);
+						break;
 					case WM_LBUTTONDOWN:
 					case WM_LBUTTONUP:
+						ie = setMouseEvent(msg, MOUSE_BUTTON_LEFT);
+						break;
 					case WM_MBUTTONDOWN:
 					case WM_MBUTTONUP:
+						ie = setMouseEvent(msg, MOUSE_BUTTON_MIDDLE);
+						break;
 					case WM_RBUTTONDOWN:
 					case WM_RBUTTONUP:
+						ie = setMouseEvent(msg, MOUSE_BUTTON_RIGHT);
+						break;
 					case WM_XBUTTONDOWN:
 					case WM_XBUTTONUP:
-						ie.mouseX = GET_X_LPARAM(msg.lParam);
-						ie.mouseY = GET_Y_LPARAM(msg.lParam);
-						ie.mouseXButton = 0;
 						if (msg.wParam & 0x0020) {
-							ie.mouseXButton = 1;
+							ie = setMouseEvent(msg, MOUSE_BUTTON_X1);
 						} else if (msg.wParam & 0x0040) {
-							ie.mouseXButton = 2;
+							ie = setMouseEvent(msg, MOUSE_BUTTON_X2);
 						}
 						break;
 				}

--- a/windowing/window.go
+++ b/windowing/window.go
@@ -75,15 +75,19 @@ func (w *Window) processMouseEvent(evtType eventType) {
 	case evtX1MouseDown:
 		me := w.evtSharedMem.toMouseEvent()
 		if me.mouseButtonId == 4 {
+			println("X2 down")
 			w.Mouse.SetDown(hid.MouseButtonX2)
 		} else {
+			println("X1 down")
 			w.Mouse.SetDown(hid.MouseButtonX1)
 		}
 	case evtX1MouseUp:
 		me := w.evtSharedMem.toMouseEvent()
 		if me.mouseButtonId == 4 {
+			println("X2 up")
 			w.Mouse.SetUp(hid.MouseButtonX2)
 		} else {
+			println("X1 up")
 			w.Mouse.SetUp(hid.MouseButtonX1)
 		}
 	case evtX2MouseDown:

--- a/windowing/window.go
+++ b/windowing/window.go
@@ -51,7 +51,7 @@ func (w Window) IsCrashed() bool {
 }
 
 func (w *Window) processEvent() {
-	evtType := toEventType(w.evtSharedMem.EventType())
+	evtType := w.evtSharedMem.toEventType()
 	w.processMouseEvent(evtType)
 }
 
@@ -74,14 +74,14 @@ func (w *Window) processMouseEvent(evtType eventType) {
 		w.Mouse.SetUp(hid.MouseButtonRight)
 	case evtX1MouseDown:
 		me := w.evtSharedMem.toMouseEvent()
-		if me.mouseXButton == 2 {
+		if me.mouseButtonId == 4 {
 			w.Mouse.SetDown(hid.MouseButtonX2)
 		} else {
 			w.Mouse.SetDown(hid.MouseButtonX1)
 		}
 	case evtX1MouseUp:
 		me := w.evtSharedMem.toMouseEvent()
-		if me.mouseXButton == 2 {
+		if me.mouseButtonId == 4 {
 			w.Mouse.SetUp(hid.MouseButtonX2)
 		} else {
 			w.Mouse.SetUp(hid.MouseButtonX1)

--- a/windowing/windowing.h
+++ b/windowing/windowing.h
@@ -10,13 +10,19 @@
 #define SHARED_MEM_QUIT			0xFF
 #define SHARED_MEM_DATA_START	4
 
+#define MOUSE_BUTTON_LEFT		0
+#define MOUSE_BUTTON_MIDDLE		1
+#define MOUSE_BUTTON_RIGHT		2
+#define MOUSE_BUTTON_X1			3
+#define MOUSE_BUTTON_X2			4
+
 typedef struct {
 	union {
 		int32_t mouseX;
 		int32_t key;
 	};
 	int32_t mouseY;
-	int32_t mouseXButton;
+	int32_t mouseButtonId;
 } InputEvent;
 
 #if defined(_WIN32) || defined(_WIN64)

--- a/windowing/x11.go
+++ b/windowing/x11.go
@@ -6,7 +6,48 @@ package windowing
 #include "windowing.h"
 */
 import "C"
-import "unsafe"
+import (
+	"unsafe"
+)
+
+func (e evtMem) toEventType() eventType {
+	switch e.EventType() {
+	case 6:
+		return evtMouseMove
+	case 4:
+		switch e.toMouseEvent().mouseButtonId {
+		case nativeMouseButtonLeft:
+			return evtLeftMouseDown
+		case nativeMouseButtonMiddle:
+			return evtMiddleMouseDown
+		case nativeMouseButtonRight:
+			return evtRightMouseDown
+		case nativeMouseButtonX1:
+			return evtX1MouseDown
+		case nativeMouseButtonX2:
+			return evtX2MouseDown
+		default:
+			return evtUnknown
+		}
+	case 5:
+		switch e.toMouseEvent().mouseButtonId {
+		case nativeMouseButtonLeft:
+			return evtLeftMouseUp
+		case nativeMouseButtonMiddle:
+			return evtMiddleMouseUp
+		case nativeMouseButtonRight:
+			return evtRightMouseUp
+		case nativeMouseButtonX1:
+			return evtX1MouseUp
+		case nativeMouseButtonX2:
+			return evtX2MouseUp
+		default:
+			return evtUnknown
+		}
+	default:
+		return evtUnknown
+	}
+}
 
 func createWindow(windowName string, evtSharedMem *evtMem) {
 	title := C.CString(string(windowName))

--- a/windowing/x11.h
+++ b/windowing/x11.h
@@ -34,10 +34,40 @@ void window_main(const char* windowTitle, void* evtSharedMem, int size) {
 		uint32_t msgType = e.type;
 		memcpy(esmData, &msgType, sizeof(msgType));
 		esmData += sizeof(msgType);
+		InputEvent ie;
 		switch (e.type) {
 			case Expose:
 				break;
 			case KeyPress:
+				break;
+			case KeyRelease:
+				break;
+			case ButtonPress:
+			case ButtonRelease:
+				ie.mouseX = e.xbutton.x;
+				ie.mouseY = e.xbutton.y;
+				switch (e.xbutton.button) {
+					case Button1:
+						ie.mouseButtonId = MOUSE_BUTTON_LEFT;
+						break;
+					case Button2:
+						ie.mouseButtonId = MOUSE_BUTTON_MIDDLE;
+						break;
+					case Button3:
+						ie.mouseButtonId = MOUSE_BUTTON_RIGHT;
+						break;
+					case Button4:
+						ie.mouseButtonId = MOUSE_BUTTON_X1;
+						break;
+					case Button5:
+						ie.mouseButtonId = MOUSE_BUTTON_X2;
+						break;
+				}
+				break;
+			case MotionNotify:
+				ie.mouseX = e.xmotion.x;
+				ie.mouseY = e.xmotion.y;
+				ie.mouseButtonId = -1;
 				break;
 			case ClientMessage:
 				if (filtered) {
@@ -50,6 +80,7 @@ void window_main(const char* windowTitle, void* evtSharedMem, int size) {
 				break;
 		}
 		if (esm[0] == SHARED_MEM_WRITING) {
+			memcpy(esmData, &ie, sizeof(ie));
 			esm[0] = SHARED_MEM_WRITTEN;
 		}
 	}


### PR DESCRIPTION
This is working X11 mouse input events. There is also a bit of refactor for the windows mouse events here to make more common code between the windowing systems. I refactored the windows code so that which button was being clicked is being sent rather than just X1 and X2

