### PR TITLE
#33 Cleanup initial Win32 window code

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,28 @@ Being a stubborn C programmer for most of my programming life, it was not easy t
 The development of Kaiju is to be captured on video. Every PR will be required to have a video of the development process of that request. The goal of this is to be a tool for new developers to learn the process of developing features for a game engine, but also help maintainers to understand the thinking behind the code. It is often hard to know why choices were made just by looking at the final product of the code in the review, having a video log/history of the development process helps us all learn together.
 
 We are well aware that requiring a video log for every PR is something that will put off developers, but we strongly believe that code is not just some assembly line to pump out a result, it's a beautiful tapestry of ideas, puzzles, and hard-made choices. We wish to share with everyone in the process and to learn from others as well.
+
+## Windows Development
+- Download mingw into `C:/`
+  - I use [x86_64-13.2.0-release-win32-seh-msvcrt-rt_v11-rev1.7z
+](https://github.com/niXman/mingw-builds-binaries/releases)
+- Add the `bin` folder to your environment path
+  - Mine is `C:\mingw64\bin`
+- Pull the repository
+- Use `build/build.bat` to compile the executable to `bin/kaiju.exe`
+
+### Debug in VSCode
+- Open the project in VSCode
+- Select one of the Windows debug options
+- Press F5
+
+## Linux development
+- Ensure you've got `gcc` installed
+- Ensure you've got the X11 libs installed (xlib)
+- Pull the repository
+- Use `build/build.sh` to compile the executable to `bin/kaiju`
+
+### Debug in VSCode
+- Open the project in VSCode
+- Select one of the X11 debug options
+- Press F5

--- a/engine/host.go
+++ b/engine/host.go
@@ -11,15 +11,19 @@ type Host struct {
 	LateUpdater Updater
 }
 
-func NewHost() Host {
+func NewHost() (Host, error) {
+	win, err := windowing.New("Kaiju")
+	if err != nil {
+		return Host{}, err
+	}
 	return Host{
 		entities:    make([]*Entity, 0),
 		frameTime:   0,
 		Closing:     false,
 		Updater:     NewUpdater(),
 		LateUpdater: NewUpdater(),
-		Window:      windowing.New("Kaiju"),
-	}
+		Window:      win,
+	}, nil
 }
 
 func (host *Host) Update(deltaTime float64) {

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module kaiju
 
 go 1.21.3
 
-require (
-	github.com/KaijuEngine/yaegi v1.0.0
-)
+require github.com/KaijuEngine/yaegi v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
-github.com/KaijuEngine/yaegi v1.0.0 h1:qw4HT5GePE3baJwkR4BAr9CAW11edPq2b8OCI8OzcrE=
-github.com/KaijuEngine/yaegi v1.0.0/go.mod h1:KV+8UawtAJWqFdS1rzJMRoye3FvKtz+ArARQLIxUe0Y=
-github.com/traefik/yaegi v0.15.1 h1:YA5SbaL6HZA0Exh9T/oArRHqGN2HQ+zgmCY7dkoTXu4=
-github.com/traefik/yaegi v0.15.1/go.mod h1:AVRxhaI2G+nUsaM1zyktzwXn69G3t/AuTDrCiTds9p0=
+github.com/KaijuEngine/yaegi v1.0.1 h1:SJy+rcD/WpEt5DbTsj816S9Ibo7na1B0SsV98RKeAw4=
+github.com/KaijuEngine/yaegi v1.0.1/go.mod h1:KV+8UawtAJWqFdS1rzJMRoye3FvKtz+ArARQLIxUe0Y=

--- a/main.go
+++ b/main.go
@@ -8,7 +8,10 @@ import (
 
 func main() {
 	lastTime := time.Now()
-	host := engine.NewHost()
+	host, err := engine.NewHost()
+	if err != nil {
+		panic(err)
+	}
 	bootstrap.Main(&host)
 	for !host.Closing {
 		deltaTime := time.Since(lastTime).Seconds()

--- a/windowing/shared_mem.go
+++ b/windowing/shared_mem.go
@@ -20,7 +20,10 @@ const (
 	nativeMouseButtonX2     = 4
 )
 
-const evtSharedMemSize = 256
+const (
+	evtSharedMemSize      = 256
+	evtSharedMemDataStart = 4
+)
 
 type evtMem [evtSharedMemSize]byte
 
@@ -42,6 +45,7 @@ type keyboardEvent struct {
 
 func (e *evtMem) AsPointer() unsafe.Pointer { return unsafe.Pointer(&e[0]) }
 func (e evtMem) IsFatal() bool              { return e[0] == sharedMemFatal }
+func (e evtMem) FatalMessage() string       { return string([]byte(e[evtSharedMemDataStart:])) }
 func (e evtMem) IsReady() bool              { return e[0] >= sharedMemWritten }
 func (e evtMem) IsWritten() bool            { return e[0] == sharedMemWritten }
 func (e evtMem) IsQuit() bool               { return e[0] == sharedMemQuit }

--- a/windowing/window.go
+++ b/windowing/window.go
@@ -1,6 +1,7 @@
 package windowing
 
 import (
+	"errors"
 	"kaiju/hid"
 )
 
@@ -34,7 +35,7 @@ type Window struct {
 	isCrashed     bool
 }
 
-func New(windowName string) *Window {
+func New(windowName string) (*Window, error) {
 	w := &Window{
 		Mouse:  hid.NewMouse(),
 		width:  1280,
@@ -42,7 +43,10 @@ func New(windowName string) *Window {
 	}
 	// TODO:  Pass in width and height
 	createWindow(windowName, &w.evtSharedMem)
-	return w
+	if w.evtSharedMem.IsFatal() {
+		return nil, errors.New(w.evtSharedMem.FatalMessage())
+	}
+	return w, nil
 }
 
 func (w Window) IsClosed() bool {

--- a/windowing/windowing.h
+++ b/windowing/windowing.h
@@ -18,12 +18,36 @@
 
 typedef struct {
 	union {
+		uint8_t writeState;
+		int32_t buffer;
+	};
+	uint32_t evtType;
+	union {
 		int32_t mouseButtonId;
 		int32_t keyId;
 	};
 	int32_t mouseX;
 	int32_t mouseY;
 } InputEvent;
+
+typedef struct {
+	union {
+		char* sharedMem;
+		InputEvent* evt;
+	};
+	int size;
+} SharedMem;
+
+void shared_memory_wait_for_available(SharedMem* sm) {
+	while (sm->evt->writeState != SHARED_MEM_AVAILABLE) {}
+}
+
+void shared_memory_set_write_state(SharedMem* sm, uint8_t state) {
+	uint8_t smState = sm->evt->writeState;
+	if (smState != SHARED_MEM_QUIT && smState != SHARED_MEM_FATAL) {
+		sm->evt->writeState = state;
+	}
+}
 
 #if defined(_WIN32) || defined(_WIN64)
 #include "win32.h"


### PR DESCRIPTION
Adding a fatal message to be read from the caller of the window creation. If a fatal is returned from window create, then it will panic with the message. I've also better wrapped the shared memory into the InputEvent structure so that it can be written to without the need of memcpy. I also updated X11 to use the helper methods created for the shared memory.
