### PR TITLE
Shader load & triangle draw in OpenGL on Win32/X11

### DIFF
--- a/assets/database.go
+++ b/assets/database.go
@@ -1,0 +1,14 @@
+package assets
+
+import "kaiju/filesystem"
+
+type Database struct {
+}
+
+func NewDatabase() Database {
+	return Database{}
+}
+
+func (a *Database) ReadAsset(key string) (string, error) {
+	return filesystem.ReadTextFile(key)
+}

--- a/content/basic.frag
+++ b/content/basic.frag
@@ -1,0 +1,6 @@
+#version 330 core
+out vec4 FragColor;
+
+void main() {
+    FragColor = vec4(1.0, 0.5, 0.2, 1.0);
+} 

--- a/content/basic.vert
+++ b/content/basic.vert
@@ -1,0 +1,6 @@
+#version 330 core
+layout (location = 0) in vec3 aPos;
+
+void main() {
+    gl_Position = vec4(aPos.x, aPos.y, aPos.z, 1.0);
+}

--- a/engine/host.go
+++ b/engine/host.go
@@ -1,14 +1,20 @@
 package engine
 
-import "kaiju/windowing"
+import (
+	"kaiju/assets"
+	"kaiju/rendering"
+	"kaiju/windowing"
+)
 
 type Host struct {
-	entities    []*Entity
-	Window      *windowing.Window
-	frameTime   float64
-	Closing     bool
-	Updater     Updater
-	LateUpdater Updater
+	entities      []*Entity
+	Window        *windowing.Window
+	ShaderCache   rendering.ShaderCache
+	frameTime     float64
+	Closing       bool
+	Updater       Updater
+	LateUpdater   Updater
+	assetDatabase assets.Database
 }
 
 func NewHost() (Host, error) {
@@ -16,14 +22,17 @@ func NewHost() (Host, error) {
 	if err != nil {
 		return Host{}, err
 	}
-	return Host{
-		entities:    make([]*Entity, 0),
-		frameTime:   0,
-		Closing:     false,
-		Updater:     NewUpdater(),
-		LateUpdater: NewUpdater(),
-		Window:      win,
-	}, nil
+	host := Host{
+		entities:      make([]*Entity, 0),
+		frameTime:     0,
+		Closing:       false,
+		Updater:       NewUpdater(),
+		LateUpdater:   NewUpdater(),
+		Window:        win,
+		assetDatabase: assets.NewDatabase(),
+	}
+	host.ShaderCache = rendering.NewShaderCache(host.Window.Renderer, &host.assetDatabase)
+	return host, nil
 }
 
 func (host *Host) Update(deltaTime float64) {
@@ -33,5 +42,8 @@ func (host *Host) Update(deltaTime float64) {
 	if host.Window.IsClosed() || host.Window.IsCrashed() {
 		host.Closing = true
 	}
+	host.ShaderCache.CreatePending()
+	//gl.ClearScreen()
+	//host.Window.SwapBuffers()
 	// TODO:  Do end updates on various systems
 }

--- a/gl/gles.nonjs.go
+++ b/gl/gles.nonjs.go
@@ -1,0 +1,248 @@
+//go:build !js && !wasm
+
+package gl
+
+/*
+#include <stdlib.h>
+#include "glad.h"
+
+GLuint cglCreateShader(GLenum type) {
+	return glCreateShader(type);
+}
+
+void cglShaderSource(GLuint shader, GLsizei count, const GLchar **string, const GLint *length) {
+	glShaderSource(shader, count, string, length);
+}
+
+void cglCompileShader(GLuint shader) {
+	glCompileShader(shader);
+}
+
+void cglGetShaderiv(GLuint shader, GLenum pname, GLint *params) {
+	glGetShaderiv(shader, pname, params);
+}
+
+void cglClearScreen() {
+	glClearColor(0.392f, 0.584f, 0.929f, 1.0f);
+	glClear(GL_COLOR_BUFFER_BIT);
+}
+
+void cglGetShaderInfoLog(GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *infoLog) {
+	glGetShaderInfoLog(shader, bufSize, length, infoLog);
+}
+
+GLuint cglCreateProgram() {
+	return glCreateProgram();
+}
+
+void cglAttachShader(GLuint program, GLuint shader) {
+	glAttachShader(program, shader);
+}
+
+void cglLinkProgram(GLuint program) {
+	glLinkProgram(program);
+}
+
+void cglGetProgramiv(GLuint program, GLenum pname, GLint *params) {
+	glGetProgramiv(program, pname, params);
+}
+
+void cglGetProgramInfoLog(GLuint program, GLsizei bufSize, GLsizei *length, GLchar *infoLog) {
+	glGetProgramInfoLog(program, bufSize, length, infoLog);
+}
+
+void cglDeleteShader(GLuint shader) {
+	glDeleteShader(shader);
+}
+
+void cglDeleteProgram(GLuint program) {
+	glDeleteProgram(program);
+}
+
+void cglGenVertexArrays(GLsizei n, GLuint *arrays) {
+	glGenVertexArrays(n, arrays);
+}
+
+void cglGenBuffers(GLsizei n, GLuint *buffers) {
+	glGenBuffers(n, buffers);
+}
+
+void cglBindVertexArray(GLuint array) {
+	glBindVertexArray(array);
+}
+
+void cglBindBuffer(GLenum target, GLuint buffer) {
+	glBindBuffer(target, buffer);
+}
+
+void cglBufferData(GLenum target, GLsizeiptr size, const void *data, GLenum usage) {
+	glBufferData(target, size, data, usage);
+}
+
+void cglVertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void *pointer) {
+	glVertexAttribPointer(index, size, type, normalized, stride, pointer);
+}
+
+void cglEnableVertexAttribArray(GLuint index) {
+	glEnableVertexAttribArray(index);
+}
+
+void cglUseProgram(GLuint program) {
+	glUseProgram(program);
+}
+
+void cglDrawArrays(GLenum mode, GLint first, GLsizei count) {
+	glDrawArrays(mode, first, count);
+}
+*/
+import "C"
+import "unsafe"
+
+type Handle uint32
+
+func (h Handle) IsValid() bool {
+	return h != 0
+}
+
+func (h Handle) AsGL() C.GLuint {
+	return C.GLuint(h)
+}
+
+type Result int32
+
+func (r Result) IsOkay() bool {
+	return r != 0
+}
+
+func (r Result) Equal(value int32) bool {
+	return int32(r) == value
+}
+
+const (
+	CompileStatus        = 0x8B81
+	ShaderType           = 0x8B4F
+	FragmentShader       = 0x8B30
+	VertexShader         = 0x8B31
+	GeometryShader       = 0x8DD9
+	TessControlShader    = 0x8E88
+	TessEvaluationShader = 0x8E87
+	InfoLogLength        = 0x8B84
+	LinkStatus           = 0x8B82
+	ArrayBuffer          = 0x8892
+	StaticDraw           = 0x88E4
+	Float                = 0x1406
+	Triangles            = 0x0004
+)
+
+func ClearScreen() {
+	C.cglClearScreen()
+}
+
+func CreateShader(shaderType Handle) Handle {
+	res := C.cglCreateShader(C.GLenum(shaderType))
+	return Handle(res)
+}
+
+func ShaderSource(shader Handle, src string) {
+	csrc := C.CString(src)
+	defer C.free(unsafe.Pointer(csrc))
+	C.cglShaderSource(shader.AsGL(), 1, &csrc, nil)
+}
+
+func CompileShader(shader Handle) {
+	C.cglCompileShader(shader.AsGL())
+}
+
+func GetShaderParameter(shader Handle, param Handle) Result {
+	var res C.GLint
+	C.cglGetShaderiv(shader.AsGL(), C.GLenum(param), &res)
+	return Result(res)
+}
+
+func GetShaderInfoLog(shader Handle) string {
+	var length C.GLint
+	C.cglGetShaderiv(shader.AsGL(), C.GLenum(InfoLogLength), &length)
+	if length == 0 {
+		return ""
+	}
+	log := make([]byte, length)
+	C.cglGetShaderInfoLog(shader.AsGL(), C.GLsizei(length), nil, (*C.GLchar)(unsafe.Pointer(&log[0])))
+	return string(log)
+}
+
+func CreateProgram() Handle {
+	return Handle(C.cglCreateProgram())
+}
+
+func AttachShader(program Handle, shader Handle) {
+	C.cglAttachShader(program.AsGL(), C.GLuint(shader))
+}
+
+func LinkProgram(program Handle) {
+	C.cglLinkProgram(program.AsGL())
+}
+
+func GetProgramParameter(program Handle, param Handle) Result {
+	var res C.GLint
+	C.cglGetProgramiv(program.AsGL(), C.GLenum(param), &res)
+	return Result(res)
+}
+
+func GetProgramInfoLog(program Handle) string {
+	var length C.GLint
+	C.cglGetProgramiv(program.AsGL(), C.GLenum(InfoLogLength), &length)
+	if length == 0 {
+		return ""
+	}
+	log := make([]byte, length)
+	C.cglGetProgramInfoLog(program.AsGL(), C.GLsizei(length), nil, (*C.GLchar)(unsafe.Pointer(&log[0])))
+	return string(log)
+}
+
+func DeleteShader(shader Handle) {
+	C.cglDeleteShader(shader.AsGL())
+}
+
+func DeleteProgram(program Handle) {
+	C.cglDeleteProgram(program.AsGL())
+}
+
+func GenVertexArrays(n int32, arrays *Handle) {
+	C.cglGenVertexArrays(C.GLsizei(n), (*C.GLuint)(unsafe.Pointer(arrays)))
+}
+
+func GenBuffers(n int32, buffers *Handle) {
+	C.cglGenBuffers(C.GLsizei(n), (*C.GLuint)(unsafe.Pointer(buffers)))
+}
+
+func BindVertexArray(array Handle) {
+	C.cglBindVertexArray(array.AsGL())
+}
+
+func BindBuffer(target Handle, buffer Handle) {
+	C.cglBindBuffer(C.GLenum(target), buffer.AsGL())
+}
+
+func BufferData(target Handle, data []float32, usage Handle) {
+	C.cglBufferData(C.GLenum(target), C.GLsizeiptr(len(data)*4), unsafe.Pointer(&data[0]), C.GLenum(usage))
+}
+
+func VertexAttribPointer(index uint32, size int32, typ Handle, normalized bool, stride int32, offset unsafe.Pointer) {
+	var nml uint8
+	if normalized {
+		nml = 1
+	}
+	C.cglVertexAttribPointer(C.GLuint(index), C.GLint(size), C.GLenum(typ), C.GLboolean(nml), C.GLsizei(stride), offset)
+}
+
+func EnableVertexAttribArray(index uint32) {
+	C.cglEnableVertexAttribArray(C.GLuint(index))
+}
+
+func UseProgram(program Handle) {
+	C.cglUseProgram(program.AsGL())
+}
+
+func DrawArrays(mode Handle, first int32, count int32) {
+	C.cglDrawArrays(C.GLenum(mode), C.GLint(first), C.GLsizei(count))
+}

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"kaiju/bootstrap"
 	"kaiju/engine"
+	"kaiju/gl"
 	"time"
 )
 
@@ -13,9 +14,30 @@ func main() {
 		panic(err)
 	}
 	bootstrap.Main(&host)
+	shader := host.ShaderCache.CreateShader("content/basic.vert", "content/basic.frag", "", "", "")
+	verts := []float32{
+		-0.5, -0.5, 0.0,
+		0.5, -0.5, 0.0,
+		0.0, 0.5, 0.0,
+	}
+	var vao, vbo gl.Handle
+	gl.GenVertexArrays(1, &vao)
+	gl.GenBuffers(1, &vbo)
+	gl.BindVertexArray(vao)
+	gl.BindBuffer(gl.ArrayBuffer, vbo)
+	gl.BufferData(gl.ArrayBuffer, verts, gl.StaticDraw)
+	gl.VertexAttribPointer(0, 3, gl.Float, false, 0, nil)
+	gl.EnableVertexAttribArray(0)
+	gl.BindBuffer(gl.ArrayBuffer, 0)
+	gl.BindVertexArray(0)
 	for !host.Closing {
 		deltaTime := time.Since(lastTime).Seconds()
 		lastTime = time.Now()
 		host.Update(deltaTime)
+		gl.ClearScreen()
+		gl.UseProgram(shader.RenderId.(gl.Handle))
+		gl.BindVertexArray(vao)
+		gl.DrawArrays(gl.Triangles, 0, 3)
+		host.Window.SwapBuffers()
 	}
 }

--- a/rendering/renderer.gl.go
+++ b/rendering/renderer.gl.go
@@ -1,0 +1,103 @@
+package rendering
+
+import (
+	"kaiju/assets"
+	"kaiju/gl"
+	"log"
+)
+
+type GLRenderer struct {
+}
+
+func NewGLRenderer() GLRenderer {
+	return GLRenderer{}
+}
+
+func createShaderObject(assetDatabase *assets.Database, shaderKey string, shaderType gl.Handle) gl.Handle {
+	src, err := assetDatabase.ReadAsset(shaderKey)
+	if err != nil {
+		panic(err)
+	}
+	shaderObj := gl.CreateShader(shaderType)
+	gl.ShaderSource(shaderObj, src)
+	gl.CompileShader(shaderObj)
+	res := gl.GetShaderParameter(shaderObj, gl.CompileStatus)
+	if !res.IsOkay() {
+		res = gl.GetShaderParameter(shaderObj, gl.ShaderType)
+		var sType string
+		if res.Equal(gl.FragmentShader) {
+			sType = "Fragment"
+		} else if res.Equal(gl.VertexShader) {
+			sType = "Vertex"
+		} else if res.Equal(gl.GeometryShader) {
+			sType = "Geometry"
+		} else if res.Equal(gl.TessControlShader) {
+			sType = "Tessellation Control"
+		} else if res.Equal(gl.TessEvaluationShader) {
+			sType = "Tessellation Evaluation"
+		} else {
+			sType = "Unknown"
+		}
+		errLog := gl.GetShaderInfoLog(shaderObj)
+		if len(errLog) > 0 {
+			log.Fatalf("Error compiling shader %s: %s\n", sType, errLog)
+		} else {
+			log.Fatalf("Error compiling shader %s: There was an error compiling the shader and could not retrieve the error log for unknown reasons\n", sType)
+		}
+	}
+	return shaderObj
+}
+
+func linkShader(vert, frag, geom, tesc, tese gl.Handle) gl.Handle {
+	shader := gl.CreateProgram()
+	gl.AttachShader(shader, vert)
+	gl.AttachShader(shader, frag)
+	if geom.IsValid() {
+		gl.AttachShader(shader, geom)
+	}
+	if tesc.IsValid() {
+		gl.AttachShader(shader, tesc)
+	}
+	if tese.IsValid() {
+		gl.AttachShader(shader, tese)
+	}
+	gl.LinkProgram(shader)
+	// Check for linker errors
+	res := gl.GetProgramParameter(shader, gl.LinkStatus)
+	if !res.IsOkay() {
+		errLog := gl.GetProgramInfoLog(shader)
+		log.Fatalf("Error linking shader: %s\n", errLog)
+	}
+	return shader
+}
+
+func (r GLRenderer) CreateShader(shader *Shader, assetDatabase *assets.Database) {
+	vert := createShaderObject(assetDatabase, shader.VertPath, gl.VertexShader)
+	frag := createShaderObject(assetDatabase, shader.FragPath, gl.FragmentShader)
+	var geom, tesc, tese gl.Handle
+	if len(shader.GeomPath) > 0 {
+		geom = createShaderObject(assetDatabase, shader.GeomPath, gl.GeometryShader)
+	}
+	if len(shader.CtrlPath) > 0 {
+		tesc = createShaderObject(assetDatabase, shader.CtrlPath, gl.TessControlShader)
+	}
+	if len(shader.EvalPath) > 0 {
+		tese = createShaderObject(assetDatabase, shader.EvalPath, gl.TessEvaluationShader)
+	}
+	shader.RenderId = linkShader(vert, frag, geom, tesc, tese)
+	gl.DeleteShader(vert)
+	gl.DeleteShader(frag)
+	if geom.IsValid() {
+		gl.DeleteShader(geom)
+	}
+	if tesc.IsValid() {
+		gl.DeleteShader(tesc)
+	}
+	if tese.IsValid() {
+		gl.DeleteShader(tese)
+	}
+}
+
+func (r GLRenderer) FreeShader(shader *Shader) {
+	gl.DeleteProgram(shader.RenderId.(gl.Handle))
+}

--- a/rendering/renderer.go
+++ b/rendering/renderer.go
@@ -1,0 +1,10 @@
+package rendering
+
+import "kaiju/assets"
+
+type Renderer interface {
+	CreateShader(shader *Shader, assetDatabase *assets.Database)
+	FreeShader(shader *Shader)
+}
+
+type RenderId interface{}

--- a/rendering/renderer.vk.go
+++ b/rendering/renderer.vk.go
@@ -1,0 +1,14 @@
+package rendering
+
+import "kaiju/assets"
+
+type VKRenderer struct {
+}
+
+func (r *VKRenderer) CreateShader(shader *Shader, assetDatabase *assets.Database) {
+	panic("Not implemented")
+}
+
+func (r *VKRenderer) FreeShader(shader *Shader) {
+	panic("Not implemented")
+}

--- a/rendering/shader.go
+++ b/rendering/shader.go
@@ -1,0 +1,45 @@
+package rendering
+
+import (
+	"kaiju/assets"
+	"runtime"
+	"strings"
+)
+
+type Shader struct {
+	RenderId  RenderId
+	SubShader *Shader
+	KeyName   string
+	VertPath  string
+	FragPath  string
+	GeomPath  string
+	CtrlPath  string
+	EvalPath  string
+}
+
+func createShaderKey(vertPath string, fragPath string, geomPath string, ctrlPath string, evalPath string) string {
+	return strings.Join([]string{vertPath, fragPath, geomPath, ctrlPath, evalPath}, ";")
+}
+
+func NewShader(vertPath string, fragPath string, geomPath string, ctrlPath string, evalPath string, renderer Renderer) *Shader {
+	s := &Shader{
+		SubShader: nil,
+		KeyName:   createShaderKey(vertPath, fragPath, geomPath, ctrlPath, evalPath),
+		VertPath:  vertPath,
+		FragPath:  fragPath,
+		GeomPath:  geomPath,
+		CtrlPath:  ctrlPath,
+		EvalPath:  evalPath,
+	}
+	runtime.SetFinalizer(s, func(shader *Shader) {
+		renderer.FreeShader(shader)
+	})
+	return s
+}
+
+func (s *Shader) DelayedCreate(renderer Renderer, assetDatabase *assets.Database) {
+	renderer.CreateShader(s, assetDatabase)
+	if s.SubShader != nil {
+		s.SubShader.DelayedCreate(renderer, assetDatabase)
+	}
+}

--- a/rendering/shader_cache.go
+++ b/rendering/shader_cache.go
@@ -1,0 +1,40 @@
+package rendering
+
+import "kaiju/assets"
+
+type ShaderCache struct {
+	renderer       Renderer
+	assetDatabase  *assets.Database
+	shaders        map[string]*Shader
+	pendingShaders []*Shader
+}
+
+func NewShaderCache(renderer Renderer, assetDatabase *assets.Database) ShaderCache {
+	return ShaderCache{
+		renderer:       renderer,
+		assetDatabase:  assetDatabase,
+		shaders:        make(map[string]*Shader),
+		pendingShaders: make([]*Shader, 0),
+	}
+}
+
+func (s *ShaderCache) CreateShader(vertPath string, fragPath string, geomPath string, ctrlPath string, evalPath string) *Shader {
+	shaderKey := createShaderKey(vertPath, fragPath, geomPath, ctrlPath, evalPath)
+	if shader, ok := s.shaders[shaderKey]; ok {
+		return shader
+	} else {
+		shader := NewShader(vertPath, fragPath, geomPath, ctrlPath, evalPath, s.renderer)
+		if shader != nil {
+			s.pendingShaders = append(s.pendingShaders, shader)
+		}
+		// Else, use a fallback shader
+		return shader
+	}
+}
+
+func (s *ShaderCache) CreatePending() {
+	for _, shader := range s.pendingShaders {
+		shader.DelayedCreate(s.renderer, s.assetDatabase)
+	}
+	s.pendingShaders = s.pendingShaders[:0]
+}

--- a/windowing/window.go
+++ b/windowing/window.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"kaiju/hid"
+	"kaiju/rendering"
 	"unsafe"
 )
 
@@ -33,6 +34,7 @@ type Window struct {
 	handle        unsafe.Pointer
 	Mouse         hid.Mouse
 	Keyboard      hid.Keyboard
+	Renderer      rendering.Renderer
 	evtSharedMem  evtMem
 	width, height int
 	isClosed      bool
@@ -44,6 +46,8 @@ func New(windowName string) (*Window, error) {
 		Mouse:  hid.NewMouse(),
 		width:  1280,
 		height: 720,
+		// TODO:  Select the correct renderer, or pass it in
+		Renderer: rendering.NewGLRenderer(),
 	}
 	// TODO:  Pass in width and height
 	createWindow(windowName, &w.evtSharedMem)


### PR DESCRIPTION
This creates the base concept of a shader for OpenGL. It also creates a shader cache to hold shaders that have been built for reuse. This also creates the stub for all GL renderering through a C wrapper layer. Lastly a triangle is crudely drawn on the screen to verify the shader load/compile/use.