### PR TITLE
#42 Create perspective and orthographic cameras

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
 			"request": "launch",
 			"mode": "auto",
 			"program": "${workspaceFolder}",
-			"buildFlags": "-tags editor",
+			"buildFlags": "-tags editor,OPENGL",
 			"env": {
 				"CGO_LDFLAGS": "-lgdi32 -lOpenGL32"
 			}
@@ -20,7 +20,7 @@
 			"request": "launch",
 			"mode": "auto",
 			"program": "${workspaceFolder}",
-			"buildFlags": "",
+			"buildFlags": "-tags OPENGL",
 			"env": {
 				"CGO_LDFLAGS": "-lgdi32 -lOpenGL32"
 			}
@@ -30,7 +30,7 @@
 			"request": "launch",
 			"mode": "auto",
 			"program": "${workspaceFolder}",
-			"buildFlags": "-tags editor",
+			"buildFlags": "-tags editor,OPENGL",
 			"env": {
 				"CGO_LDFLAGS": "-lX11 -lGL"
 			}
@@ -40,7 +40,7 @@
 			"request": "launch",
 			"mode": "auto",
 			"program": "${workspaceFolder}",
-			"buildFlags": "",
+			"buildFlags": "-tags OPENGL",
 			"env": {
 				"CGO_LDFLAGS": "-lX11 -lGL"
 			}

--- a/build/build.bat
+++ b/build/build.bat
@@ -2,7 +2,7 @@ go test -timeout 30s -v ./...
 SET "CGO_LDFLAGS=-lgdi32 -lOpenGL32"
 if %errorlevel% equ 0 (
 	echo Tests passed, compiling code...
-	go build -tags editor -o ./bin/kaiju.exe -ldflags="-s -w" main.go
+	go build -tags editor,OPENGL -o ./bin/kaiju.exe -ldflags="-s -w" main.go
 ) else (
 	echo Tests failed, skipping code compile
 )

--- a/build/build.js.bat
+++ b/build/build.js.bat
@@ -1,4 +1,4 @@
 SET "GOOS=js"
 SET "GOARCH=wasm"
 SET "CGO_ENABLED=0"
-go build -tags editor -o ./bin/kaiju.wasm -ldflags="-s -w" main.go
+go build -tags editor,OPENGL -o ./bin/kaiju.wasm -ldflags="-s -w" main.go

--- a/build/build.js.sh
+++ b/build/build.js.sh
@@ -3,4 +3,4 @@
 export GOOS="js"
 export GOARCH="wasm"
 export CGO_ENABLED=0
-go build -tags editor -o ./bin/kaiju.wasm -ldflags="-s -w" main.go
+go build -tags editor,OPENGL -o ./bin/kaiju.wasm -ldflags="-s -w" main.go

--- a/build/build.sh
+++ b/build/build.sh
@@ -4,7 +4,7 @@ export CGO_LDFLAGS="-lX11 -lGL"
 go test -timeout 30s -v ./...
 if [ $? -eq 0 ]; then
 	echo "Tests passed, compiling code..."
-	go build -tags editor -o ./bin/kaiju -ldflags="-s -w" main.go
+	go build -tags editor,OPENGL -o ./bin/kaiju -ldflags="-s -w" main.go
 else
 	echo "Tests failed, skipping code compile"
 fi

--- a/build/project_template/build.bat.txt
+++ b/build/project_template/build.bat.txt
@@ -2,7 +2,7 @@ go test -timeout 30s -v ./...
 SET "CGO_LDFLAGS=-lgdi32 -lOpenGL32"
 if %errorlevel% equ 0 (
 	echo Tests passed, compiling code...
-	go build -o ./bin/[PROJECT_NAME].exe -ldflags="-s -w" main.go
+	go build -tags OPENGL -o ./bin/[PROJECT_NAME].exe -ldflags="-s -w" main.go
 ) else (
 	echo Tests failed, skipping code compile
 )

--- a/build/project_template/build.js.bat.txt
+++ b/build/project_template/build.js.bat.txt
@@ -1,4 +1,4 @@
 SET "GOOS=js"
 SET "GOARCH=wasm"
 SET "CGO_ENABLED=0"
-go build -o ./bin/[PROJECT_NAME].wasm -ldflags="-s -w" main.go
+go build -tags OPENGL -o ./bin/[PROJECT_NAME].wasm -ldflags="-s -w" main.go

--- a/build/project_template/build.js.sh.txt
+++ b/build/project_template/build.js.sh.txt
@@ -3,4 +3,4 @@
 export GOOS="js"
 export GOARCH="wasm"
 export CGO_ENABLED=0
-go build -o ./bin/[PROJECT_NAME].wasm -ldflags="-s -w" main.go
+go build -tags OPENGL -o ./bin/[PROJECT_NAME].wasm -ldflags="-s -w" main.go

--- a/build/project_template/build.sh.txt
+++ b/build/project_template/build.sh.txt
@@ -4,7 +4,7 @@ export CGO_LDFLAGS="-lX11 -lGL"
 go test -timeout 30s -v ./...
 if [ $? -eq 0 ]; then
 	echo "Tests passed, compiling code..."
-	go build -o ./bin/[PROJECT_NAME] -ldflags="-s -w" main.go
+	go build -tags OPENGL -o ./bin/[PROJECT_NAME] -ldflags="-s -w" main.go
 else
 	echo "Tests failed, skipping code compile"
 fi

--- a/cameras/standard_camera.go
+++ b/cameras/standard_camera.go
@@ -1,0 +1,287 @@
+package cameras
+
+import (
+	"kaiju/collision"
+	"kaiju/matrix"
+)
+
+type StandardCamera struct {
+	view           matrix.Mat4
+	iView          matrix.Mat4
+	projection     matrix.Mat4
+	iProjection    matrix.Mat4
+	frustum        collision.Frustum
+	position       matrix.Vec3
+	lookAt         matrix.Vec3
+	up             matrix.Vec3
+	fieldOfView    float32
+	nearPlane      float32
+	farPlane       float32
+	pitch          float32
+	yaw            float32
+	width          float32
+	height         float32
+	isOrthographic bool
+}
+
+func NewStandardCamera(width, height float32, position matrix.Vec3) *StandardCamera {
+	c := new(StandardCamera)
+	c.initializeValues(position)
+	c.initialize(width, height)
+	return c
+}
+
+func NewStandardCameraOrthographic(width, height float32, position matrix.Vec3) *StandardCamera {
+	c := new(StandardCamera)
+	c.initializeValues(position)
+	c.isOrthographic = true
+	c.nearPlane = -1
+	c.initialize(width, height)
+	return c
+}
+
+func (c *StandardCamera) initializeValues(position matrix.Vec3) {
+	c.fieldOfView = 60.0
+	c.nearPlane = 0.01
+	c.farPlane = 500.0
+	c.position = position
+	c.view = matrix.Mat4Identity()
+	c.projection = matrix.Mat4Identity()
+	c.yaw = -90.0
+	c.pitch = 0.0
+	c.up = matrix.Vec3Up()
+	c.lookAt = matrix.Vec3Forward()
+}
+
+func (c *StandardCamera) initialize(width, height float32) {
+	c.setProjection(width, height)
+	c.updateView()
+}
+
+func (c *StandardCamera) SetPosition(position matrix.Vec3) {
+	c.position = position
+	c.updateView()
+}
+
+func (c *StandardCamera) setProjection(width, height float32) {
+	c.width = width
+	c.height = height
+	c.updateProjection()
+}
+
+func (c *StandardCamera) updateProjection() {
+	if !c.isOrthographic {
+		c.projection.Perspective(matrix.Deg2Rad(c.fieldOfView),
+			c.width/c.height, c.nearPlane, c.farPlane)
+	} else {
+		c.projection.Orthographic(-c.width*0.5, c.width*0.5, -c.height*0.5, c.height*0.5, c.nearPlane, c.farPlane)
+	}
+	c.iProjection = c.projection
+	c.iProjection.Inverse()
+}
+
+func (c *StandardCamera) updateView() {
+	if !c.isOrthographic {
+		c.view.LookAt(c.position, c.lookAt, c.up)
+	} else {
+		iPos := c.position
+		iPos.ScaleAssign(-1.0)
+		c.view.Reset()
+		c.view.Translate(iPos)
+	}
+	c.iView = c.view
+	c.iView.Inverse()
+	c.updateFrustum()
+}
+
+func (c *StandardCamera) updateFrustum() {
+	vp := c.view.Multiply(c.projection)
+	for i := 3; i >= 0; i-- {
+		c.frustum.Planes[0].SetFloatValue(vp[i*4+3]+vp[i*4+0], i)
+		c.frustum.Planes[1].SetFloatValue(vp[i*4+3]-vp[i*4+0], i)
+		c.frustum.Planes[2].SetFloatValue(vp[i*4+3]+vp[i*4+1], i)
+		c.frustum.Planes[3].SetFloatValue(vp[i*4+3]-vp[i*4+1], i)
+		c.frustum.Planes[4].SetFloatValue(vp[i*4+3]+vp[i*4+2], i)
+		c.frustum.Planes[5].SetFloatValue(vp[i*4+3]-vp[i*4+2], i)
+	}
+}
+
+func (c *StandardCamera) SetFOV(fov float32) {
+	c.fieldOfView = fov
+	c.updateProjection()
+}
+
+func (c *StandardCamera) SetNearPlane(near float32) {
+	c.nearPlane = near
+	c.updateProjection()
+}
+
+func (c *StandardCamera) SetFarPlane(far float32) {
+	c.farPlane = far
+	c.updateProjection()
+}
+
+func (c *StandardCamera) SetWidth(width float32) {
+	c.width = width
+	c.updateProjection()
+}
+
+func (c *StandardCamera) SetHeight(height float32) {
+	c.height = height
+	c.updateProjection()
+}
+
+func (c *StandardCamera) SetProperties(fov, nearPlane, farPlane, width, height float32) {
+	c.fieldOfView = fov
+	c.nearPlane = nearPlane
+	c.farPlane = farPlane
+	c.width = width
+	c.height = height
+	c.updateProjection()
+}
+
+func (c *StandardCamera) SetYaw(yaw float32) {
+	c.yaw = yaw
+	if yaw > 360 {
+		c.yaw -= 360
+	} else if yaw < -360 {
+		c.yaw += 360
+	}
+	direction := matrix.Vec3{
+		matrix.Cos(matrix.Deg2Rad(c.yaw)) * matrix.Cos(matrix.Deg2Rad(c.pitch)),
+		matrix.Sin(matrix.Deg2Rad(c.pitch)),
+		matrix.Sin(matrix.Deg2Rad(c.yaw)) * matrix.Cos(matrix.Deg2Rad(c.pitch)),
+	}
+	direction.Normalize()
+	c.lookAt = c.position.Add(direction)
+	c.updateView()
+}
+
+func (c *StandardCamera) SetPitch(pitch float32) {
+	c.pitch = pitch
+	if c.pitch > 89.0 {
+		c.pitch = 89.0
+	} else if c.pitch < -89.0 {
+		c.pitch = -89.0
+	}
+	direction := matrix.Vec3{
+		matrix.Cos(matrix.Deg2Rad(c.yaw)) * matrix.Cos(matrix.Deg2Rad(c.pitch)),
+		matrix.Sin(matrix.Deg2Rad(c.pitch)),
+		matrix.Sin(matrix.Deg2Rad(c.yaw)) * matrix.Cos(matrix.Deg2Rad(c.pitch)),
+	}
+	direction.Normalize()
+	c.lookAt = c.position.Add(direction)
+	c.updateView()
+}
+
+func (c *StandardCamera) SetYawAndPitch(yaw, pitch float32) {
+	c.yaw = yaw
+	c.pitch = pitch
+	if c.pitch > 89.0 {
+		c.pitch = 89.0
+	} else if c.pitch < -89.0 {
+		c.pitch = -89.0
+	}
+	if yaw > 360 {
+		c.yaw -= 360
+	} else if yaw < -360 {
+		c.yaw += 360
+	}
+	direction := matrix.Vec3{
+		matrix.Cos(matrix.Deg2Rad(c.yaw)) * matrix.Cos(matrix.Deg2Rad(c.pitch)),
+		matrix.Sin(matrix.Deg2Rad(c.pitch)),
+		matrix.Sin(matrix.Deg2Rad(c.yaw)) * matrix.Cos(matrix.Deg2Rad(c.pitch)),
+	}
+	direction.Normalize()
+	c.lookAt = c.position.Add(direction)
+	c.updateView()
+}
+
+func (c StandardCamera) Forward() matrix.Vec3 {
+	return matrix.Vec3{
+		-c.iView[matrix.Mat4x0y2],
+		-c.iView[matrix.Mat4x1y2],
+		-c.iView[matrix.Mat4x2y2],
+	}
+}
+
+func (c StandardCamera) Right() matrix.Vec3 {
+	return matrix.Vec3{
+		c.iView[matrix.Mat4x0y0],
+		c.iView[matrix.Mat4x1y0],
+		c.iView[matrix.Mat4x2y0],
+	}
+}
+
+func (c StandardCamera) Up() matrix.Vec3 {
+	return matrix.Vec3{
+		c.iView[matrix.Mat4x0y1],
+		c.iView[matrix.Mat4x1y1],
+		c.iView[matrix.Mat4x2y1],
+	}
+}
+
+func (c *StandardCamera) SetLookAt(position matrix.Vec3) {
+	c.lookAt = position
+	c.updateView()
+}
+
+func (c *StandardCamera) LookAt(point, up matrix.Vec3) {
+	c.lookAt = point
+	c.up = up
+	c.updateView()
+}
+
+func (c *StandardCamera) SetPositionAndLookAt(position, lookAt matrix.Vec3) {
+	if matrix.Approx(position.Z(), lookAt.Z()) {
+		position[matrix.Vz] += 0.0001
+	}
+	c.position = position
+	c.lookAt = lookAt
+	c.updateView()
+}
+
+func (c StandardCamera) Raycast(screenPos matrix.Vec2) collision.Ray {
+	x := (2.0*screenPos.X())/c.width - 1.0
+	y := 1.0 - (2.0*screenPos.Y())/c.height
+	rayNdc := matrix.Vec3{x, y, -1.0}
+	rayClip := matrix.Vec4{rayNdc.X(), rayNdc.Y(), -1.0, 1.0}
+	rayEye := rayClip.MultiplyMat4(c.iProjection)
+	origin := matrix.Vec3{rayEye.X() / rayEye.W(), rayEye.Y() / rayEye.W(), rayEye.Z() / rayEye.W()}
+	origin.AddAssign(c.position)
+	rayEye = matrix.Vec4{rayEye.X(), rayEye.Y(), -1.0, 0.0}
+	res := rayEye.MultiplyMat4(c.view)
+	rayWorld := res.AsVec3().Normal()
+	return collision.Ray{Origin: origin, Direction: rayWorld}
+}
+
+func (c *StandardCamera) TryPlaneHit(screenPos matrix.Vec2, planePos, planeNml matrix.Vec3) (hit matrix.Vec3, success bool) {
+	r := c.Raycast(screenPos)
+	d := matrix.Vec3Dot(planeNml, r.Direction)
+	if matrix.Abs(d) < matrix.FloatSmallestNonzero {
+		return hit, success
+	}
+	diff := planePos.Subtract(r.Origin)
+	distance := matrix.Vec3Dot(diff, planeNml) / d
+	if distance < 0 {
+		return hit, success
+	}
+	hit = r.Point(distance)
+	return hit, true
+}
+
+func (c *StandardCamera) ForwardPlaneHit(screenPos matrix.Vec2, planePos matrix.Vec3) (matrix.Vec3, bool) {
+	fwd := c.Forward()
+	return c.TryPlaneHit(screenPos, planePos, fwd)
+}
+
+func (c StandardCamera) Position() matrix.Vec3    { return c.position }
+func (c StandardCamera) Width() float32           { return c.width }
+func (c StandardCamera) Height() float32          { return c.height }
+func (c *StandardCamera) View() matrix.Mat4       { return c.view }
+func (c *StandardCamera) Projection() matrix.Mat4 { return c.projection }
+func (c *StandardCamera) Center() matrix.Vec3     { return c.lookAt }
+func (c *StandardCamera) Yaw() float32            { return c.yaw }
+func (c *StandardCamera) Pitch() float32          { return c.pitch }
+func (c *StandardCamera) NearPlane() float32      { return c.nearPlane }
+func (c *StandardCamera) FarPlane() float32       { return c.farPlane }

--- a/collision/frustum.go
+++ b/collision/frustum.go
@@ -1,0 +1,5 @@
+package collision
+
+type Frustum struct {
+	Planes [6]Plane
+}

--- a/collision/plane.go
+++ b/collision/plane.go
@@ -1,0 +1,55 @@
+package collision
+
+import "kaiju/matrix"
+
+type Plane struct {
+	Normal matrix.Vec3
+	Dot    float32
+}
+
+func PlaneCCW(a, b, c matrix.Vec3) Plane {
+	var p Plane
+	e0 := b.Subtract(a)
+	e1 := c.Subtract(a)
+	p.Normal = matrix.Vec3Cross(e0, e1).Normal()
+	p.Dot = matrix.Vec3Dot(p.Normal, a)
+	return p
+}
+
+func (p *Plane) SetFloatValue(value float32, index int) {
+	switch index {
+	case 0:
+		p.Normal.SetX(value)
+	case 1:
+		p.Normal.SetY(value)
+	case 2:
+		p.Normal.SetZ(value)
+	case 3:
+		p.Dot = value
+	}
+}
+
+func (p Plane) ToArray() [4]float32 {
+	return [4]float32{p.Normal.X(), p.Normal.Y(), p.Normal.Z(), p.Dot}
+}
+
+func (p Plane) ToVec4() matrix.Vec4 {
+	return matrix.Vec4{p.Normal.X(), p.Normal.Y(), p.Normal.Z(), p.Dot}
+}
+
+func (p Plane) ClosestPoint(point matrix.Vec3) matrix.Vec3 {
+	// If normalized, t := matrix.Vec3Dot(point, p.Normal) - p.Dot
+	t := (matrix.Vec3Dot(p.Normal, point) - p.Dot) / matrix.Vec3Dot(p.Normal, p.Normal)
+	return point.Subtract(p.Normal.Scale(t))
+}
+
+func (p Plane) Distance(point matrix.Vec3) float32 {
+	// If normalized, return matrix.Vec3Dot(p.Normal, point) - p.Dot
+	return (matrix.Vec3Dot(p.Normal, point) - p.Dot) / matrix.Vec3Dot(p.Normal, p.Normal)
+}
+
+func PointOutsideOfPlane(p, a, b, c, d matrix.Vec3) bool {
+	signp := matrix.Vec3Dot(p.Subtract(a), matrix.Vec3Cross(b.Subtract(a), c.Subtract(a)))
+	signd := matrix.Vec3Dot(d.Subtract(a), matrix.Vec3Cross(b.Subtract(a), c.Subtract(a)))
+	return signp*signd < 0
+}

--- a/collision/ray.go
+++ b/collision/ray.go
@@ -1,0 +1,44 @@
+package collision
+
+import (
+	"kaiju/matrix"
+)
+
+type Ray struct {
+	Origin    matrix.Vec3
+	Direction matrix.Vec3
+}
+
+func (r Ray) Point(distance float32) matrix.Vec3 {
+	return r.Origin.Add(r.Direction.Scale(distance))
+}
+
+func (r Ray) TriangleHit(rayLen float32, a, b, c matrix.Vec3) bool {
+	s := Segment{r.Origin, r.Point(rayLen)}
+	return s.TriangleHit(a, b, c)
+}
+
+func (r Ray) PlaneHit(planePosition, planeNormal matrix.Vec3) (hit matrix.Vec3, success bool) {
+	hit = matrix.Vec3{}
+	success = false
+	d := matrix.Vec3Dot(planeNormal, r.Direction)
+	if matrix.Abs(d) < matrix.FloatSmallestNonzero {
+		return
+	}
+	diff := planePosition.Subtract(r.Origin)
+	distance := matrix.Vec3Dot(diff, planeNormal) / d
+	if distance < 0 {
+		return
+	}
+	return r.Point(distance), true
+}
+
+func (r Ray) SphereHit(center matrix.Vec3, radius, maxLen float32) bool {
+	delta := center.Subtract(r.Origin)
+	lenght := matrix.Vec3Dot(r.Direction, delta)
+	if lenght < 0 || lenght > (maxLen+radius) {
+		return false
+	}
+	d2 := matrix.Vec3Dot(delta, delta) - lenght*lenght
+	return d2 <= (radius * radius)
+}

--- a/collision/segment.go
+++ b/collision/segment.go
@@ -1,0 +1,42 @@
+package collision
+
+import "kaiju/matrix"
+
+type Segment struct {
+	A matrix.Vec3
+	B matrix.Vec3
+}
+
+func LineSegmentFromRay(ray Ray, length float32) Segment {
+	return Segment{ray.Origin, ray.Point(length)}
+}
+
+func (l Segment) TriangleHit(a, b, c matrix.Vec3) bool {
+	p := l.A
+	q := l.B
+	ab := b.Subtract(a)
+	ac := c.Subtract(a)
+	qp := p.Subtract(q)
+	// Compute triangle normal, can be pre-calculated or cached if
+	// intersecting multiple segments against the same triangle
+	n := matrix.Vec3Cross(ab, ac)
+	d := matrix.Vec3Dot(qp, n)
+	if d <= 0 {
+		return false
+	}
+	ap := p.Subtract(a)
+	t := matrix.Vec3Dot(ap, n)
+	if t < 0 {
+		return false
+	}
+	e := matrix.Vec3Cross(qp, ap)
+	v := matrix.Vec3Dot(ac, e)
+	if v < 0 || v > d {
+		return false
+	}
+	w := -matrix.Vec3Dot(ab, e)
+	if w < 0 || v+w > d {
+		return false
+	}
+	return true
+}

--- a/content/basic.vert
+++ b/content/basic.vert
@@ -8,9 +8,17 @@ layout (location = 5) in vec4 JointIds;
 layout (location = 6) in vec4 JointWeights;
 layout (location = 7) in vec3 MorphTarget;
 
+uniform struct GlobalData {
+    mat4 view;
+    mat4 projection;
+    vec3 cameraPosition;
+    float time;
+} globalData;
+
 out vec4 fragColor;
 
 void main() {
     fragColor = Color;
-    gl_Position = vec4(Position.x, Position.y, Position.z, 1.0);
+    mat4 model = mat4(1.0);
+    gl_Position = globalData.projection * globalData.view * model * vec4(Position, 1.0);
 }

--- a/engine/host.go
+++ b/engine/host.go
@@ -2,6 +2,8 @@ package engine
 
 import (
 	"kaiju/assets"
+	"kaiju/cameras"
+	"kaiju/matrix"
 	"kaiju/rendering"
 	"kaiju/windowing"
 )
@@ -9,6 +11,7 @@ import (
 type Host struct {
 	entities      []*Entity
 	Window        *windowing.Window
+	Camera        *cameras.StandardCamera
 	ShaderCache   rendering.ShaderCache
 	frameTime     float64
 	Closing       bool
@@ -30,6 +33,7 @@ func NewHost() (Host, error) {
 		LateUpdater:   NewUpdater(),
 		Window:        win,
 		assetDatabase: assets.NewDatabase(),
+		Camera:        cameras.NewStandardCamera(float32(win.Width()), float32(win.Height()), matrix.Vec3{0, 0, 1}),
 	}
 	host.ShaderCache = rendering.NewShaderCache(host.Window.Renderer, &host.assetDatabase)
 	return host, nil
@@ -46,4 +50,8 @@ func (host *Host) Update(deltaTime float64) {
 	//gl.ClearScreen()
 	//host.Window.SwapBuffers()
 	// TODO:  Do end updates on various systems
+}
+
+func (host Host) Runtime() float64 {
+	return host.frameTime
 }

--- a/gl/gles.nonjs.go
+++ b/gl/gles.nonjs.go
@@ -94,9 +94,28 @@ void cglUseProgram(GLuint program) {
 void cglDrawArrays(GLenum mode, GLint first, GLsizei count) {
 	glDrawArrays(mode, first, count);
 }
+
+GLint cglGetUniformLocation(GLuint program, const GLchar *name) {
+	return glGetUniformLocation(program, name);
+}
+
+void cglUniformMatrix4fv(GLint location, GLsizei count, GLboolean transpose, const GLfloat *value) {
+	glUniformMatrix4fv(location, count, transpose, value);
+}
+
+void cglUniform3fv(GLint location, GLsizei count, const GLfloat *value) {
+	glUniform3fv(location, count, value);
+}
+
+void cglUniform1f(GLint location, GLfloat value) {
+	glUniform1f(location, value);
+}
 */
 import "C"
-import "unsafe"
+import (
+	"kaiju/matrix"
+	"unsafe"
+)
 
 type Handle uint32
 
@@ -255,4 +274,27 @@ func UnBindBuffer(target Handle) {
 
 func UnBindVertexArray() {
 	C.cglBindVertexArray(0)
+}
+
+func GetUniformLocation(program Handle, name string) Result {
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+	res := C.cglGetUniformLocation(program.AsGL(), cname)
+	return Result(res)
+}
+
+func UniformMatrix4fv(location Result, transpose bool, matrices *matrix.Mat4) {
+	var nml uint8
+	if transpose {
+		nml = 1
+	}
+	C.cglUniformMatrix4fv(C.GLint(location), C.GLsizei(1), C.GLboolean(nml), (*C.GLfloat)(unsafe.Pointer(&matrices[0])))
+}
+
+func Uniform3fv(location Result, values *matrix.Vec3) {
+	C.cglUniform3fv(C.GLint(location), C.GLsizei(1), (*C.GLfloat)(unsafe.Pointer(&values[0])))
+}
+
+func Uniform1f(location Result, value float32) {
+	C.cglUniform1f(C.GLint(location), C.GLfloat(value))
 }

--- a/main.go
+++ b/main.go
@@ -38,6 +38,8 @@ func main() {
 		host.Update(deltaTime)
 		gl.ClearScreen()
 		gl.UseProgram(shader.RenderId.(gl.Handle))
+		host.Window.Renderer.ReadyFrame(host.Camera, float32(host.Runtime()))
+		host.Window.Renderer.Draw(shader)
 		gl.BindVertexArray(mesh.MeshId.(rendering.MeshIdGL).VAO)
 		gl.DrawArrays(gl.Triangles, 0, 3)
 		host.Window.SwapBuffers()

--- a/matrix/config.go
+++ b/matrix/config.go
@@ -49,12 +49,16 @@ type tMatrix interface {
 	Mat3 | Mat4
 }
 
-func rad2Deg[T tFloatingPoint](radian T) T {
+func Rad2Deg(radian Float) Float {
 	return radian * (180.0 / math.Pi)
 }
 
-func deg2Rad[T tFloatingPoint](degree T) T {
+func Deg2Rad(degree Float) Float {
 	return degree * (math.Pi / 180.0)
+}
+
+func Approx(a, b Float) bool {
+	return math.Abs(float64(a-b)) < FloatSmallestNonzero
 }
 
 func clamp[T tFloatingPoint](current, minimum, maximum T) T {

--- a/matrix/float32.go
+++ b/matrix/float32.go
@@ -6,6 +6,8 @@ import "math"
 
 type Float = float32
 
+const FloatSmallestNonzero = math.SmallestNonzeroFloat32
+
 func Abs(x Float) Float {
 	return math.Float32frombits(math.Float32bits(x) &^ (1 << 31))
 }

--- a/matrix/float64.go
+++ b/matrix/float64.go
@@ -6,6 +6,8 @@ import "math"
 
 type Float = float64
 
+const FloatSmallestNonzero = math.SmallestNonzeroFloat64
+
 func Abs(x Float) Float {
 	return math.Abs(x)
 }

--- a/matrix/mat4.go
+++ b/matrix/mat4.go
@@ -257,7 +257,7 @@ func (m *Mat4) MultiplyAssign(rhs Mat4) {
 	m[15] = m[12]*rhs[3] + m[13]*rhs[6] + m[14]*rhs[9] + m[15]*rhs[12]
 }
 
-func (m *Mat4) Ortho(left Float, right Float, bottom Float, top Float, near Float, far Float) {
+func (m *Mat4) Orthographic(left Float, right Float, bottom Float, top Float, near Float, far Float) {
 	m.Zero()
 	m[x0y0] = 2.0 / (right - left)
 	// Vulkan inverts x1y1 (see mat4_projection_gl2vulkan)
@@ -276,9 +276,7 @@ func (m *Mat4) Perspective(fovy Float, aspect Float, nearVal Float, farVal Float
 	f = 1.0 / Tan(fovy*0.5)
 	fn = 1.0 / (nearVal - farVal)
 	m[x0y0] = f / aspect
-	// Vulkan inverts x1y1 (see mat4_projection_gl2vulkan)
-	m[x1y1] = -f
-	//matrix4x4->x1y1 = f;
+	m[x1y1] = mat4X1Y1(f)
 	m[x2y2] = (nearVal + farVal) * fn
 	m[x3y2] = -1.0
 	m[x2y3] = 2.0 * nearVal * farVal * fn
@@ -330,28 +328,28 @@ func (m *Mat4) Rotate(rotate Vec3) {
 
 func (m *Mat4) RotateX(angles Float) {
 	rot := Mat4Identity()
-	rot[x1y1] = Cos(deg2Rad(angles))
-	rot[x2y1] = -Sin(deg2Rad(angles))
-	rot[x1y2] = Sin(deg2Rad(angles))
-	rot[x2y2] = Cos(deg2Rad(angles))
+	rot[x1y1] = Cos(Deg2Rad(angles))
+	rot[x2y1] = -Sin(Deg2Rad(angles))
+	rot[x1y2] = Sin(Deg2Rad(angles))
+	rot[x2y2] = Cos(Deg2Rad(angles))
 	m.MultiplyAssign(rot)
 }
 
 func (m *Mat4) RotateY(angles Float) {
 	rot := Mat4Identity()
-	rot[x0y0] = Cos(deg2Rad(angles))
-	rot[x2y0] = Sin(deg2Rad(angles))
-	rot[x0y2] = -Sin(deg2Rad(angles))
-	rot[x2y2] = Cos(deg2Rad(angles))
+	rot[x0y0] = Cos(Deg2Rad(angles))
+	rot[x2y0] = Sin(Deg2Rad(angles))
+	rot[x0y2] = -Sin(Deg2Rad(angles))
+	rot[x2y2] = Cos(Deg2Rad(angles))
 	m.MultiplyAssign(rot)
 }
 
 func (m *Mat4) RotateZ(angles Float) {
 	rot := Mat4Identity()
-	rot[x0y0] = Cos(deg2Rad(angles))
-	rot[x1y0] = -Sin(deg2Rad(angles))
-	rot[x0y1] = Sin(deg2Rad(angles))
-	rot[x1y1] = Cos(deg2Rad(angles))
+	rot[x0y0] = Cos(Deg2Rad(angles))
+	rot[x1y0] = -Sin(Deg2Rad(angles))
+	rot[x0y1] = Sin(Deg2Rad(angles))
+	rot[x1y1] = Cos(Deg2Rad(angles))
 	m.MultiplyAssign(rot)
 }
 

--- a/matrix/quaternion.go
+++ b/matrix/quaternion.go
@@ -90,9 +90,9 @@ func (q Quaternion) ToMat4() Mat4 {
 }
 
 func QuaternionFromEuler(v Vec3) Quaternion {
-	x := deg2Rad(v.X())
-	y := deg2Rad(v.Y())
-	z := deg2Rad(v.Z())
+	x := Deg2Rad(v.X())
+	y := Deg2Rad(v.Y())
+	z := Deg2Rad(v.Z())
 	c1 := Cos(x / 2.0)
 	c2 := Cos(y / 2.0)
 	c3 := Cos(z / 2.0)
@@ -108,12 +108,12 @@ func QuaternionFromEuler(v Vec3) Quaternion {
 func (q Quaternion) ToEuler() Vec3 {
 	out := Vec3{}
 	m := q.ToMat4()
-	out[Vy] = rad2Deg(Asin(clamp(m[x0y2], -1.0, 1.0)))
+	out[Vy] = Rad2Deg(Asin(clamp(m[x0y2], -1.0, 1.0)))
 	if Abs(m[x0y2]) < 0.9999999 {
-		out.SetX(rad2Deg(Atan2(-m[x1y2], m[x2y2])))
-		out.SetZ(rad2Deg(Atan2(-m[x0y1], m[x0y0])))
+		out.SetX(Rad2Deg(Atan2(-m[x1y2], m[x2y2])))
+		out.SetZ(Rad2Deg(Atan2(-m[x0y1], m[x0y0])))
 	} else {
-		out.SetX(rad2Deg(Atan2(m[x2y1], m[x1y1])))
+		out.SetX(Rad2Deg(Atan2(m[x2y1], m[x1y1])))
 		out.SetZ(0.0)
 	}
 	return out
@@ -286,11 +286,11 @@ func QuaternionLookAt(from, to Vec3) Quaternion {
 	dot := Vec3Dot(back, direction)
 	if Abs(dot-(-1.0)) < 0.000001 {
 		u := Vec3Up()
-		return QuaternionAxisAngle(u, rad2Deg(Float(math.Pi)))
+		return QuaternionAxisAngle(u, Rad2Deg(Float(math.Pi)))
 	} else if Abs(dot-(1.0)) < 0.000001 {
 		return QuaternionIdentity()
 	}
-	angle := -rad2Deg(Acos(dot))
+	angle := -Rad2Deg(Acos(dot))
 	cross := Vec3Cross(back, direction)
 	nmlCross := cross.Normal()
 	return QuaternionAxisAngle(nmlCross, angle)

--- a/rendering/global_shader_data.go
+++ b/rendering/global_shader_data.go
@@ -1,0 +1,10 @@
+package rendering
+
+import "kaiju/matrix"
+
+type GlobalShaderData struct {
+	View           matrix.Mat4
+	Projection     matrix.Mat4
+	CameraPosition matrix.Vec3
+	Time           float32
+}

--- a/rendering/renderer.go
+++ b/rendering/renderer.go
@@ -1,11 +1,16 @@
 package rendering
 
-import "kaiju/assets"
+import (
+	"kaiju/assets"
+	"kaiju/cameras"
+)
 
 type Renderer interface {
+	ReadyFrame(camera *cameras.StandardCamera, runtime float32)
 	CreateShader(shader *Shader, assetDatabase *assets.Database)
 	FreeShader(shader *Shader)
 	CreateMesh(mesh *Mesh, verts []Vertex, indices []uint32)
+	Draw(shader *Shader)
 }
 
 type ShaderId interface{}


### PR DESCRIPTION
Working perspective and orthographic camera code. This needed to add Ray and Frustum into a collision package, which also required helper functions and planes to be described. I also exposed Rad2Deg and Deg2Rad. Then I added the OPENGL tag to the build and debugging scripts. I then modified the shaders to have global data containing the camera matrices. Lastly I set the global data for the shader to the pre-calculated values from the camera code. There was a change to make the window shared memory into a pointer rather than embedded into the structure to fix a Go memory pinning issue that came up from the Renderer having pointer functions as well.