### PR TITLE
#47 Make window spin relinquish time back to OS

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,8 +6,13 @@ import (
 	"kaiju/gl"
 	"kaiju/matrix"
 	"kaiju/rendering"
+	"runtime"
 	"time"
 )
+
+func init() {
+	runtime.LockOSThread()
+}
 
 func main() {
 	lastTime := time.Now()

--- a/windowing/win32.h
+++ b/windowing/win32.h
@@ -11,6 +11,22 @@
 #include <windowsx.h>
 #include "../gl/glad_wgl.h"
 
+int shared_mem_set_thread_priority(SharedMem* sm) {
+	int priority = GetThreadPriority(GetCurrentThread());
+	if (sm->evt->writeState != SHARED_MEM_WRITTEN) {
+		SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_IDLE);
+	}
+	return priority;
+}
+
+void shared_mem_reset_thread_priority(SharedMem* sm, int priority) {
+	SetThreadPriority(GetCurrentThread(), priority);
+}
+
+void shared_mem_wait(SharedMem* sm) {
+	SwitchToThread();
+}
+
 void setMouseEvent(InputEvent* evt, LPARAM lParam, int buttonId) {
 	evt->mouseButtonId = buttonId;
 	evt->mouseX = GET_X_LPARAM(lParam);

--- a/windowing/windowing.h
+++ b/windowing/windowing.h
@@ -41,8 +41,16 @@ typedef struct {
 	int size;
 } SharedMem;
 
+int shared_mem_set_thread_priority(SharedMem* sm);
+void shared_mem_reset_thread_priority(SharedMem* sm, int priority);
+void shared_mem_wait(SharedMem* sm);
+
 void shared_memory_wait_for_available(SharedMem* sm) {
-	while (sm->evt->writeState != SHARED_MEM_AVAILABLE) {}
+	int priority = shared_mem_set_thread_priority(sm);
+	while (sm->evt->writeState != SHARED_MEM_AVAILABLE) {
+		shared_mem_wait(sm);
+	}
+	shared_mem_reset_thread_priority(sm, priority);
 }
 
 void shared_memory_set_write_state(SharedMem* sm, uint8_t state) {

--- a/windowing/x11.h
+++ b/windowing/x11.h
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <string.h>
 #include <stdbool.h>
+#include <pthread.h>
 #include <X11/Xlib.h>
 #include "../gl/glad.h"
 #include <GL/glx.h>
@@ -17,6 +18,19 @@ typedef struct {
 	GLXFBConfig bestFbcConfig;
 	GLXContext ctx;
 } X11State;
+
+int shared_mem_set_thread_priority(SharedMem* sm) {
+	// TODO:  Get current thread priority and set the current thread priority to idle
+	return 0;
+}
+
+void shared_mem_reset_thread_priority(SharedMem* sm, int priority) {
+	// TODO:  Set the current thread priority to the given priority
+}
+
+void shared_mem_wait(SharedMem* sm) {
+	sched_yield();
+}
 
 static bool isExtensionSupported(const char* extList, const char* extension) {
 	const char* start;


### PR DESCRIPTION
On windows we need to set the priority of the currently running thread to idle for the window events while it waits on the main loop to continue. This lowers the check-in calls from the OS to this thread as it's setting idle and spinning. We then re-stack the thread on both X11 and Windows if it is not ready to read yet. If it is ready to read, we return the thread priority back to what it was (normal). I also fix the long-running GL crash as I need the program to run longer for testing idle CPU usage.