### PR TITLE
#49 Cleanup rendering, make instanced draw default

### DIFF
--- a/content/basic.vert
+++ b/content/basic.vert
@@ -1,4 +1,5 @@
 #version 330 core
+
 layout (location = 0) in vec3 Position;
 layout (location = 1) in vec3 Normal;
 layout (location = 2) in vec4 Tangent;
@@ -7,6 +8,9 @@ layout (location = 4) in vec4 Color;
 layout (location = 5) in vec4 JointIds;
 layout (location = 6) in vec4 JointWeights;
 layout (location = 7) in vec3 MorphTarget;
+
+#define INSTANCE_VEC4_COUNT 5
+uniform sampler2D instanceSampler;
 
 uniform struct GlobalData {
     mat4 view;
@@ -18,7 +22,13 @@ uniform struct GlobalData {
 out vec4 fragColor;
 
 void main() {
-    fragColor = Color;
-    mat4 model = mat4(1.0);
+    mat4 model;
+    int xOffset = gl_InstanceID*INSTANCE_VEC4_COUNT;
+    model[0] = texelFetch(instanceSampler, ivec2(xOffset,0), 0);
+    model[1] = texelFetch(instanceSampler, ivec2(xOffset+1,0), 0);
+    model[2] = texelFetch(instanceSampler, ivec2(xOffset+2,0), 0);
+    model[3] = texelFetch(instanceSampler, ivec2(xOffset+3,0), 0);
+    vec4 color = texelFetch(instanceSampler, ivec2(xOffset+4,0), 0);
+    fragColor = Color * color;
     gl_Position = globalData.projection * globalData.view * model * vec4(Position, 1.0);
 }

--- a/gl/gles.nonjs.go
+++ b/gl/gles.nonjs.go
@@ -59,6 +59,10 @@ void cglDeleteProgram(GLuint program) {
 	glDeleteProgram(program);
 }
 
+void cglDeleteTextures(GLsizei n, GLuint *textures) {
+	glDeleteTextures(n, textures);
+}
+
 void cglGenVertexArrays(GLsizei n, GLuint *arrays) {
 	glGenVertexArrays(n, arrays);
 }
@@ -67,12 +71,36 @@ void cglGenBuffers(GLsizei n, GLuint *buffers) {
 	glGenBuffers(n, buffers);
 }
 
+void cglGenTextures(GLsizei n, GLuint *textures) {
+	glGenTextures(n, textures);
+}
+
 void cglBindVertexArray(GLuint array) {
 	glBindVertexArray(array);
 }
 
 void cglBindBuffer(GLenum target, GLuint buffer) {
 	glBindBuffer(target, buffer);
+}
+
+void cglBindTexture(GLenum target, GLuint texture) {
+	glBindTexture(target, texture);
+}
+
+void cglActiveTexture(GLenum texture) {
+	glActiveTexture(texture);
+}
+
+void cglUniform1i(GLint location, GLint value) {
+	glUniform1i(location, value);
+}
+
+void cglTexImage2D(GLenum target, GLint level, GLint internalFormat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void *pixels) {
+	glTexImage2D(target, level, internalFormat, width, height, border, format, type, pixels);
+}
+
+void cglTexParameteri(GLenum target, GLenum pname, GLint param) {
+	glTexParameteri(target, pname, param);
 }
 
 void cglBufferData(GLenum target, GLsizeiptr size, const void *data, GLenum usage) {
@@ -93,6 +121,10 @@ void cglUseProgram(GLuint program) {
 
 void cglDrawArrays(GLenum mode, GLint first, GLsizei count) {
 	glDrawArrays(mode, first, count);
+}
+
+void cglDrawElementsInstanced(GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instanceCount) {
+	glDrawElementsInstanced(mode, count, type, indices, instanceCount);
 }
 
 GLint cglGetUniformLocation(GLuint program, const GLchar *name) {
@@ -152,7 +184,18 @@ const (
 	StaticDraw           = 0x88E4
 	Float                = 0x1406
 	Int                  = 0x1404
+	UnsignedInt          = 0x1405
 	Triangles            = 0x0004
+	Texture2D            = 0x0DE1
+	RGBA32F              = 0x8814
+	RGBA                 = 0x1908
+	TextureWrapS         = 0x2802
+	TextureWrapT         = 0x2803
+	TextureMinFilter     = 0x2801
+	TextureMagFilter     = 0x2800
+	ClampToEdge          = 0x812F
+	Nearest              = 0x2600
+	Texture0             = 0x84C0
 )
 
 func ClearScreen() {
@@ -228,6 +271,10 @@ func DeleteProgram(program Handle) {
 	C.cglDeleteProgram(program.AsGL())
 }
 
+func DeleteTextures(n int32, textures *Handle) {
+	C.cglDeleteTextures(C.GLsizei(n), (*C.GLuint)(unsafe.Pointer(textures)))
+}
+
 func GenVertexArrays(n int32, arrays *Handle) {
 	C.cglGenVertexArrays(C.GLsizei(n), (*C.GLuint)(unsafe.Pointer(arrays)))
 }
@@ -236,12 +283,32 @@ func GenBuffers(n int32, buffers *Handle) {
 	C.cglGenBuffers(C.GLsizei(n), (*C.GLuint)(unsafe.Pointer(buffers)))
 }
 
+func GenTextures(n int32, textures *Handle) {
+	C.cglGenTextures(C.GLsizei(n), (*C.GLuint)(unsafe.Pointer(textures)))
+}
+
 func BindVertexArray(array Handle) {
 	C.cglBindVertexArray(array.AsGL())
 }
 
 func BindBuffer(target Handle, buffer Handle) {
 	C.cglBindBuffer(C.GLenum(target), buffer.AsGL())
+}
+
+func BindTexture(target Handle, texture Handle) {
+	C.cglBindTexture(C.GLenum(target), texture.AsGL())
+}
+
+func Uniform1i(location Result, value int32) {
+	C.cglUniform1i(C.GLint(location), C.GLint(value))
+}
+
+func TexImage2D(target Handle, level int32, internalFormat Handle, width int32, height int32, border int32, format Handle, typ Handle, pixels unsafe.Pointer) {
+	C.cglTexImage2D(C.GLenum(target), C.GLint(level), C.GLint(internalFormat), C.GLsizei(width), C.GLsizei(height), C.GLint(border), C.GLenum(format), C.GLenum(typ), pixels)
+}
+
+func TexParameteri(target Handle, pname Handle, param Handle) {
+	C.cglTexParameteri(C.GLenum(target), C.GLenum(pname), C.GLint(param))
 }
 
 func BufferData(target Handle, data unsafe.Pointer, dataSize uint, usage Handle) {
@@ -268,12 +335,24 @@ func DrawArrays(mode Handle, first int32, count int32) {
 	C.cglDrawArrays(C.GLenum(mode), C.GLint(first), C.GLsizei(count))
 }
 
+func DrawElementsInstanced(mode Handle, count int32, typ Handle, first int32, instanceCount int32) {
+	C.cglDrawElementsInstanced(C.GLenum(mode), C.GLsizei(count), C.GLenum(typ), unsafe.Pointer(uintptr(first)), C.GLsizei(instanceCount))
+}
+
 func UnBindBuffer(target Handle) {
 	C.cglBindBuffer(C.GLenum(target), 0)
 }
 
 func UnBindVertexArray() {
 	C.cglBindVertexArray(0)
+}
+
+func UnBindTexture(target Handle) {
+	C.cglBindTexture(C.GLenum(target), 0)
+}
+
+func ActivateTexture(target Handle) {
+	C.cglActiveTexture(C.GLenum(target))
 }
 
 func GetUniformLocation(program Handle, name string) Result {

--- a/main.go
+++ b/main.go
@@ -3,12 +3,19 @@ package main
 import (
 	"kaiju/bootstrap"
 	"kaiju/engine"
-	"kaiju/gl"
 	"kaiju/matrix"
 	"kaiju/rendering"
 	"runtime"
 	"time"
+	"unsafe"
 )
+
+const TriangleShaderDataSize = int(unsafe.Sizeof(TriangleShaderData{}))
+
+type TriangleShaderData struct {
+	rendering.ShaderDataBase
+	Color matrix.Color
+}
 
 func init() {
 	runtime.LockOSThread()
@@ -25,28 +32,36 @@ func main() {
 	verts := []rendering.Vertex{
 		{
 			Position: matrix.Vec3{-0.5, -0.5, 0.0},
-			Color:    matrix.ColorGreen(),
+			Color:    matrix.ColorWhite(),
 		}, {
 			Position: matrix.Vec3{0.5, -0.5, 0.0},
-			Color:    matrix.ColorGreen(),
+			Color:    matrix.ColorWhite(),
 		}, {
 			Position: matrix.Vec3{0.0, 0.5, 0.0},
-			Color:    matrix.ColorGreen(),
+			Color:    matrix.ColorWhite(),
 		},
 	}
-	indices := []uint32{0, 1, 2}
 	mesh := rendering.Mesh{}
-	host.Window.Renderer.CreateMesh(&mesh, verts, indices)
+	host.Window.Renderer.CreateMesh(&mesh, verts, []uint32{0, 1, 2})
+	drawGroup := rendering.NewDrawInstanceGroup(shader, &mesh, TriangleShaderDataSize)
+	{
+		t := TriangleShaderData{Color: matrix.ColorRed()}
+		t.Model = matrix.Mat4Identity()
+		t.Model.Translate(matrix.Vec3{-0.51, 0, 0})
+		drawGroup.AddInstance(&t)
+	}
+	{
+		t := TriangleShaderData{Color: matrix.ColorBlue()}
+		t.Model = matrix.Mat4Identity()
+		t.Model.Translate(matrix.Vec3{0.51, 0, 0})
+		drawGroup.AddInstance(&t)
+	}
 	for !host.Closing {
 		deltaTime := time.Since(lastTime).Seconds()
 		lastTime = time.Now()
 		host.Update(deltaTime)
-		gl.ClearScreen()
-		gl.UseProgram(shader.RenderId.(gl.Handle))
 		host.Window.Renderer.ReadyFrame(host.Camera, float32(host.Runtime()))
-		host.Window.Renderer.Draw(shader)
-		gl.BindVertexArray(mesh.MeshId.(rendering.MeshIdGL).VAO)
-		gl.DrawArrays(gl.Triangles, 0, 3)
+		host.Window.Renderer.Draw([]rendering.DrawInstanceGroup{drawGroup})
 		host.Window.SwapBuffers()
 	}
 }

--- a/rendering/draw_instance.go
+++ b/rendering/draw_instance.go
@@ -1,0 +1,58 @@
+package rendering
+
+import (
+	"kaiju/matrix"
+	"unsafe"
+)
+
+type DrawInstance interface {
+	DataPointer() unsafe.Pointer
+}
+
+type ShaderDataBase struct {
+	Model matrix.Mat4
+}
+
+func (s *ShaderDataBase) DataPointer() unsafe.Pointer {
+	return unsafe.Pointer(&s.Model[0])
+}
+
+type DrawInstanceGroup struct {
+	Shader       *Shader
+	Mesh         *Mesh
+	Instances    []DrawInstance
+	instanceData []byte
+	instanceSize int
+	dataSize     int
+}
+
+func NewDrawInstanceGroup(shader *Shader, mesh *Mesh, dataSize int) DrawInstanceGroup {
+	return DrawInstanceGroup{
+		Shader:       shader,
+		Mesh:         mesh,
+		Instances:    make([]DrawInstance, 0),
+		instanceData: make([]byte, 0),
+		instanceSize: dataSize,
+		dataSize:     0,
+	}
+}
+
+func (d *DrawInstanceGroup) IsEmpty() bool {
+	return len(d.Instances) == 0
+}
+
+func (d *DrawInstanceGroup) AddInstance(instance DrawInstance) {
+	d.Instances = append(d.Instances, instance)
+	d.dataSize += d.instanceSize
+	d.instanceData = append(d.instanceData, make([]byte, d.instanceSize)...)
+}
+
+func (d *DrawInstanceGroup) UpdateData() {
+	base := unsafe.Pointer(&d.instanceData[0])
+	for i, instance := range d.Instances {
+		to := unsafe.Pointer(uintptr(base) + uintptr(i*d.instanceSize))
+		from := instance.DataPointer()
+		copy(unsafe.Slice((*byte)(to), d.instanceSize),
+			unsafe.Slice((*byte)(from), d.instanceSize))
+	}
+}

--- a/rendering/renderer.go
+++ b/rendering/renderer.go
@@ -10,7 +10,7 @@ type Renderer interface {
 	CreateShader(shader *Shader, assetDatabase *assets.Database)
 	FreeShader(shader *Shader)
 	CreateMesh(mesh *Mesh, verts []Vertex, indices []uint32)
-	Draw(shader *Shader)
+	Draw(drawings []DrawInstanceGroup)
 }
 
 type ShaderId interface{}


### PR DESCRIPTION
This changes the sample code in main to use instanced drawing and instanced data controlled through an instance group. This is not a complete finish of the implementation as we'll need to share shaders and only bind the shader once. This will likely be through a shader draw which then has all the instance groups beneath it. For now the instancing and writing of instance data into a texture for GL to use in the shader is functional.