### PR TITLE
#51 and #52 Improve GL instance drawing

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,25 +43,25 @@ func main() {
 	}
 	mesh := rendering.Mesh{}
 	host.Window.Renderer.CreateMesh(&mesh, verts, []uint32{0, 1, 2})
-	drawGroup := rendering.NewDrawInstanceGroup(shader, &mesh, TriangleShaderDataSize)
+	drawGroup := rendering.NewDrawInstanceGroup(&mesh, TriangleShaderDataSize)
 	{
 		t := TriangleShaderData{Color: matrix.ColorRed()}
 		t.Model = matrix.Mat4Identity()
 		t.Model.Translate(matrix.Vec3{-0.51, 0, 0})
 		drawGroup.AddInstance(&t)
 	}
-	{
-		t := TriangleShaderData{Color: matrix.ColorBlue()}
-		t.Model = matrix.Mat4Identity()
-		t.Model.Translate(matrix.Vec3{0.51, 0, 0})
-		drawGroup.AddInstance(&t)
-	}
+	t := TriangleShaderData{Color: matrix.ColorBlue()}
+	t.Model = matrix.Mat4Identity()
+	drawGroup.AddInstance(&t)
+	sd := rendering.NewShaderDraw(shader)
+	sd.AddInstanceGroup(&drawGroup)
 	for !host.Closing {
 		deltaTime := time.Since(lastTime).Seconds()
 		lastTime = time.Now()
 		host.Update(deltaTime)
 		host.Window.Renderer.ReadyFrame(host.Camera, float32(host.Runtime()))
-		host.Window.Renderer.Draw([]rendering.DrawInstanceGroup{drawGroup})
+		host.Window.Renderer.Draw([]rendering.ShaderDraw{sd})
 		host.Window.SwapBuffers()
+		t.Model.Translate(matrix.Vec3{matrix.Float(0.1 * deltaTime), 0, 0})
 	}
 }

--- a/rendering/renderer.gl.go
+++ b/rendering/renderer.gl.go
@@ -184,37 +184,27 @@ func (r GLRenderer) setGlobalUniforms(shader *Shader) {
 	gl.Uniform1f(timeLoc, r.globalShaderData.Time)
 }
 
-func (r GLRenderer) Draw(drawings []DrawInstanceGroup) {
+func (r GLRenderer) Draw(drawings []ShaderDraw) {
 	gl.ClearScreen()
-	for _, draw := range drawings {
-		if draw.IsEmpty() {
-			continue
-		}
-		draw.UpdateData()
-		shaderId := draw.Shader.RenderId.(gl.Handle)
-		meshId := draw.Mesh.MeshId.(MeshIdGL)
+	for _, sd := range drawings {
+		shaderId := sd.shader.RenderId.(gl.Handle)
 		gl.UseProgram(shaderId)
-		r.setGlobalUniforms(draw.Shader)
-		gl.BindVertexArray(meshId.VAO)
-		var instanceTexBuff gl.Handle
-		gl.GenTextures(1, &instanceTexBuff)
-		gl.BindTexture(gl.Texture2D, instanceTexBuff)
-		gl.TexImage2D(gl.Texture2D, 0, gl.RGBA32F,
-			int32(len(draw.instanceData))/4/4, 1, 0,
-			gl.RGBA, gl.Float, unsafe.Pointer(&draw.instanceData[0]))
-		gl.TexParameteri(gl.Texture2D, gl.TextureWrapS, gl.ClampToEdge)
-		gl.TexParameteri(gl.Texture2D, gl.TextureWrapT, gl.ClampToEdge)
-		gl.TexParameteri(gl.Texture2D, gl.TextureMinFilter, gl.Nearest)
-		gl.TexParameteri(gl.Texture2D, gl.TextureMagFilter, gl.Nearest)
-		gl.UnBindTexture(gl.Texture2D)
-		gl.ActivateTexture(gl.Texture0)
-		gl.BindTexture(gl.Texture2D, instanceTexBuff)
-		gl.Uniform1i(gl.GetUniformLocation(shaderId, "instanceSampler"), 0)
-		gl.BindBuffer(gl.ElementArrayBuffer, meshId.EBO)
-		gl.DrawElementsInstanced(gl.Triangles, meshId.indexCount,
-			gl.UnsignedInt, 0, int32(len(draw.Instances)))
-		gl.UnBindBuffer(gl.ElementArrayBuffer)
-		gl.UnBindVertexArray()
-		gl.DeleteTextures(1, &instanceTexBuff)
+		r.setGlobalUniforms(sd.shader)
+		for _, draw := range sd.instanceGroups {
+			if draw.IsEmpty() {
+				continue
+			}
+			draw.UpdateData()
+			meshId := draw.Mesh.MeshId.(MeshIdGL)
+			gl.BindVertexArray(meshId.VAO)
+			gl.ActivateTexture(gl.Texture0)
+			gl.BindTexture(gl.Texture2D, draw.TextureData)
+			gl.Uniform1i(gl.GetUniformLocation(shaderId, "instanceSampler"), 0)
+			gl.BindBuffer(gl.ElementArrayBuffer, meshId.EBO)
+			gl.DrawElementsInstanced(gl.Triangles, meshId.indexCount,
+				gl.UnsignedInt, 0, int32(len(draw.Instances)))
+			gl.UnBindBuffer(gl.ElementArrayBuffer)
+			gl.UnBindVertexArray()
+		}
 	}
 }

--- a/rendering/renderer.gl.go
+++ b/rendering/renderer.gl.go
@@ -215,6 +215,6 @@ func (r GLRenderer) Draw(drawings []DrawInstanceGroup) {
 			gl.UnsignedInt, 0, int32(len(draw.Instances)))
 		gl.UnBindBuffer(gl.ElementArrayBuffer)
 		gl.UnBindVertexArray()
-		//gl.DeleteTextures(1, &instanceTexBuff)
+		gl.DeleteTextures(1, &instanceTexBuff)
 	}
 }

--- a/rendering/renderer.go
+++ b/rendering/renderer.go
@@ -10,7 +10,7 @@ type Renderer interface {
 	CreateShader(shader *Shader, assetDatabase *assets.Database)
 	FreeShader(shader *Shader)
 	CreateMesh(mesh *Mesh, verts []Vertex, indices []uint32)
-	Draw(drawings []DrawInstanceGroup)
+	Draw(drawings []ShaderDraw)
 }
 
 type ShaderId interface{}

--- a/rendering/shader_draw.go
+++ b/rendering/shader_draw.go
@@ -1,0 +1,17 @@
+package rendering
+
+type ShaderDraw struct {
+	shader         *Shader
+	instanceGroups []DrawInstanceGroup
+}
+
+func NewShaderDraw(shader *Shader) ShaderDraw {
+	return ShaderDraw{
+		shader:         shader,
+		instanceGroups: make([]DrawInstanceGroup, 0),
+	}
+}
+
+func (s *ShaderDraw) AddInstanceGroup(group *DrawInstanceGroup) {
+	s.instanceGroups = append(s.instanceGroups, *group)
+}


### PR DESCRIPTION
This makes it so that shaders are only bound once and will draw all of the instances that are bound do them. This also fixes an issue of re-generating the texture every frame for draw instance groups instance data. The texture is now re-crated only when the group expands.
