### PR TITLE
#68 Prepare mesh code for loading mesh data

### DIFF
--- a/engine/host.go
+++ b/engine/host.go
@@ -14,6 +14,7 @@ type Host struct {
 	Camera        *cameras.StandardCamera
 	ShaderCache   rendering.ShaderCache
 	TextureCache  rendering.TextureCache
+	MeshCache     rendering.MeshCache
 	Drawings      rendering.Drawings
 	frameTime     float64
 	Closing       bool
@@ -40,6 +41,7 @@ func NewHost() (Host, error) {
 	}
 	host.ShaderCache = rendering.NewShaderCache(host.Window.Renderer, &host.assetDatabase)
 	host.TextureCache = rendering.NewTextureCache(host.Window.Renderer, &host.assetDatabase)
+	host.MeshCache = rendering.NewMeshCache(host.Window.Renderer, &host.assetDatabase)
 	return host, nil
 }
 
@@ -52,6 +54,7 @@ func (host *Host) Update(deltaTime float64) {
 	}
 	host.ShaderCache.CreatePending()
 	host.TextureCache.CreatePending()
+	host.MeshCache.CreatePending()
 	//gl.ClearScreen()
 	//host.Window.SwapBuffers()
 	// TODO:  Do end updates on various systems

--- a/main.go
+++ b/main.go
@@ -21,39 +21,27 @@ func init() {
 	runtime.LockOSThread()
 }
 
-func testDrawing(host *engine.Host) *TriangleShaderData {
-	shader := host.ShaderCache.CreateShader("content/basic.vert", "content/basic.frag", "", "", "")
-	verts := []rendering.Vertex{
-		{
-			Position: matrix.Vec3{-0.5, -0.5, 0.0},
-			Color:    matrix.ColorWhite(),
-			UV0:      matrix.Vec2{0, 0},
-		}, {
-			Position: matrix.Vec3{0.5, -0.5, 0.0},
-			Color:    matrix.ColorWhite(),
-			UV0:      matrix.Vec2{1, 0},
-		}, {
-			Position: matrix.Vec3{0.0, 0.5, 0.0},
-			Color:    matrix.ColorWhite(),
-			UV0:      matrix.Vec2{0.5, 1},
-		},
+func testDrawing(host *engine.Host) {
+	positions := []matrix.Vec3{
+		{-0.6, 0.0, 0.0},
+		{0.6, 0.0, 0.0},
 	}
-	mesh := rendering.Mesh{}
-	host.Window.Renderer.CreateMesh(&mesh, verts, []uint32{0, 1, 2})
-	drawGroup := rendering.NewDrawInstanceGroup(&mesh, TriangleShaderDataSize)
-	droidTex, _ := host.TextureCache.Texture("content/android.png", rendering.TextureFilterNearest)
-	drawGroup.Textures = []*rendering.Texture{droidTex}
-	{
-		t := TriangleShaderData{Color: matrix.ColorRed()}
-		t.Model = matrix.Mat4Identity()
-		t.Model.Translate(matrix.Vec3{-0.51, 0, 0})
-		drawGroup.AddInstance(&t)
+	colors := []matrix.Color{
+		{1.0, 0.0, 0.0, 1.0},
+		{0.0, 1.0, 0.0, 1.0},
 	}
-	t := TriangleShaderData{Color: matrix.ColorBlue()}
-	t.Model = matrix.Mat4Identity()
-	drawGroup.AddInstance(&t)
-	host.Drawings.AddDrawing(shader, drawGroup)
-	return &t
+	for i := 0; i < 2; i++ {
+		shader := host.ShaderCache.CreateShader("content/basic.vert", "content/basic.frag", "", "", "")
+		mesh := rendering.NewMeshQuad(&host.MeshCache)
+		drawGroup := rendering.NewDrawInstanceGroup(mesh, TriangleShaderDataSize)
+		droidTex, _ := host.TextureCache.Texture("content/android.png", rendering.TextureFilterNearest)
+		drawGroup.Textures = []*rendering.Texture{droidTex}
+		tsd := TriangleShaderData{Color: colors[i]}
+		tsd.Model = matrix.Mat4Identity()
+		tsd.Model.Translate(positions[i])
+		drawGroup.AddInstance(&tsd)
+		host.Drawings.AddDrawing(shader, drawGroup)
+	}
 }
 
 func main() {
@@ -63,12 +51,11 @@ func main() {
 		panic(err)
 	}
 	bootstrap.Main(&host)
-	t := testDrawing(&host)
+	testDrawing(&host)
 	for !host.Closing {
 		deltaTime := time.Since(lastTime).Seconds()
 		lastTime = time.Now()
 		host.Update(deltaTime)
 		host.Render()
-		t.Model.Translate(matrix.Vec3{matrix.Float(0.1 * deltaTime), 0, 0})
 	}
 }

--- a/rendering/draw_instance.go
+++ b/rendering/draw_instance.go
@@ -7,11 +7,16 @@ import (
 )
 
 type DrawInstance interface {
+	SetModel(model matrix.Mat4)
 	DataPointer() unsafe.Pointer
 }
 
 type ShaderDataBase struct {
 	Model matrix.Mat4
+}
+
+func (s *ShaderDataBase) SetModel(model matrix.Mat4) {
+	s.Model = model
 }
 
 func (s *ShaderDataBase) DataPointer() unsafe.Pointer {

--- a/rendering/mesh.go
+++ b/rendering/mesh.go
@@ -1,5 +1,7 @@
 package rendering
 
+import "kaiju/matrix"
+
 type MeshDrawMode int
 
 const (
@@ -10,5 +12,550 @@ const (
 )
 
 type Mesh struct {
-	MeshId MeshId
+	MeshId         MeshId
+	key            string
+	pendingVerts   []Vertex
+	pendingIndexes []uint32
+}
+
+func NewMesh(key string, verts []Vertex, indexes []uint32) *Mesh {
+	return &Mesh{
+		key:            key,
+		pendingVerts:   verts,
+		pendingIndexes: indexes,
+	}
+}
+
+func (m *Mesh) DelayedCreate(renderer Renderer) {
+	renderer.CreateMesh(m, m.pendingVerts, m.pendingIndexes)
+	m.pendingVerts = m.pendingVerts[:0]
+	m.pendingIndexes = m.pendingIndexes[:0]
+}
+
+func (m Mesh) Key() string   { return m.key }
+func (m Mesh) IsReady() bool { return m.MeshId != nil && m.MeshId.IsValid() }
+
+func NewMeshQuad(cache *MeshCache) *Mesh {
+	const key = "quad"
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		verts := make([]Vertex, 4)
+		verts[0].Position = matrix.Vec3{-0.5, -0.5, 0.0}
+		verts[0].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[0].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[0].Color = matrix.ColorWhite()
+		verts[1].Position = matrix.Vec3{-0.5, 0.5, 0.0}
+		verts[1].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[1].UV0 = matrix.Vec2{0.0, 0.0}
+		verts[1].Color = matrix.ColorWhite()
+		verts[2].Position = matrix.Vec3{0.5, 0.5, 0.0}
+		verts[2].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[2].UV0 = matrix.Vec2{1.0, 0.0}
+		verts[2].Color = matrix.ColorWhite()
+		verts[3].Position = matrix.Vec3{0.5, -0.5, 0.0}
+		verts[3].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[3].UV0 = matrix.Vec2{1.0, 1.0}
+		verts[3].Color = matrix.ColorWhite()
+		indexes := []uint32{0, 2, 1, 0, 3, 2}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshTriangle(cache *MeshCache) *Mesh {
+	const key = "triangle"
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		verts := make([]Vertex, 3)
+		verts[0].Position = matrix.Vec3{-0.5, -0.5, 0.0}
+		verts[0].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[0].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[0].Color = matrix.ColorWhite()
+		verts[1].Position = matrix.Vec3{0.0, 0.5, 0.0}
+		verts[1].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[1].UV0 = matrix.Vec2{0.0, 0.0}
+		verts[1].Color = matrix.ColorWhite()
+		verts[2].Position = matrix.Vec3{0.5, -0.5, 0.0}
+		verts[2].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[2].UV0 = matrix.Vec2{1.0, 0.0}
+		verts[2].Color = matrix.ColorWhite()
+		indexes := []uint32{0, 2, 1}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshUnitQuad(cache *MeshCache) *Mesh {
+	const key = "unit_quad"
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		verts := make([]Vertex, 4)
+		verts[0].Position = matrix.Vec3{-1.0, -1.0, 0.0}
+		verts[0].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[0].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[0].Color = matrix.ColorWhite()
+		verts[1].Position = matrix.Vec3{-1.0, 1.0, 0.0}
+		verts[1].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[1].UV0 = matrix.Vec2{0.0, 0.0}
+		verts[1].Color = matrix.ColorWhite()
+		verts[2].Position = matrix.Vec3{1.0, 1.0, 0.0}
+		verts[2].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[2].UV0 = matrix.Vec2{1.0, 0.0}
+		verts[2].Color = matrix.ColorWhite()
+		verts[3].Position = matrix.Vec3{1.0, -1.0, 0.0}
+		verts[3].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[3].UV0 = matrix.Vec2{1.0, 1.0}
+		verts[3].Color = matrix.ColorWhite()
+		indexes := []uint32{0, 2, 1, 0, 3, 2}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshScreenQuad(cache *MeshCache) *Mesh {
+	const key = "screen_quad"
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		verts := make([]Vertex, 4)
+		verts[0].Position = matrix.Vec3{0.0, 0.0, 0.0}
+		verts[0].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[0].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[0].Color = matrix.ColorWhite()
+		verts[1].Position = matrix.Vec3{0.0, 1.0, 0.0}
+		verts[1].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[1].UV0 = matrix.Vec2{0.0, 0.0}
+		verts[1].Color = matrix.ColorWhite()
+		verts[2].Position = matrix.Vec3{1.0, 1.0, 0.0}
+		verts[2].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[2].UV0 = matrix.Vec2{1.0, 0.0}
+		verts[2].Color = matrix.ColorWhite()
+		verts[3].Position = matrix.Vec3{1.0, 0.0, 0.0}
+		verts[3].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[3].UV0 = matrix.Vec2{1.0, 1.0}
+		verts[3].Color = matrix.ColorWhite()
+		indexes := []uint32{0, 2, 1, 0, 3, 2}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshPlane(cache *MeshCache) *Mesh {
+	const key = "plane"
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		verts := make([]Vertex, 4)
+		verts[0].Position = matrix.Vec3{-0.5, 0.0, 0.5}
+		verts[0].Normal = matrix.Vec3{0.0, 1.0, 0.0}
+		verts[0].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[0].Color = matrix.ColorWhite()
+		verts[1].Position = matrix.Vec3{-0.5, 0.0, -0.5}
+		verts[1].Normal = matrix.Vec3{0.0, 1.0, 0.0}
+		verts[1].UV0 = matrix.Vec2{0.0, 0.0}
+		verts[1].Color = matrix.ColorWhite()
+		verts[2].Position = matrix.Vec3{0.5, 0.0, -0.5}
+		verts[2].Normal = matrix.Vec3{0.0, 1.0, 0.0}
+		verts[2].UV0 = matrix.Vec2{1.0, 0.0}
+		verts[2].Color = matrix.ColorWhite()
+		verts[3].Position = matrix.Vec3{0.5, 0.0, 0.5}
+		verts[3].Normal = matrix.Vec3{0.0, 1.0, 0.0}
+		verts[3].UV0 = matrix.Vec2{1.0, 1.0}
+		verts[3].Color = matrix.ColorWhite()
+		indexes := []uint32{0, 2, 1, 0, 3, 2}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshCube(cache *MeshCache) *Mesh {
+	const key = "cube"
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		verts := make([]Vertex, 8)
+		verts[0].Position = matrix.Vec3{-0.5, -0.5, 0.5} // 0 - lbf
+		verts[0].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[0].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[0].Color = matrix.ColorWhite()
+		verts[1].Position = matrix.Vec3{-0.5, 0.5, 0.5} // 1 - ltf
+		verts[1].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[1].UV0 = matrix.Vec2{0.0, 0.0}
+		verts[1].Color = matrix.ColorWhite()
+		verts[2].Position = matrix.Vec3{0.5, 0.5, 0.5} // 2 - rtf
+		verts[2].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[2].UV0 = matrix.Vec2{1.0, 0.0}
+		verts[2].Color = matrix.ColorWhite()
+		verts[3].Position = matrix.Vec3{0.5, -0.5, 0.5} // 3 - rbf
+		verts[3].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[3].UV0 = matrix.Vec2{1.0, 1.0}
+		verts[3].Color = matrix.ColorWhite()
+		verts[4].Position = matrix.Vec3{-0.5, -0.5, -0.5} // 4 - lbb
+		verts[4].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[4].UV0 = matrix.Vec2{1.0, 1.0}
+		verts[4].Color = matrix.ColorWhite()
+		verts[5].Position = matrix.Vec3{-0.5, 0.5, -0.5} // 5 - ltb
+		verts[5].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[5].UV0 = matrix.Vec2{1.0, 0.0}
+		verts[5].Color = matrix.ColorWhite()
+		verts[6].Position = matrix.Vec3{0.5, 0.5, -0.5} // 6 - rtb
+		verts[6].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[6].UV0 = matrix.Vec2{0.0, 0.0}
+		verts[6].Color = matrix.ColorWhite()
+		verts[7].Position = matrix.Vec3{0.5, -0.5, -0.5} // 7 - rbb
+		verts[7].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[7].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[7].Color = matrix.ColorWhite()
+		indexes := []uint32{
+			5, 2, 6, 2, 0, 3,
+			1, 4, 0, 7, 0, 4,
+			6, 3, 7, 5, 7, 4,
+			5, 1, 2, 2, 1, 0,
+			1, 5, 4, 7, 3, 0,
+			6, 2, 3, 5, 6, 7,
+		}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshTexturableCube(cache *MeshCache) *Mesh {
+	const key = "texturable_cube"
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		verts := make([]Vertex, 36)
+		for i := 0; i < 36; i++ {
+			verts[i].Color = matrix.ColorWhite()
+			if i%4 == 0 {
+				verts[i+0].UV0 = matrix.Vec2{0.0, 1.0}
+				verts[i+1].UV0 = matrix.Vec2{0.0, 0.0}
+				verts[i+2].UV0 = matrix.Vec2{1.0, 0.0}
+				verts[i+3].UV0 = matrix.Vec2{1.0, 1.0}
+			}
+		}
+		for i := 0; i < 4; i++ {
+			verts[i].Normal = matrix.Vec3Forward()
+		}
+		for i := 4; i < 8; i++ {
+			verts[i].Normal = matrix.Vec3Left()
+		}
+		for i := 8; i < 12; i++ {
+			verts[i].Normal = matrix.Vec3Backward()
+		}
+		for i := 12; i < 16; i++ {
+			verts[i].Normal = matrix.Vec3Right()
+		}
+		for i := 16; i < 20; i++ {
+			verts[i].Normal = matrix.Vec3Up()
+		}
+		for i := 20; i < 24; i++ {
+			verts[i].Normal = matrix.Vec3Down()
+		}
+
+		offset := 0
+		verts[offset].Position = matrix.Vec3{-0.5, -0.5, 0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{-0.5, 0.5, 0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{0.5, 0.5, 0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{0.5, -0.5, 0.5}
+		offset++
+
+		verts[offset].Position = matrix.Vec3{-0.5, -0.5, -0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{-0.5, 0.5, -0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{-0.5, 0.5, 0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{-0.5, -0.5, 0.5}
+		offset++
+
+		verts[offset].Position = matrix.Vec3{0.5, -0.5, -0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{0.5, 0.5, -0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{-0.5, 0.5, -0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{-0.5, -0.5, -0.5}
+		offset++
+
+		verts[offset].Position = matrix.Vec3{0.5, -0.5, 0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{0.5, 0.5, 0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{0.5, 0.5, -0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{0.5, -0.5, -0.5}
+		offset++
+
+		verts[offset].Position = matrix.Vec3{-0.5, 0.5, 0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{-0.5, 0.5, -0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{0.5, 0.5, -0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{0.5, 0.5, 0.5}
+		offset++
+
+		verts[offset].Position = matrix.Vec3{-0.5, -0.5, -0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{-0.5, -0.5, 0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{0.5, -0.5, 0.5}
+		offset++
+		verts[offset].Position = matrix.Vec3{0.5, -0.5, -0.5}
+		offset++
+
+		indexes := []uint32{
+			0, 2, 1, 0, 3, 2,
+			4, 6, 5, 4, 7, 6,
+			8, 10, 9, 8, 11, 10,
+			12, 14, 13, 12, 15, 14,
+			16, 18, 17, 16, 19, 18,
+			20, 22, 21, 20, 23, 22,
+		}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshSkyboxCube(cache *MeshCache) *Mesh {
+	const key = "skybox"
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		verts := make([]Vertex, 8)
+		verts[0].Position = matrix.Vec3{-0.5, -0.5, 0.5} // 0 - lbf
+		verts[0].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[0].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[0].Color = matrix.ColorWhite()
+		verts[1].Position = matrix.Vec3{-0.5, 0.5, 0.5} // 1 - ltf
+		verts[1].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[1].UV0 = matrix.Vec2{0.0, 0.0}
+		verts[1].Color = matrix.ColorWhite()
+		verts[2].Position = matrix.Vec3{0.5, 0.5, 0.5} // 2 - rtf
+		verts[2].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[2].UV0 = matrix.Vec2{1.0, 0.0}
+		verts[2].Color = matrix.ColorWhite()
+		verts[3].Position = matrix.Vec3{0.5, -0.5, 0.5} // 3 - rbf
+		verts[3].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[3].UV0 = matrix.Vec2{1.0, 1.0}
+		verts[3].Color = matrix.ColorWhite()
+		verts[4].Position = matrix.Vec3{-0.5, -0.5, -0.5} // 4 - lbb
+		verts[4].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[4].UV0 = matrix.Vec2{1.0, 1.0}
+		verts[4].Color = matrix.ColorWhite()
+		verts[5].Position = matrix.Vec3{-0.5, 0.5, -0.5} // 5 - ltb
+		verts[5].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[5].UV0 = matrix.Vec2{1.0, 0.0}
+		verts[5].Color = matrix.ColorWhite()
+		verts[6].Position = matrix.Vec3{0.5, 0.5, -0.5} // 6 - rtb
+		verts[6].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[6].UV0 = matrix.Vec2{0.0, 0.0}
+		verts[6].Color = matrix.ColorWhite()
+		verts[7].Position = matrix.Vec3{0.5, -0.5, -0.5} // 7 - rbb
+		verts[7].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[7].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[7].Color = matrix.ColorWhite()
+		indexes := []uint32{
+			5, 4, 7, 7, 6, 5,
+			0, 4, 5, 5, 1, 0,
+			7, 3, 2, 2, 6, 7,
+			0, 1, 2, 2, 3, 0,
+			5, 6, 2, 2, 1, 5,
+			4, 0, 7, 7, 0, 3,
+		}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshCubeInverse(cache *MeshCache) *Mesh {
+	const key = "cube_inverse"
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		verts := meshCube(matrix.ColorWhite())
+		indexes := []uint32{
+			5, 4, 7, 7, 6, 5,
+			0, 4, 5, 5, 1, 0,
+			7, 3, 2, 2, 6, 7,
+			0, 1, 2, 2, 3, 0,
+			5, 6, 2, 2, 1, 5,
+			4, 0, 7, 7, 0, 3,
+		}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func meshCube(vertColor matrix.Color) []Vertex {
+	var verts = make([]Vertex, 8)
+	verts[0].Position = matrix.Vec3{-0.5, -0.5, 0.5} // 0
+	verts[0].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+	verts[0].UV0 = matrix.Vec2{0.0, 1.0}
+	verts[0].Color = vertColor
+	verts[1].Position = matrix.Vec3{-0.5, 0.5, 0.5} // 1
+	verts[1].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+	verts[1].UV0 = matrix.Vec2{0.0, 0.0}
+	verts[1].Color = vertColor
+	verts[2].Position = matrix.Vec3{0.5, 0.5, 0.5} // 2
+	verts[2].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+	verts[2].UV0 = matrix.Vec2{1.0, 0.0}
+	verts[2].Color = vertColor
+	verts[3].Position = matrix.Vec3{0.5, -0.5, 0.5} // 3
+	verts[3].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+	verts[3].UV0 = matrix.Vec2{1.0, 1.0}
+	verts[3].Color = vertColor
+	verts[4].Position = matrix.Vec3{-0.5, -0.5, -0.5} // 4
+	verts[4].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+	verts[4].UV0 = matrix.Vec2{0.0, 1.0}
+	verts[4].Color = vertColor
+	verts[5].Position = matrix.Vec3{-0.5, 0.5, -0.5} // 5
+	verts[5].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+	verts[5].UV0 = matrix.Vec2{0.0, 0.0}
+	verts[5].Color = vertColor
+	verts[6].Position = matrix.Vec3{0.5, 0.5, -0.5} // 6
+	verts[6].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+	verts[6].UV0 = matrix.Vec2{1.0, 0.0}
+	verts[6].Color = vertColor
+	verts[7].Position = matrix.Vec3{0.5, -0.5, -0.5} // 7
+	verts[7].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+	verts[7].UV0 = matrix.Vec2{1.0, 1.0}
+	verts[7].Color = vertColor
+	return verts
+}
+
+func NewMeshFrustum(cache *MeshCache, key string, inverseProjection matrix.Mat4) *Mesh {
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		verts := meshCube(matrix.ColorWhite())
+		for i := 0; i < 8; i++ {
+			verts[i].Position.ScaleAssign(2.0)
+			verts[i].Position = inverseProjection.TransformPoint(verts[i].Position)
+		}
+		indexes := []uint32{
+			0, 1, 2, 3, 0,
+			4, 5, 6, 7, 4,
+			0, 1, 5, 6,
+			2, 3, 7,
+		}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshOffsetQuad(cache *MeshCache, key string, sideOffsets matrix.Vec4) *Mesh {
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		l := sideOffsets.X()
+		t := -sideOffsets.Y()
+		r := -sideOffsets.Z()
+		b := sideOffsets.W()
+		var verts = make([]Vertex, 4)
+		verts[0].Position = matrix.Vec3{-0.5 + l, -0.5 + b, 0.0}
+		verts[0].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[1].Position = matrix.Vec3{-0.5 + l, 0.5 + t, 0.0}
+		verts[1].UV0 = matrix.Vec2{0.0, 0.0}
+		verts[2].Position = matrix.Vec3{0.5 + r, 0.5 + t, 0.0}
+		verts[2].UV0 = matrix.Vec2{1.0, 0.0}
+		verts[3].Position = matrix.Vec3{0.5 + r, -0.5 + b, 0.0}
+		verts[3].UV0 = matrix.Vec2{1.0, 1.0}
+		for i := 0; i < 4; i++ {
+			verts[i].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+			verts[i].Color = matrix.ColorWhite()
+		}
+		indexes := []uint32{0, 1, 2, 0, 2, 3}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshGrid(cache *MeshCache, key string, points []matrix.Vec3, vertColor matrix.Color) *Mesh {
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		length := uint32(len(points))
+		if length%2 != 0 {
+			panic("points length must be even")
+		}
+		var verts = make([]Vertex, length)
+		var indexes = make([]uint32, length)
+		for i := uint32(0); i < length; i++ {
+			verts[i].Position = points[i]
+			verts[i].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+			verts[i].UV0 = matrix.Vec2{0.0, 1.0}
+			verts[i].Color = vertColor
+			indexes[i] = i
+		}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshPoint(cache *MeshCache, key string, position matrix.Vec3, vertColor matrix.Color) *Mesh {
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		var verts = make([]Vertex, 1)
+		verts[0].Position = position
+		verts[0].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[0].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[0].Color = vertColor
+		indexes := []uint32{0}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshLine(cache *MeshCache, key string, p0, p1 matrix.Vec3, vertColor matrix.Color) *Mesh {
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		var verts = make([]Vertex, 2)
+		verts[0].Position = p0
+		verts[0].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[0].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[0].Color = vertColor
+		verts[1].Position = p1
+		verts[1].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[1].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[1].Color = vertColor
+		indexes := []uint32{0, 1}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshWireQuad(cache *MeshCache, key string, vertColor matrix.Color) *Mesh {
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		var verts = make([]Vertex, 4)
+		verts[0].Position = matrix.Vec3{-0.5, -0.5, 0.0}
+		verts[0].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[0].UV0 = matrix.Vec2{0.0, 1.0}
+		verts[0].Color = vertColor
+		verts[1].Position = matrix.Vec3{-0.5, 0.5, 0.0}
+		verts[1].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[1].UV0 = matrix.Vec2{0.0, 0.0}
+		verts[1].Color = vertColor
+		verts[2].Position = matrix.Vec3{0.5, 0.5, 0.0}
+		verts[2].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[2].UV0 = matrix.Vec2{1.0, 0.0}
+		verts[2].Color = vertColor
+		verts[3].Position = matrix.Vec3{0.5, -0.5, 0.0}
+		verts[3].Normal = matrix.Vec3{0.0, 0.0, 1.0}
+		verts[3].UV0 = matrix.Vec2{1.0, 1.0}
+		verts[3].Color = vertColor
+		var indexes = []uint32{0, 1, 1, 2, 2, 3, 3, 0}
+		return cache.Mesh(key, verts, indexes)
+	}
+}
+
+func NewMeshWireCube(cache *MeshCache, key string, vertColor matrix.Color) *Mesh {
+	if mesh, ok := cache.FindMesh(key); ok {
+		return mesh
+	} else {
+		verts := meshCube(vertColor)
+		indexes := []uint32{
+			0, 1, 1, 2, 2, 3, 3, 0,
+			0, 4, 1, 5, 2, 6, 3, 7,
+			4, 5, 5, 6, 6, 7, 7, 4,
+		}
+		return cache.Mesh(key, verts, indexes)
+	}
 }

--- a/rendering/mesh_cache.go
+++ b/rendering/mesh_cache.go
@@ -1,0 +1,52 @@
+package rendering
+
+import (
+	"kaiju/assets"
+)
+
+type MeshCache struct {
+	renderer      Renderer
+	assetDatabase *assets.Database
+	meshes        map[string]*Mesh
+	pendingMeshes []*Mesh
+}
+
+func NewMeshCache(renderer Renderer, assetDatabase *assets.Database) MeshCache {
+	return MeshCache{
+		renderer:      renderer,
+		assetDatabase: assetDatabase,
+		meshes:        make(map[string]*Mesh),
+		pendingMeshes: make([]*Mesh, 0),
+	}
+}
+
+func (m *MeshCache) FindMesh(key string) (*Mesh, bool) {
+	if mesh, ok := m.meshes[key]; ok {
+		return mesh, true
+	} else if m.assetDatabase.AssetExists(key) {
+		//mesh := NewMeshFromAsset(key, m.assetDatabase)
+		//m.textures[key] = mesh
+		//return mesh, nil
+		panic("Not implemented")
+	} else {
+		return nil, false
+	}
+}
+
+func (m *MeshCache) Mesh(key string, verts []Vertex, indexes []uint32) *Mesh {
+	if mesh, ok := m.meshes[key]; ok {
+		return mesh
+	} else {
+		mesh := NewMesh(key, verts, indexes)
+		m.pendingMeshes = append(m.pendingMeshes, mesh)
+		m.meshes[key] = mesh
+		return mesh
+	}
+}
+
+func (m *MeshCache) CreatePending() {
+	for _, mesh := range m.pendingMeshes {
+		mesh.DelayedCreate(m.renderer)
+	}
+	m.pendingMeshes = m.pendingMeshes[:0]
+}

--- a/rendering/renderer.gl.go
+++ b/rendering/renderer.gl.go
@@ -18,6 +18,10 @@ type MeshIdGL struct {
 	indexCount int32
 }
 
+func (m MeshIdGL) IsValid() bool {
+	return m.VAO.IsValid()
+}
+
 type GLRenderer struct {
 	globalShaderData GlobalShaderData
 }
@@ -253,7 +257,7 @@ func (r GLRenderer) Draw(drawings []ShaderDraw) {
 		gl.UseProgram(shaderId)
 		r.setGlobalUniforms(sd.shader)
 		for _, draw := range sd.instanceGroups {
-			if draw.IsEmpty() {
+			if draw.IsEmpty() || !draw.Mesh.IsReady() {
 				continue
 			}
 			draw.UpdateData()

--- a/rendering/renderer.go
+++ b/rendering/renderer.go
@@ -21,4 +21,6 @@ type Renderer interface {
 
 type ShaderId interface{}
 type TextureId interface{}
-type MeshId interface{}
+type MeshId interface {
+	IsValid() bool
+}

--- a/rendering/shader_cache.go
+++ b/rendering/shader_cache.go
@@ -27,7 +27,7 @@ func (s *ShaderCache) CreateShader(vertPath string, fragPath string, geomPath st
 		if shader != nil {
 			s.pendingShaders = append(s.pendingShaders, shader)
 		}
-		// Else, use a fallback shader
+		s.shaders[shaderKey] = shader
 		return shader
 	}
 }

--- a/rendering/texture.go
+++ b/rendering/texture.go
@@ -181,13 +181,14 @@ func ReadRawTextureData(mem []byte, inputType TextureFileFormat) TextureData {
 			res.InternalFormat = TextureInputTypeRgba8
 			res.Format = TextureColorFormatRgbaUnorm
 			res.Type = TextureMemTypeUnsignedByte
-			res.Mem = make([]byte, len(mem))
-			byteWidth := res.Width * bytesInPixel
-			for y := 0; y < res.Height; y++ {
-				from := y * byteWidth
-				to := (res.Height - y - 1) * byteWidth
-				copy(res.Mem[to:to+byteWidth], mem[from:from+byteWidth])
-			}
+			res.Mem = mem
+			//res.Mem = make([]byte, len(mem))
+			//byteWidth := res.Width * bytesInPixel
+			//for y := 0; y < res.Height; y++ {
+			//	from := y * byteWidth
+			//	to := (res.Height - y - 1) * byteWidth
+			//	copy(res.Mem[to:to+byteWidth], mem[from:from+byteWidth])
+			//}
 		}
 	case TextureFileFormatRaw:
 		res.Mem = mem[:]

--- a/rendering/texture_cache.go
+++ b/rendering/texture_cache.go
@@ -24,6 +24,7 @@ func (t *TextureCache) Texture(textureKey string, filter TextureFilter) (*Textur
 	} else {
 		if texture, err := NewTexture(t.renderer, t.assetDatabase, textureKey, filter); err == nil {
 			t.pendingTextures = append(t.pendingTextures, texture)
+			t.textures[textureKey] = texture
 			return texture, nil
 		} else {
 			return nil, err


### PR DESCRIPTION
Adding in mesh cache for loading meshes by key. Updated main sample and tested code that was made in this and previous PRs. Added helper method for setting the model on the instance data. Added lots of mesh generation functions for primitive types of meshes. Added skipping of drawing instances if the target mesh is not ready to be drawn. Fixed bugs in caches where they weren't actually caching. Also removed old texture flipping as it isn't needed anymore.