### PR TITLE
#75 Create the base UI, layout, and grouping code

### DIFF
--- a/bitmap/bitmap.go
+++ b/bitmap/bitmap.go
@@ -8,6 +8,14 @@ func New(length int) Bitmap {
 	return make([]byte, LengthFor(length))
 }
 
+func NewTrue(length int) Bitmap {
+	b := make([]byte, LengthFor(length))
+	for i := 0; i < len(b); i++ {
+		b[i] = 0xFF
+	}
+	return b
+}
+
 func LengthFor(byteCount int) int {
 	return (byteCount / bitsInByte) + 1
 }

--- a/content/shaders/ui.frag
+++ b/content/shaders/ui.frag
@@ -1,0 +1,36 @@
+#version 300 es
+precision mediump float;
+
+in vec4 fragColor;
+in vec4 fragBGColor;
+in vec4 fragSize2D;
+in vec4 fragScissor;
+in vec2 fragTexCoord;
+
+layout(location = 0) out vec4 outColor;
+layout (location = 1) out float reveal;
+
+uniform sampler2D texSampler;
+
+void main(void) {
+	if (gl_FragCoord.x < fragScissor.x || gl_FragCoord.x > fragScissor.z ||
+		gl_FragCoord.y < fragScissor.y || gl_FragCoord.y > fragScissor.w)
+	{
+		discard;
+	}
+	vec4 texColor = texture(texSampler, fragTexCoord) * fragColor;
+	vec4 unWeightedColor = texColor;
+#ifdef OIT
+	float distWeight = clamp(0.03 / (1e-5 + pow(gl_FragCoord.z / 200.0, 4.0)), 1e-2, 3e3);
+	float alphaWeight = min(1.0, max(max(unWeightedColor.r, unWeightedColor.g),
+	max(unWeightedColor.b, unWeightedColor.a)) * 40.0 + 0.01);
+	alphaWeight *= alphaWeight;
+	float weight = alphaWeight * distWeight;
+	outColor = vec4(unWeightedColor.rgb * unWeightedColor.a, unWeightedColor.a) * weight;
+	reveal = unWeightedColor.a;
+#else
+	if (unWeightedColor.a < (1.0 - 0.0001))
+		discard;
+	outColor = unWeightedColor;
+#endif
+}

--- a/content/shaders/ui.vert
+++ b/content/shaders/ui.vert
@@ -1,0 +1,72 @@
+#version 300 es
+precision mediump float;
+
+layout (location = 0) in vec3 Position;
+layout (location = 1) in vec3 Normal;
+layout (location = 2) in vec4 Tangent;
+layout (location = 3) in vec2 UV0;
+layout (location = 4) in vec4 Color;
+layout (location = 5) in vec4 JointIds;
+layout (location = 6) in vec4 JointWeights;
+layout (location = 7) in vec3 MorphTarget;
+
+out vec4 fragColor;
+out vec4 fragBGColor;
+out vec4 fragSize2D;
+out vec4 fragScissor;
+out vec2 fragTexCoord;
+out vec2 fragBorderLen;
+
+uniform struct GlobalData {
+    mat4 view;
+    mat4 projection;
+    mat4 uiView;
+    mat4 uiProjection;
+    vec3 cameraPosition;
+    vec3 uiCameraPosition;
+    float time;
+} globalData;
+
+uniform sampler2D instanceSampler;
+#define INSTANCE_VEC4_COUNT 10
+struct InstanceData {
+	mat4 model;
+	vec4 uvs;
+	vec4 fgColor;
+	vec4 bgColor;
+	vec4 scissor;
+	vec4 size2D;
+	vec2 borderLen;
+};
+
+InstanceData pullInstanceData() {
+	InstanceData data;
+	int xOffset = gl_InstanceID*INSTANCE_VEC4_COUNT;
+    data.model[0] = texelFetch(instanceSampler, ivec2(xOffset,0), 0);
+    data.model[1] = texelFetch(instanceSampler, ivec2(xOffset+1,0), 0);
+    data.model[2] = texelFetch(instanceSampler, ivec2(xOffset+2,0), 0);
+    data.model[3] = texelFetch(instanceSampler, ivec2(xOffset+3,0), 0);
+	data.uvs = texelFetch(instanceSampler, ivec2(xOffset+4,0), 0);
+	data.fgColor = texelFetch(instanceSampler, ivec2(xOffset+5,0), 0);
+	data.bgColor = texelFetch(instanceSampler, ivec2(xOffset+6,0), 0);
+	data.scissor = texelFetch(instanceSampler, ivec2(xOffset+7,0), 0);
+	data.size2D = texelFetch(instanceSampler, ivec2(xOffset+8,0), 0);
+	data.borderLen = texelFetch(instanceSampler, ivec2(xOffset+9,0), 0).xy;
+	return data;
+}
+
+void main() {
+	InstanceData data = pullInstanceData();
+	vec4 vPos = data.model * vec4(Position, 1.0);
+	gl_Position = globalData.uiProjection * globalData.uiView * vPos;
+	vec2 uv = UV0;
+	uv *= data.uvs.zw;
+	uv.y += (1.0 - data.uvs.w) - data.uvs.y;
+	uv.x += data.uvs.x;
+	fragColor = Color * data.fgColor;
+	fragBGColor = data.bgColor;
+	fragSize2D = data.size2D;
+	fragScissor = data.scissor;
+	fragTexCoord = uv;
+	fragBorderLen = data.borderLen;
+}

--- a/content/shaders/ui_nine.frag
+++ b/content/shaders/ui_nine.frag
@@ -1,0 +1,52 @@
+#version 300 es
+precision mediump float;
+
+in vec4 fragColor;
+in vec4 fragBGColor;
+in vec4 fragSize2D;
+in vec4 fragScissor;
+in vec2 fragTexCoord;
+in vec2 fragBorderLen;
+
+layout(location = 0) out vec4 outColor;
+layout (location = 1) out float reveal;
+
+uniform sampler2D texSampler;
+
+float processAxis(float coord, float border, float ratio) {
+	float len = border * ratio;
+	float lScale = 1.0 - len * 2.0;
+	float bScale = 1.0 - (border * 2.0);
+	float res = (coord - len) * (bScale / lScale) + border;
+	if (coord < len)
+		res = coord / ratio;
+	else if (coord > 1.0 - len)
+		res = 1.0 - ((1.0 - coord) / ratio);
+	return res;
+}
+
+void main(void) {
+	if (gl_FragCoord.x < fragScissor.x || gl_FragCoord.x > fragScissor.z ||
+		gl_FragCoord.y < fragScissor.y || gl_FragCoord.y > fragScissor.w)
+	{
+		discard;
+	}
+	vec2 newUV = vec2(
+		processAxis(fragTexCoord.x, fragBorderLen.x / fragSize2D.z, fragSize2D.z / fragSize2D.x),
+		processAxis(fragTexCoord.y, fragBorderLen.y / fragSize2D.w, fragSize2D.w / fragSize2D.y)
+	);
+	vec4 unWeightedColor = texture(texSampler, newUV) * fragColor;
+#ifdef OIT
+	float distWeight = clamp(0.03 / (1e-5 + pow(gl_FragCoord.z / 200.0, 4.0)), 1e-2, 3e3);
+	float alphaWeight = min(1.0, max(max(unWeightedColor.r, unWeightedColor.g),
+	max(unWeightedColor.b, unWeightedColor.a)) * 40.0 + 0.01);
+	alphaWeight *= alphaWeight;
+	float weight = alphaWeight * distWeight;
+	outColor = vec4(unWeightedColor.rgb * unWeightedColor.a, unWeightedColor.a) * weight;
+	reveal = unWeightedColor.a;
+#else
+	if (unWeightedColor.a < (1.0 - 0.0001))
+		discard;
+	outColor = unWeightedColor;
+#endif
+}

--- a/ui/entity_data.go
+++ b/ui/entity_data.go
@@ -1,0 +1,27 @@
+package ui
+
+import "kaiju/engine"
+
+const (
+	EntityDataName = "ui"
+)
+
+func FirstOnEntity(entity *engine.Entity) UI {
+	found := entity.NamedData(EntityDataName)
+	if len(found) == 0 {
+		return nil
+	}
+	return found[0].(UI)
+}
+
+func AllOnEntity(entity *engine.Entity) []UI {
+	found := entity.NamedData(EntityDataName)
+	if len(found) == 0 {
+		return []UI{}
+	}
+	res := make([]UI, len(found))
+	for i := range found {
+		res[i] = found[i].(UI)
+	}
+	return res
+}

--- a/ui/event.go
+++ b/ui/event.go
@@ -1,0 +1,56 @@
+package ui
+
+import "slices"
+
+type EventType = int
+
+const (
+	EventTypeInvalid = iota
+	EventTypeEnter
+	EventTypeExit
+	EventTypeClick
+	EventTypeDown
+	EventTypeUp
+	EventTypeMiss
+	EventTypeScroll
+	EventTypeRebuild
+	EventTypeDestroy
+	EventTypeChange
+	EventTypeEnd
+)
+
+type EventId = int
+
+type uiEventEntry struct {
+	id   EventId
+	call func()
+}
+
+type uiEvent struct {
+	nextId   EventId
+	uiEvents []uiEventEntry
+}
+
+func (evt *uiEvent) isEmpty() bool { return len(evt.uiEvents) == 0 }
+
+func (evt *uiEvent) add(call func()) EventId {
+	id := evt.nextId
+	evt.nextId++
+	evt.uiEvents = append(evt.uiEvents, uiEventEntry{id: id, call: call})
+	return id
+}
+
+func (evt *uiEvent) remove(id EventId) {
+	for i := 0; i < len(evt.uiEvents); i++ {
+		if evt.uiEvents[i].id == id {
+			evt.uiEvents = slices.Delete(evt.uiEvents, i, i+1)
+			return
+		}
+	}
+}
+
+func (evt *uiEvent) execute() {
+	for _, entry := range evt.uiEvents {
+		entry.call()
+	}
+}

--- a/ui/group.go
+++ b/ui/group.go
@@ -1,0 +1,96 @@
+package ui
+
+import (
+	"kaiju/bitmap"
+	"kaiju/engine"
+	"sort"
+)
+
+type groupRequest struct {
+	target    UI
+	eventType EventType
+}
+
+type Group struct {
+	requests []groupRequest
+	focus    UI
+	updateId int
+}
+
+func NewGroup() *Group {
+	return &Group{
+		requests: make([]groupRequest, 0),
+		focus:    nil,
+	}
+}
+
+func (group *Group) requestEvent(ui UI, eType EventType) {
+	if eType < EventTypeInvalid || eType >= EventTypeEnd {
+		panic("Invalid UI event type")
+	}
+	group.requests = append(group.requests, groupRequest{
+		target:    ui,
+		eventType: eType,
+	})
+}
+
+func (group *Group) setFocus(ui UI) {
+	if group.focus != nil {
+		group.focus.ExecuteEvent(EventTypeMiss)
+	}
+	group.focus = ui
+	group.focus.ExecuteEvent(EventTypeClick)
+}
+
+func (group *Group) attach(host *engine.Host) {
+	group.updateId = host.LateUpdater.AddUpdate(func(dt float64) {
+		group.lateUpdate()
+	})
+}
+
+func (group *Group) detach(host *engine.Host) {
+	host.LateUpdater.RemoveUpdate(group.updateId)
+	group.updateId = -1
+}
+
+func sortRequests(a *groupRequest, b *groupRequest) int {
+	return (int)((b.target.Entity().Transform.WorldPosition().Z() -
+		a.target.Entity().Transform.WorldPosition().Z()) * 1000.0)
+}
+
+func (group *Group) lateUpdate() {
+	if len(group.requests) > 0 {
+		sort.Slice(group.requests, func(i, j int) bool {
+			return sortRequests(&group.requests[i], &group.requests[j]) < 0
+		})
+		available := bitmap.NewTrue(EventTypeEnd)
+		for i := 0; i < len(group.requests); i++ {
+			req := &group.requests[i]
+			if available.Check(req.eventType) {
+				shouldContinue := true
+				switch req.eventType {
+				case EventTypeEnter:
+					fallthrough
+				case EventTypeExit:
+					fallthrough
+				case EventTypeMiss:
+					req.target.ExecuteEvent(req.eventType)
+				case EventTypeClick:
+					fallthrough
+				case EventTypeDown:
+					fallthrough
+				case EventTypeUp:
+					fallthrough
+				case EventTypeScroll:
+					if req.target.ExecuteEvent(req.eventType) {
+						shouldContinue = false
+					}
+				default:
+					panic("Invalid UI event type")
+				}
+				available.Assign(req.eventType, shouldContinue)
+			}
+		}
+		group.requests = group.requests[:0]
+	}
+}

--- a/ui/layout.go
+++ b/ui/layout.go
@@ -1,0 +1,597 @@
+package ui
+
+import (
+	"kaiju/engine"
+	"kaiju/matrix"
+)
+
+type Anchor int32
+type Positioning = int
+
+const (
+	AnchorTopLeft = Anchor(1 + iota)
+	AnchorTopCenter
+	AnchorTopRight
+	AnchorLeft
+	AnchorCenter
+	AnchorRight
+	AnchorBottomLeft
+	AnchorBottomCenter
+	AnchorBottomRight
+	AnchorStretchLeft
+	AnchorStretchTop
+	AnchorStretchRight
+	AnchorStretchBottom
+	AnchorStretchCenter
+)
+
+const (
+	PositioningStatic = Positioning(iota)
+	PositioningAbsolute
+	PositioningFixed
+	PositioningRelative
+	PositioningSticky
+)
+
+func (a Anchor) ConvertToTop() Anchor {
+	switch a {
+	case AnchorBottomLeft:
+		return AnchorTopLeft
+	case AnchorBottomCenter:
+		return AnchorTopCenter
+	case AnchorBottomRight:
+		return AnchorTopRight
+	case AnchorStretchTop:
+		return AnchorStretchBottom
+	default:
+		return a
+	}
+}
+
+func (a Anchor) ConvertToBottom() Anchor {
+	switch a {
+	case AnchorTopLeft:
+		return AnchorBottomLeft
+	case AnchorTopCenter:
+		return AnchorBottomCenter
+	case AnchorTopRight:
+		return AnchorBottomRight
+	case AnchorStretchBottom:
+		return AnchorStretchTop
+	default:
+		return a
+	}
+}
+
+func (a Anchor) ConvertToLeft() Anchor {
+	switch a {
+	case AnchorTopRight:
+		return AnchorTopLeft
+	case AnchorCenter:
+		return AnchorLeft
+	case AnchorBottomRight:
+		return AnchorBottomLeft
+	case AnchorStretchRight:
+		return AnchorStretchLeft
+	default:
+		return a
+	}
+}
+
+func (a Anchor) ConvertToRight() Anchor {
+	switch a {
+	case AnchorTopLeft:
+		return AnchorTopRight
+	case AnchorLeft:
+		return AnchorRight
+	case AnchorBottomLeft:
+		return AnchorBottomRight
+	case AnchorStretchLeft:
+		return AnchorStretchRight
+	default:
+		return a
+	}
+}
+
+func (a Anchor) ConvertToCenter() Anchor {
+	switch a {
+	case AnchorTopLeft:
+		fallthrough
+	case AnchorTopRight:
+		return AnchorTopCenter
+	case AnchorLeft:
+		fallthrough
+	case AnchorRight:
+		return AnchorCenter
+	case AnchorBottomLeft:
+		fallthrough
+	case AnchorBottomRight:
+		return AnchorBottomCenter
+	default:
+		return a
+	}
+}
+
+func (a Anchor) IsLeft() bool {
+	return a == AnchorLeft || a == AnchorTopLeft || a == AnchorBottomLeft || a == AnchorStretchLeft
+}
+
+func (a Anchor) IsRight() bool {
+	return a == AnchorRight || a == AnchorTopRight || a == AnchorBottomRight || a == AnchorStretchRight
+}
+
+func (a Anchor) IsTop() bool {
+	return a == AnchorTopLeft || a == AnchorTopCenter || a == AnchorTopRight || a == AnchorStretchTop
+}
+
+func (a Anchor) IsBottom() bool {
+	return a == AnchorBottomLeft || a == AnchorBottomCenter || a == AnchorBottomRight || a == AnchorStretchBottom
+}
+
+type Layout struct {
+	offset           matrix.Vec2
+	innerOffset      matrix.Vec4
+	localInnerOffset matrix.Vec4
+	left             float32
+	top              float32
+	right            float32
+	bottom           float32
+	z                float32
+	anchor           matrix.Vec2
+	pixelSize        matrix.Vec2
+	ui               UI
+	screenAnchor     Anchor
+	layoutFunction   func(layout *Layout)
+	anchorFunction   func(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4
+	bounds           matrix.Vec4
+	lastParent       *engine.Entity
+	mySize           matrix.Vec3
+	worldScalar      matrix.Vec2
+	border           matrix.Vec4
+	padding          matrix.Vec4
+	margin           matrix.Vec4
+	inset            matrix.Vec4
+	positioning      Positioning
+	functions        []func(layout *Layout)
+	runningFuncs     bool
+}
+
+func NewLayout(ui UI) Layout {
+	return Layout{
+		ui:        ui,
+		anchor:    matrix.Vec2{0.0, 0.0},
+		pixelSize: matrix.Vec2{1.0, 1.0},
+	}
+}
+
+func (layout *Layout) AddFunction(fn func(layout *Layout)) {
+	layout.functions = append(layout.functions, fn)
+}
+
+func anchorTopLeft(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	return matrix.Vec4{size.X() * 0.5, h - size.Y()*0.5, 0.0, 0.0}
+}
+
+func anchorTopCenter(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	return matrix.Vec4{w * 0.5, h - size.Y()*0.5, 0.0, 0.0}
+}
+
+func anchorTopRight(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	return matrix.Vec4{w - size.X()*0.5, h - size.Y()*0.5, 0.0, 0.0}
+}
+
+func anchorLeft(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	return matrix.Vec4{size.X() * 0.5, h * 0.5, 0.0, 0.0}
+}
+
+func anchorCenter(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	return matrix.Vec4{w * 0.5, h * 0.5, 0.0, 0.0}
+}
+
+func anchorRight(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	return matrix.Vec4{w - size.X()*0.5, h * 0.5, 0.0, 0.0}
+}
+
+func anchorBottomLeft(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	return matrix.Vec4{size.X() * 0.5, size.Y() * 0.5, 0.0, 0.0}
+}
+
+func anchorBottomCenter(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	return matrix.Vec4{w * 0.5, size.Y() * 0.5, 0.0, 0.0}
+}
+
+func anchorBottomRight(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	return matrix.Vec4{w - size.X()*0.5, size.Y() * 0.5, 0.0, 0.0}
+}
+
+func layoutFloating(self *Layout) {
+	t := &self.ui.Entity().Transform
+	w := self.bounds.Z() - self.bounds.X()
+	h := self.bounds.W() - self.bounds.Y()
+	pos := self.anchorFunction(self, w, h, self.mySize)
+	p := matrix.Vec3{pos.X() + self.offset.X() + self.bounds.X(),
+		pos.Y() + self.offset.Y() + self.bounds.Y(), t.Position().Z()}
+	t.SetPosition(p)
+}
+
+func anchorStretchLeft(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	xSize := self.right
+	ySize := h - (self.top + self.bottom)
+	xMid := xSize*0.5 + self.left
+	yMid := self.bottom + ySize*0.5
+	return matrix.Vec4{xMid, yMid, xSize, ySize}
+}
+
+func anchorStretchTop(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	xSize := w - (self.left + self.right)
+	ySize := self.bottom
+	xMid := self.left + xSize*0.5
+	yMid := h - (ySize * 0.5) - self.top
+	return matrix.Vec4{xMid, yMid, xSize, ySize}
+}
+
+func anchorStretchRight(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	xSize := self.left
+	ySize := h - (self.top + self.bottom)
+	xMid := w - (xSize * 0.5) - self.right
+	yMid := self.bottom + ySize*0.5
+	return matrix.Vec4{xMid, yMid, xSize, ySize}
+}
+
+func anchorStretchBottom(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	xSize := w - (self.left + self.right)
+	ySize := self.top
+	xMid := self.left + xSize*0.5
+	yMid := ySize*0.5 + self.bottom
+	return matrix.Vec4{xMid, yMid, xSize, ySize}
+}
+
+func anchorStretchCenter(self *Layout, w, h float32, size matrix.Vec3) matrix.Vec4 {
+	xSize := w - (self.left + self.right)
+	ySize := h - (self.top + self.bottom)
+	xMid := self.left + xSize*0.5
+	yMid := self.bottom + ySize*0.5
+	return matrix.Vec4{xMid, yMid, xSize, ySize}
+}
+
+func layoutStretch(self *Layout) {
+	t := &self.ui.Entity().Transform
+	width := self.bounds.Z() - self.bounds.X()
+	height := self.bounds.W() - self.bounds.Y()
+	res := self.anchorFunction(self, width, height, matrix.Vec3Zero())
+	x := res.X() + self.offset.X()
+	y := res.Y() + self.offset.Y()
+	xSize := res.Z()
+	ySize := res.W()
+	scale := matrix.Vec3{xSize * self.worldScalar.X(), ySize * self.worldScalar.Y(), self.mySize.Z()}
+	scale[matrix.Vx] -= (self.inset.X() + self.inset.Z()) / width
+	scale[matrix.Vy] -= (self.inset.Y() + self.inset.W()) / height
+	self.ui.Entity().ScaleWithoutChildren(scale)
+	pos := matrix.Vec3{
+		x + self.bounds.X() + (self.inset.X()-self.inset.Z())*0.5,
+		y + self.bounds.Y() + (self.inset.W()-self.inset.Y())*0.5,
+		t.Position().Z(),
+	}
+	t.SetPosition(pos)
+}
+
+func (layout *Layout) prepare() {
+	if layout.runningFuncs {
+		return
+	}
+	layout.runningFuncs = true
+	for _, fn := range layout.functions {
+		fn(layout)
+	}
+	layout.runningFuncs = false
+	layout.setBounds()
+}
+
+func (layout *Layout) setBounds() {
+	t := &layout.ui.Entity().Transform
+	layout.mySize = t.WorldScale()
+	if layout.ui.Entity().IsRoot() {
+		layout.bounds = matrix.Vec4{0, 0,
+			matrix.Float(layout.ui.selfHost().Window.Width()),
+			matrix.Float(layout.ui.selfHost().Window.Height()),
+		}
+		layout.worldScalar = matrix.Vec2One()
+		et := &layout.ui.Entity().Transform
+		pos := matrix.Vec3{et.Position().X(), et.Position().Y(), layout.z}
+		et.SetPosition(pos)
+	} else {
+		parent := layout.ui.Entity().Parent
+		s := parent.Transform.WorldScale()
+		p := parent
+		layout.inset = matrix.Vec4Zero()
+		for ; p != nil; p = p.Parent {
+			pUI := FirstOnEntity(p)
+			if pUI != nil {
+				pLayout := pUI.Layout()
+				layout.inset.AddAssign(pLayout.margin)
+				layout.inset.AddAssign(pLayout.border)
+				layout.inset.AddAssign(pLayout.padding)
+			}
+		}
+		layout.worldScalar = matrix.Vec2{1.0 / s.X(), 1.0 / s.Y()}
+		layout.bounds = matrix.Vec4{-s.X() * 0.5, -s.Y() * 0.5, s.X() * 0.5, s.Y() * 0.5}
+		// Set this child in front of parent
+		et := &layout.ui.Entity().Transform
+		pos := matrix.Vec3{et.Position().X(), et.Position().Y(), 0.2 + layout.z}
+		et.SetPosition(pos)
+	}
+	if layout.parentChanged() {
+		layout.lastParent = layout.ui.Entity().Parent
+		layout.Scale(layout.pixelSize.Width(), layout.pixelSize.Height())
+		for _, c := range layout.ui.Entity().Children {
+			if ui := FirstOnEntity(c); ui != nil {
+				cl := ui.Layout()
+				cl.Scale(cl.pixelSize.Width(), cl.pixelSize.Height())
+			}
+		}
+	}
+}
+
+func (layout *Layout) initialize() {
+	layout.anchor = matrix.Vec2Zero()
+	layout.AnchorTo(AnchorTopLeft)
+	layout.prepare()
+	layout.update()
+}
+
+func (layout *Layout) SetOffset(x, y float32) {
+	if matrix.Vec2Approx(layout.offset, matrix.Vec2{x, y}) {
+		return
+	}
+	layout.offset.SetX(x)
+	layout.offset.SetY(y)
+	layout.ui.SetDirty(DirtyTypeLayout)
+}
+
+func (layout *Layout) SetInnerOffset(left, top, right, bottom float32) {
+	if matrix.Vec4Approx(layout.innerOffset, matrix.Vec4{left, top, right, bottom}) {
+		return
+	}
+	layout.innerOffset = matrix.Vec4{left, top, right, bottom}
+	layout.ui.SetDirty(DirtyTypeLayout)
+}
+
+func (layout *Layout) SetInnerOffsetLeft(offset float32) {
+	if matrix.Approx(layout.innerOffset.X(), offset) {
+		return
+	}
+	layout.innerOffset.SetX(offset)
+	layout.ui.SetDirty(DirtyTypeLayout)
+}
+
+func (layout *Layout) SetInnerOffsetTop(offset float32) {
+	if matrix.Approx(layout.innerOffset[matrix.Vy], offset) {
+		return
+	}
+	layout.innerOffset.SetY(offset)
+	layout.ui.SetDirty(DirtyTypeLayout)
+}
+
+func (layout *Layout) SetInnerOffsetRight(offset float32) {
+	if matrix.Approx(layout.innerOffset.Right(), offset) {
+		return
+	}
+	layout.innerOffset.SetRight(offset)
+	layout.ui.SetDirty(DirtyTypeLayout)
+}
+
+func (layout *Layout) SetInnerOffsetBottom(offset float32) {
+	if matrix.Approx(layout.innerOffset.Bottom(), offset) {
+		return
+	}
+	layout.innerOffset.SetBottom(offset)
+	layout.ui.SetDirty(DirtyTypeLayout)
+}
+
+func (layout *Layout) LocalInnerOffset() matrix.Vec4 {
+	return layout.localInnerOffset
+}
+
+func (layout *Layout) SetLocalInnerOffset(left, top, right, bottom float32) {
+	if matrix.Vec4Approx(layout.localInnerOffset, matrix.Vec4{left, top, right, bottom}) {
+		return
+	}
+	layout.localInnerOffset = matrix.Vec4{left, top, right, bottom}
+	layout.ui.SetDirty(DirtyTypeLayout)
+}
+
+func (layout Layout) InnerOffset() matrix.Vec4 {
+	return matrix.Vec4{
+		layout.localInnerOffset.Left() + layout.innerOffset.Left(),
+		layout.localInnerOffset.Top() + layout.innerOffset.Top(),
+		layout.localInnerOffset.Right() + layout.innerOffset.Right(),
+		layout.localInnerOffset.Bottom() + layout.innerOffset.Bottom(),
+	}
+}
+
+func (layout *Layout) SetStretch(left, top, right, bottom float32) {
+	layout.left = left
+	layout.top = top
+	layout.right = right
+	layout.bottom = bottom
+	layout.ui.SetDirty(DirtyTypeResize)
+}
+
+func (layout *Layout) SetStretchRatio(leftRatio, topRatio, rightRatio, bottomRatio float32) {
+	w := layout.bounds.Z() - layout.bounds.X()
+	h := layout.bounds.W() - layout.bounds.Y()
+	layout.left = w * leftRatio
+	layout.top = h * topRatio
+	layout.right = w * rightRatio
+	layout.bottom = h * bottomRatio
+	layout.ui.SetDirty(DirtyTypeResize)
+}
+
+func (layout *Layout) Scale(width, height float32) {
+	width += layout.padding.X() + layout.padding.Z()
+	height += layout.padding.Y() + layout.padding.W()
+	if matrix.Vec2Approx(layout.pixelSize, matrix.Vec2{width, height}) {
+		return
+	}
+	layout.pixelSize.SetX(width)
+	layout.pixelSize.SetY(height)
+	size := matrix.Vec3{width, height, 1.0}
+	if layout.ui.Entity().Parent != nil {
+		size.DivideAssign(layout.ui.Entity().Parent.Transform.WorldScale())
+	}
+	layout.ui.Entity().ScaleWithoutChildren(size)
+	layout.prepare()
+	layout.ui.SetDirty(DirtyTypeResize)
+}
+
+func (layout *Layout) ScaleWidth(width float32) {
+	width += layout.padding.X() + layout.padding.Z()
+	if matrix.Approx(layout.pixelSize[matrix.Vx], width) {
+		return
+	}
+	layout.pixelSize.SetX(width)
+	size := matrix.Vec3{width, layout.pixelSize.Height(), 1.0}
+	if layout.ui.Entity().Parent != nil {
+		size.DivideAssign(layout.ui.Entity().Parent.Transform.WorldScale())
+	}
+	layout.ui.Entity().ScaleWithoutChildren(size)
+	layout.prepare()
+	layout.ui.SetDirty(DirtyTypeResize)
+}
+
+func (layout *Layout) ScaleHeight(height float32) {
+	height += layout.padding.Y() + layout.padding.W()
+	if matrix.Approx(layout.pixelSize.Y(), height) {
+		return
+	}
+	layout.pixelSize.SetY(height)
+	size := matrix.Vec3{layout.pixelSize.Width(), height, 1.0}
+	if layout.ui.Entity().Parent != nil {
+		size.DivideAssign(layout.ui.Entity().Parent.Transform.WorldScale())
+	}
+	layout.ui.Entity().ScaleWithoutChildren(size)
+	layout.prepare()
+	layout.ui.SetDirty(DirtyTypeResize)
+}
+
+func (layout Layout) Positioning() Positioning { return layout.positioning }
+func (layout Layout) Anchor() Anchor           { return layout.screenAnchor }
+func (layout Layout) Border() matrix.Vec4      { return layout.border }
+func (layout Layout) Padding() matrix.Vec4     { return layout.padding }
+func (layout Layout) Margin() matrix.Vec4      { return layout.margin }
+func (layout Layout) Offset() matrix.Vec2      { return matrix.Vec2{layout.offset.X(), layout.offset.Y()} }
+
+func (layout Layout) PixelSize() matrix.Vec2 {
+	return matrix.NewVec2(layout.pixelSize.Width(), layout.pixelSize.Height())
+}
+
+func (layout Layout) Stretch() matrix.Vec4 {
+	return matrix.Vec4{layout.left, layout.top, layout.right, layout.bottom}
+}
+
+func (layout *Layout) SetBorder(left, top, right, bottom float32) {
+	layout.border = matrix.Vec4{left, top, right, bottom}
+	layout.ui.SetDirty(DirtyTypeResize)
+}
+
+func (layout *Layout) SetPadding(left, top, right, bottom float32) {
+	lastPad := layout.padding
+	layout.padding = matrix.Vec4{left, top, right, bottom}
+	layout.Scale(layout.pixelSize.Width()-lastPad.X()-lastPad.Z(),
+		layout.pixelSize.Height()-lastPad.Y()-lastPad.W())
+	layout.ui.SetDirty(DirtyTypeResize)
+}
+
+func (layout *Layout) SetMargin(left, top, right, bottom float32) {
+	layout.margin = matrix.Vec4{left, top, right, bottom}
+	layout.ui.SetDirty(DirtyTypeResize)
+}
+
+func (layout *Layout) AnchorTo(anchorPosition Anchor) {
+	if layout.screenAnchor == anchorPosition {
+		return
+	}
+	var lfn func(*Layout) = nil
+	var afn func(*Layout, float32, float32, matrix.Vec3) matrix.Vec4 = nil
+	if anchorPosition == AnchorTopLeft {
+		afn = anchorTopLeft
+		lfn = layoutFloating
+	} else if anchorPosition == AnchorTopCenter {
+		afn = anchorTopCenter
+		lfn = layoutFloating
+	} else if anchorPosition == AnchorTopRight {
+		afn = anchorTopRight
+		lfn = layoutFloating
+	} else if anchorPosition == AnchorLeft {
+		afn = anchorLeft
+		lfn = layoutFloating
+	} else if anchorPosition == AnchorCenter {
+		afn = anchorCenter
+		lfn = layoutFloating
+	} else if anchorPosition == AnchorRight {
+		afn = anchorRight
+		lfn = layoutFloating
+	} else if anchorPosition == AnchorBottomLeft {
+		afn = anchorBottomLeft
+		lfn = layoutFloating
+	} else if anchorPosition == AnchorBottomCenter {
+		afn = anchorBottomCenter
+		lfn = layoutFloating
+	} else if anchorPosition == AnchorBottomRight {
+		afn = anchorBottomRight
+		lfn = layoutFloating
+	} else if anchorPosition == AnchorStretchLeft {
+		afn = anchorStretchLeft
+		lfn = layoutStretch
+	} else if anchorPosition == AnchorStretchTop {
+		afn = anchorStretchTop
+		lfn = layoutStretch
+	} else if anchorPosition == AnchorStretchRight {
+		afn = anchorStretchRight
+		lfn = layoutStretch
+	} else if anchorPosition == AnchorStretchBottom {
+		afn = anchorStretchBottom
+		lfn = layoutStretch
+	} else if anchorPosition == AnchorStretchCenter {
+		afn = anchorStretchCenter
+		lfn = layoutStretch
+	} else {
+		panic("Invalid anchor position")
+	}
+	layout.screenAnchor = anchorPosition
+	layout.anchorFunction = afn
+	layout.layoutFunction = lfn
+	layout.ui.SetDirty(DirtyTypeGenerated)
+}
+
+func (layout *Layout) parentChanged() bool {
+	return layout.lastParent != layout.ui.Entity().Parent
+}
+
+func (layout *Layout) update() {
+	if layout.layoutFunction != nil {
+		layout.prepare()
+		layout.layoutFunction(layout)
+		if layout.ui.hasScissor() {
+			layout.ui.generateScissor()
+		}
+	}
+}
+
+func (layout Layout) Z() float32 {
+	return layout.z
+}
+
+func (layout *Layout) SetZ(z float32) {
+	layout.z = z
+}
+
+func (layout *Layout) SetPositioning(pos Positioning) {
+	layout.positioning = pos
+	layout.ui.SetDirty(DirtyTypeLayout)
+}
+
+func (layout *Layout) ContentSize() (float32, float32) {
+	return layout.pixelSize.X() - layout.padding.X() - layout.padding.Z(),
+		layout.pixelSize.Y() - layout.padding.Y() - layout.padding.W()
+}

--- a/ui/shader_data.go
+++ b/ui/shader_data.go
@@ -1,0 +1,31 @@
+package ui
+
+import (
+	"kaiju/matrix"
+	"kaiju/rendering"
+	"unsafe"
+)
+
+type ShaderData struct {
+	rendering.ShaderDataBase
+	UVs       matrix.Vec4
+	FGColor   matrix.Vec4
+	BGColor   matrix.Vec4
+	Scissor   matrix.Vec4
+	Size2D    matrix.Vec4
+	BorderLen matrix.Vec2
+}
+
+func (s ShaderData) Size() int {
+	const size = int(unsafe.Sizeof(ShaderData{}) - rendering.ShaderBaseDataStart)
+	return size
+}
+
+func (s *ShaderData) setSize2d(ui UI, texWidth, texHeight float32) {
+	// TODO:  This is skipped for text
+	ws := ui.Entity().Transform.WorldScale()
+	s.Size2D[0] = ws.X()
+	s.Size2D[1] = ws.Y()
+	s.Size2D[2] = texWidth
+	s.Size2D[3] = texHeight
+}

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -1,0 +1,256 @@
+package ui
+
+import (
+	"kaiju/engine"
+	"kaiju/hid"
+	"kaiju/matrix"
+	"kaiju/windowing"
+)
+
+type DirtyType = int
+
+const (
+	DirtyTypeNone = iota
+	DirtyTypeLayout
+	DirtyTypeResize
+	DirtyTypeGenerated
+	DirtyTypeReGenerated
+	DirtyTypeColorChange
+	DirtyTypeScissor
+	DirtyTypeParent
+	DirtyTypeParentLayout
+	DirtyTypeParentResize
+	DirtyTypeParentGenerated
+	DirtyTypeParentReGenerated
+	DirtyTypeParentColorChange
+	DirtyTypeParentScissor
+)
+
+type UI interface {
+	Entity() *engine.Entity
+	ExecuteEvent(evtType EventType) bool
+	AddEvent(evtType EventType, evt func()) EventId
+	RemoveEvent(evtType EventType, evtId EventId)
+	Update(deltaTime float64)
+	SetDirty(dirtyType DirtyType)
+	Layout() *Layout
+	ShaderData() *ShaderData
+	generateScissor()
+	hasScissor() bool
+	selfHost() *engine.Host
+	dirty() DirtyType
+	setScissor(scissor matrix.Vec4)
+	clean()
+}
+
+type uiBase struct {
+	host                *engine.Host
+	entity              *engine.Entity
+	events              [EventTypeEnd]uiEvent
+	group               *Group
+	scissor             matrix.Vec4
+	dragStartPos        matrix.Vec3
+	downPos             matrix.Vec2
+	layout              Layout
+	dirtyType           DirtyType
+	shaderData          ShaderData
+	textureSize         matrix.Vec2
+	hovering            bool
+	cantMiss            bool
+	isDown              bool
+	drag                bool
+	lastActive          bool
+	disconnectedScissor bool
+}
+
+func (ui *uiBase) init(host *engine.Host, textureSize matrix.Vec2) {
+	ui.host = host
+	ui.entity = host.NewEntity()
+	ui.entity.AddNamedData(EntityDataName, ui)
+	ui.textureSize = textureSize
+}
+
+func (ui *uiBase) Entity() *engine.Entity  { return ui.entity }
+func (ui *uiBase) Layout() *Layout         { return &ui.layout }
+func (ui *uiBase) hasScissor() bool        { return ui.scissor.X() > -matrix.FloatMax }
+func (ui *uiBase) selfHost() *engine.Host  { return ui.host }
+func (ui *uiBase) dirty() DirtyType        { return ui.dirtyType }
+func (ui *uiBase) ShaderData() *ShaderData { return &ui.shaderData }
+
+func (ui *uiBase) ExecuteEvent(evtType EventType) bool {
+	ui.events[evtType].execute()
+	return !ui.events[evtType].isEmpty()
+}
+
+func (ui *uiBase) AddEvent(evtType EventType, evt func()) EventId {
+	return ui.events[evtType].add(evt)
+}
+
+func (ui *uiBase) RemoveEvent(evtType EventType, evtId EventId) {
+	ui.events[evtType].remove(evtId)
+}
+
+func (ui *uiBase) SetDirty(dirtyType DirtyType) {
+	if ui.dirtyType == DirtyTypeNone || ui.dirtyType >= DirtyTypeParent || dirtyType == DirtyTypeGenerated || dirtyType == DirtyTypeReGenerated {
+		ui.dirtyType = dirtyType
+		for i := 0; i < len(ui.entity.Children); i++ {
+			kid := ui.entity.Children[i]
+			all := AllOnEntity(kid)
+			for _, cui := range all {
+				if cui.dirty() == DirtyTypeNone || cui.dirty() > DirtyTypeParent {
+					// TODO:  Let it know it was from the parent and what type
+					if ui.dirtyType < DirtyTypeParent {
+						cui.SetDirty(DirtyTypeParent + ui.dirtyType)
+					} else {
+						cui.SetDirty(ui.dirtyType)
+					}
+				}
+			}
+		}
+	}
+}
+
+func (ui *uiBase) clean() {
+	ui.layout.update()
+	if !ui.events[EventTypeRebuild].isEmpty() {
+		ui.ExecuteEvent(EventTypeRebuild)
+	}
+	// TODO:  Layout should do this, so remove if so
+	ui.entity.Transform.SetDirty()
+	if ui.dirtyType == DirtyTypeReGenerated {
+		ui.dirtyType = DirtyTypeGenerated
+	} else {
+		ui.dirtyType = DirtyTypeNone
+	}
+	ui.shaderData.setSize2d(ui, ui.textureSize.X(), ui.textureSize.Y())
+}
+
+func cleanParent(host *engine.Host, entity *engine.Entity) {
+	if entity.Parent != nil {
+		cleanParent(host, entity.Parent)
+	}
+	all := AllOnEntity(entity)
+	for i := 0; i < len(all); i++ {
+		if all[i].dirty() != DirtyTypeNone {
+			all[i].clean()
+		}
+	}
+}
+
+func (ui *uiBase) generateScissor() {
+	if !ui.hasScissor() {
+		pos := ui.entity.Transform.WorldPosition()
+		size := ui.entity.Transform.WorldScale()
+		bounds := matrix.Vec4{
+			pos.X() - size.X()*0.5,
+			pos.Y() - size.Y()*0.5,
+			pos.X() + size.X()*0.5,
+			pos.Y() + size.Y()*0.5,
+		}
+		ui.setScissor(bounds)
+	}
+}
+
+func (ui *uiBase) setScissor(scissor matrix.Vec4) {
+	if ui.disconnectedScissor {
+		return
+	}
+	ui.scissor = scissor
+	for i := 0; i < len(ui.entity.Children); i++ {
+		cUI := FirstOnEntity(ui.entity.Children[i])
+		if cUI != nil {
+			cUI.setScissor(scissor)
+		}
+	}
+	ui.shaderData.Scissor = scissor
+	if ui.dirtyType == DirtyTypeNone {
+		ui.SetDirty(DirtyTypeScissor)
+	}
+}
+
+func (ui *uiBase) requestEvent(evtType EventType) {
+	if ui.group != nil {
+		ui.group.requestEvent(ui, evtType)
+	} else {
+		ui.ExecuteEvent(evtType)
+	}
+}
+
+func (ui *uiBase) Update(deltaTime float64) {
+	cursor := &ui.host.Window.Cursor
+	if cursor.Moved() {
+		pos := ui.cursorPos(cursor)
+		ui.containedCheck(cursor, ui.entity)
+		if ui.isDown && !ui.drag {
+			w := ui.selfHost().Window.Width()
+			h := ui.selfHost().Window.Height()
+			wmm, hmm, _ := ui.host.Window.GetDPI()
+			threshold := max(windowing.DPI2PX(w, wmm, 4), windowing.DPI2PX(h, hmm, 4))
+			if ui.downPos.Distance(pos) > float32(threshold) {
+				ui.dragStartPos = ui.entity.Transform.WorldPosition()
+				ui.drag = true
+			}
+		}
+	}
+	if cursor.Pressed() {
+		ui.containedCheck(cursor, ui.entity)
+		if ui.hovering && !ui.isDown {
+			ui.isDown = true
+			ui.downPos = ui.cursorPos(cursor)
+			ui.requestEvent(EventTypeDown)
+			ui.cantMiss = true
+		}
+	}
+	if cursor.Released() {
+		if ui.hovering {
+			ui.requestEvent(EventTypeUp)
+		}
+		if ui.lastActive {
+			if ui.isDown {
+				ui.isDown = false
+				dragged := false
+				if ui.drag {
+					p := ui.entity.Transform.WorldPosition()
+					dragged = ui.dragStartPos.Distance(p) > 5
+				}
+				ui.drag = false
+				if ui.hovering && !dragged {
+					ui.requestEvent(EventTypeClick)
+				}
+			} else if !ui.hovering && !ui.cantMiss {
+				ui.requestEvent(EventTypeMiss)
+			}
+			ui.cantMiss = false
+		}
+	}
+	if ui.host.Window.Mouse.Scrolled() && ui.hovering {
+		ui.requestEvent(EventTypeScroll)
+	}
+	if ui.dirtyType != DirtyTypeNone {
+		if ui.entity.Parent != nil {
+			cleanParent(ui.selfHost(), ui.entity.Parent)
+		}
+		ui.clean()
+	}
+	ui.lastActive = ui.entity.IsActive()
+}
+
+func (ui *uiBase) cursorPos(cursor *hid.Cursor) matrix.Vec2 {
+	camPos := ui.host.UICamera.Position()
+	return cursor.ScreenPosition().Add(matrix.Vec2{camPos.X(), camPos.Y()})
+}
+
+func (ui *uiBase) containedCheck(cursor *hid.Cursor, entity *engine.Entity) {
+	cp := ui.cursorPos(cursor)
+	contained := entity.Transform.ContainsPoint2D(cp)
+	if contained && ui.hasScissor() {
+		contained = ui.scissor.ScreenAreaContains(cp.X(), cp.Y())
+	}
+	if !ui.hovering && contained {
+		ui.hovering = true
+		ui.requestEvent(EventTypeEnter)
+	} else if ui.hovering && !contained {
+		ui.hovering = false
+		ui.requestEvent(EventTypeExit)
+	}
+}


### PR DESCRIPTION
I have added all of the base ui code. This includes the grouping to help with ui elements that overlap that are related, it prevents things like click-through UI. I also have added the layout code which has all the math to do layouts for floating and stretched UI. There is a small addition to bitmap so that it has a new true option that will make a bitmap with all bits set to 1. The events for the UI have also been setup in here for requesting execution through the UI itself (if there isn't a group) or through the group. Some of the layout code may not be used, but it available for things like like CSS/HTML designed UI.