### PR TITLE
docs: Specify windows-amd64 Go distribution requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ For the latest updates, please join the [Discord](https://discord.gg/HYj7Dh7ke3)
 Please review the Ad-Hoc [editor readme](https://github.com/KaijuEngine/kaiju/blob/master/src/editor/README.md)
 
 ## Compiling the engine
+> **Windows developers must install the 64-bit Go toolchain (`windows-amd64`).**
+> The 32-bit (`windows-386`) Go distribution will not compile Kaiju’s Vulkan backend.
 Please see the [documentation](https://kaijuengine.org/engine_developers/build_from_source/) on how to get started and compile the engine
 
 ## Editor previews

--- a/docs/engine_developers/build_from_source-custom.md
+++ b/docs/engine_developers/build_from_source-custom.md
@@ -19,6 +19,23 @@ I have made modifications to the Go compiler to increase the performance of the 
   - This will build the Kaiju Engine Go compiler into the `bin` directory
 
 ## Windows Development
+### Windows Requirements (Important)
+
+Kaiju requires a **64-bit Go toolchain** on Windows.
+
+Do **not** install the legacy 32-bit `windows-386` version of Go, as it will
+fail when compiling the Vulkan backend.
+
+Install the 64-bit distribution: goX.Y.Z.windows-amd64.msi
+
+Download from: https://go.dev/dl/
+
+You can verify your Go architecture by running:
+```
+go env GOARCH
+```
+Expected output: amd64
+
 - Download mingw into `C:/`
   - I use [x86_64-13.2.0-release-win32-seh-msvcrt-rt_v11-rev1.7z
 ](https://github.com/niXman/mingw-builds-binaries/releases)

--- a/docs/engine_developers/build_from_source.md
+++ b/docs/engine_developers/build_from_source.md
@@ -10,6 +10,23 @@ Below are instructions on how to build the editor from source
 To start, make sure you have the [Vulkan SDK](https://vulkan.lunarg.com/sdk/home) installed for your system.
 
 ## Windows Development
+### Windows Requirements (Important)
+
+Kaiju requires a **64-bit Go toolchain** on Windows.
+
+Do **not** install the legacy 32-bit `windows-386` version of Go, as it will
+fail when compiling the Vulkan backend.
+
+Install the 64-bit distribution: goX.Y.Z.windows-amd64.msi
+
+Download from: https://go.dev/dl/
+
+You can verify your Go architecture by running:
+```
+go env GOARCH
+```
+Expected output: amd64
+
 - Download mingw into `C:/`
   - I use [x86_64-15.2.0-release-win32-seh-msvcrt-rt_v13-rev0.7z](https://github.com/niXman/mingw-builds-binaries/releases)
 - Add the `bin` folder to your environment path


### PR DESCRIPTION
Fixes #48 - Updated documentation to explicitly mention installing the 64-bit (windows-amd64) version of Go instead of the 32-bit (windows-386) version, which causes Vulkan compilation errors.

Changes:
- README.md: Added prominent note about 64-bit requirement
- build_from_source.md: Enhanced Windows Requirements section with download link and verification steps
- build_from_source-custom.md: Already had correct documentation

Users can now verify their Go architecture with 'go env GOARCH' (should output 'amd64').