### PR TITLE
fix(editor): fixes untracked editor settings with defaults

### DIFF
--- a/src/editor/editor_settings/editor_settings.go
+++ b/src/editor/editor_settings/editor_settings.go
@@ -63,7 +63,7 @@ type Settings struct {
 }
 
 type EditorCameraSettings struct {
-	ZoomSpeed float32 `default:"120" label:"Editor Camera Zoom Speed (floor)"`
+	ZoomSpeed float32 `default:"120" label:"Zoom Speed"`
 }
 
 type SnapSettings struct {
@@ -75,6 +75,16 @@ type SnapSettings struct {
 type BuildToolSettings struct {
 	AndroidNDK string `label:"Android NDK"`
 	JavaHome   string
+}
+
+// setDefaults explicitly sets default values for all settings.
+// Struct tag defaults are informational for the Editor UI, we
+// must still explicitly set them in code.
+func (s *Settings) setDefaults() {
+	s.RefreshRate = 60
+	s.CodeEditor = "code"
+	s.UIScrollSpeed = 20
+	s.EditorCamera.ZoomSpeed = 120
 }
 
 func (s *Settings) AddRecentProject(path string) {
@@ -113,14 +123,15 @@ func (s *Settings) Load() error {
 	if err != nil {
 		return AppDataMissingError{err}
 	}
+	// Set defaults before attempting to load.
+	// An existing settings file overrides these values during decode,
+	// but also populates previously untracked settings with non-zero
+	// value defaults.
+	s.setDefaults()
 	path := filepath.Join(appData, settingsFileName)
 	if _, err := os.Stat(path); err != nil {
 		// If the settings file doesn't exist, then create it. It is returning
 		// here as there is no need to continue with the load if we're saving
-		s.RefreshRate = 60
-		s.UIScrollSpeed = 20
-		s.EditorCamera.ZoomSpeed = 120
-		s.CodeEditor = "code"
 		return s.Save()
 	}
 	f, err := os.Open(path)


### PR DESCRIPTION
Always sets default values before attempting to load settings.

Case 1: New user with no `settings.json` file, generates a default `settings.json` file (existing behavior).

Case 2: Existing user has a `settings.json` file, but any new setting being added isn't present in the existing `settings.json` file. Defaults are overridden during the json decode, but defaults will stay populated and get saved.