### PR TITLE
ci(windows): add full windows build, DirectX install, Vulkan SDK setup, MinGW setup, Mesa/Lavapipe, caching, and E2E test pipeline

### DIFF
--- a/.github/workflows/ci-build-test.yml
+++ b/.github/workflows/ci-build-test.yml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # optional, but handy if you need full history
+          submodules: recursive   # or: true
 
       - name: Setup Go
         uses: actions/setup-go@v5


### PR DESCRIPTION
- Added new Windows job using matrix (both `windows-2022` and `windows-2025` runners), to allow for multiple version testing
- Installs:
  - Vulkan SDK: 1.4.335.0 (uses cache to speed things up)
  - MinGW: 15.2.0-rt_v13-rev0/x86_64-15.2.0-release-win32-seh-msvcrt-rt_v13-rev0  (uses cache to speed things up)
  - Mesa (lavapipe) as a software renderer
- Runs the automated editor build and E2E test step - same as the linux step except skipping running of xvfb
- Upload build artifacts for inspection

Tested here: https://github.com/mikenye/kaiju-workflow-testing/actions/runs/20430674329