### PR TITLE
feat: press and hold backspace to delete continously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ kaiju_android.so
 
 # GoLand
 .idea/
+
+#Mac
+.DS_Store

--- a/src/engine/ui/input.go
+++ b/src/engine/ui/input.go
@@ -45,6 +45,7 @@ import (
 	"kaiju/platform/profiler/tracing"
 	"kaiju/rendering"
 	"math"
+	"time"
 	"unicode"
 	"unicode/utf8"
 	"weak"
@@ -805,6 +806,16 @@ func (input *Input) keyPressed(keyId int, keyState hid.KeyState) {
 			(*UI)(input).requestEvent(EventTypeKeyDown)
 		} else if keyState == hid.KeyStateUp {
 			(*UI)(input).requestEvent(EventTypeKeyUp)
+		} else if keyState == hid.KeyStateHeld {
+			kb := &host.Window.Keyboard
+			switch keyId {
+			case hid.KeyboardKeyBackspace:
+				prev := kb.GetKeyLastClicked(keyId)
+				dt := time.Since(prev)
+				if dt.Milliseconds() > 500 {
+					input.backspace(kb)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
With reference to #492

Changes Made:
1. Changed keyboard struct to store time of last button press for each key (when the state changes from idle -> down)
>  The reason for adding this is because there was no way of knowing how long key was held for so having this gives us access to that.
2. Updated input keyPressed function for press and hold for continuous delete

Here is a demo video
https://github.com/user-attachments/assets/734701fc-6ada-4f55-8331-5469443c16bc

**Note: only tested for mac**
