### PR TITLE
Add right-click copy for log entries (#455)

### DIFF
--- a/src/editor/editor_embedded_content/editor_content/editor/ui/global/status_bar.go.html
+++ b/src/editor/editor_embedded_content/editor_content/editor/ui/global/status_bar.go.html
@@ -57,11 +57,10 @@
     <div id="logPopup" onclick="closePopup()" onmiss="closePopup()">
         <div id="logEntryTemplate" class="logLine">Logs...</div>
     </div>
-
     <script>
         function addLogEntry(text) {
             const logPopup = document.getElementById('logPopup');
-
+            
             const template = document.getElementById('logEntryTemplate');
             const entry = template.cloneNode(true);
             entry.id = ''; 
@@ -69,8 +68,8 @@
             entry.style.display = 'block';
 
             entry.addEventListener('contextmenu', function(e) {
-                e.preventDefault();
-                navigator.clipboard.writeText(text);
+                e.preventDefault(); 
+                navigator.clipboard.writeText(text); 
             });
 
             logPopup.appendChild(entry);


### PR DESCRIPTION
Fixes #455 — added the ability to right click a log entry in the status bar
and copy its full text to the clipboard.
