### PR TITLE
Fix: remove example addLogEntry calls, keep right-click copy function…

### DIFF
--- a/src/editor/editor_embedded_content/editor_content/editor/ui/global/status_bar.go.html
+++ b/src/editor/editor_embedded_content/editor_content/editor/ui/global/status_bar.go.html
@@ -57,5 +57,23 @@
 		<div id="logPopup" onclick="closePopup" onmiss="closePopup">
 			<div id="logEntryTemplate" class="logLine">Logs...</div>
 		</div>
+		 <script>
+        function addLogEntry(text) {
+            const logPopup = document.getElementById('logPopup');
+            
+            const template = document.getElementById('logEntryTemplate');
+            const entry = template.cloneNode(true);
+            entry.id = ''; 
+            entry.textContent = text;
+            entry.style.display = 'block';
+
+            entry.addEventListener('contextmenu', function(e) {
+                e.preventDefault(); 
+                navigator.clipboard.writeText(text); 
+            });
+
+            logPopup.appendChild(entry);
+        }
+    </script>
 	</body>
 </html>


### PR DESCRIPTION
Removed the hardcoded example log entries from the status bar HTML. The addLogEntry function remains functional, but the log popup no longer auto populates with test messages. This fixes the issue of unnecessary logs appearing in the editor UI. Fixing my own mistake.