### PR TITLE
refactor: Change ContentConfig tags type from []string -> Set[string]

### DIFF
--- a/src/editor/editor_workspace/content_workspace/content_workspace.go
+++ b/src/editor/editor_workspace/content_workspace/content_workspace.go
@@ -487,10 +487,12 @@ func (w *ContentWorkspace) showRightPanel() {
 	}
 	w.info.nameInput.UI.ToInput().SetText(cc.Config.Name)
 	cpys := w.Doc.DuplicateElementRepeat(w.info.entryTagTemplate, len(cc.Config.Tags))
-	for i := range cpys {
-		cpys[i].Children[0].InnerLabel().SetText(cc.Config.Tags[i])
-		cpys[i].Children[1].SetAttribute("data-tag", cc.Config.Tags[i])
-		cpys[i].UI.Show()
+	idx := 0
+	for tag := range cc.Config.Tags {
+		cpys[idx].Children[0].InnerLabel().SetText(tag)
+		cpys[idx].Children[1].SetAttribute("data-tag", tag)
+		cpys[idx].UI.Show()
+		idx++
 	}
 	if len(w.selectedContent) > 1 {
 		w.info.multiSelectNote.UI.Show()
@@ -680,7 +682,7 @@ func (w *ContentWorkspace) entryMouseEnter(e *document.Element) {
 		lbl.SetText(fmt.Sprintf("Name: %s\nType: %s", cc.Config.Name, cc.Config.Type))
 	} else {
 		lbl.SetText(fmt.Sprintf("Name: %s\nType: %s\nTags: %s",
-			cc.Config.Name, cc.Config.Type, strings.Join(cc.Config.Tags, ",")))
+			cc.Config.Name, cc.Config.Type, strings.Join(cc.Config.Tags.ToSlice(), ",")))
 	}
 }
 

--- a/src/editor/editor_workspace/content_workspace/content_workspace_filters.go
+++ b/src/editor/editor_workspace/content_workspace/content_workspace_filters.go
@@ -38,6 +38,7 @@ package content_workspace
 
 import (
 	"kaiju/editor/project/project_database/content_database"
+	"kaiju/klib"
 	"kaiju/platform/profiler/tracing"
 	"strings"
 )
@@ -74,10 +75,10 @@ func ShouldHideContent(id string, typeFilters, tagFilters map[string]struct{}, c
 	return hide
 }
 
-func filterThroughTags(cc *content_database.CachedContent, tagFilters map[string]struct{}) bool {
+func filterThroughTags(cc *content_database.CachedContent, tagFilters klib.Set[string]) bool {
 	defer tracing.NewRegion("content_workspace.filterThroughTags").End()
 	for i := range cc.Config.Tags {
-		_, hasTag := tagFilters[cc.Config.Tags[i]]
+		_, hasTag := tagFilters[i]
 		if hasTag {
 			return true
 		}
@@ -85,14 +86,14 @@ func filterThroughTags(cc *content_database.CachedContent, tagFilters map[string
 	return false
 }
 
-func runQueryOnContent(cc *content_database.CachedContent, query string, tagFilters map[string]struct{}) bool {
+func runQueryOnContent(cc *content_database.CachedContent, query string, tagFilters klib.Set[string]) bool {
 	defer tracing.NewRegion("content_workspace.runQueryOnContent").End()
 	// TODO:  Use filters like tag:..., type:..., etc.
 	if strings.Contains(cc.Config.NameLower(), query) {
 		return true
 	}
-	for i := range cc.Config.Tags {
-		if _, ok := tagFilters[cc.Config.Tags[i]]; ok {
+	for tag := range cc.Config.Tags {
+		if _, ok := tagFilters[tag]; ok {
 			return true
 		}
 	}

--- a/src/editor/editor_workspace/content_workspace/content_workspace_ui_data.go
+++ b/src/editor/editor_workspace/content_workspace/content_workspace_ui_data.go
@@ -58,7 +58,7 @@ func (w *WorkspaceUIData) SetupUIData(cdb *content_database.Cache) []string {
 	ids := make([]string, 0, len(list))
 	for i := range list {
 		ids = append(ids, list[i].Id())
-		for _, tag := range list[i].Config.Tags {
+		for tag := range list[i].Config.Tags {
 			w.Tags[tag]++
 		}
 	}

--- a/src/editor/editor_workspace/stage_workspace/stage_workspace_content_ui.go
+++ b/src/editor/editor_workspace/stage_workspace/stage_workspace_content_ui.go
@@ -381,7 +381,7 @@ func (cui *WorkspaceContentUI) entryMouseEnter(e *document.Element) {
 		lbl.SetText(fmt.Sprintf("Name: %s\nType: %s", cc.Config.Name, cc.Config.Type))
 	} else {
 		lbl.SetText(fmt.Sprintf("Name: %s\nType: %s\nTags: %s",
-			cc.Config.Name, cc.Config.Type, strings.Join(cc.Config.Tags, ",")))
+			cc.Config.Name, cc.Config.Type, strings.Join(cc.Config.Tags.ToSlice(), ",")))
 	}
 }
 

--- a/src/editor/editor_workspace/stage_workspace/stage_workspace_ui_data.go
+++ b/src/editor/editor_workspace/stage_workspace/stage_workspace_ui_data.go
@@ -59,8 +59,8 @@ func (w *WorkspaceUIData) SetupUIData(cdb *content_database.Cache, cm string) []
 	ids := make([]string, 0, len(list))
 	for i := range list {
 		ids = append(ids, list[i].Id())
-		for j := range list[i].Config.Tags {
-			w.Tags[list[i].Config.Tags[j]]++
+		for tag := range list[i].Config.Tags {
+			w.Tags[tag]++
 		}
 	}
 	w.CameraMode = cm

--- a/src/editor/project/project_database/content_database/cache_database.go
+++ b/src/editor/project/project_database/content_database/cache_database.go
@@ -44,7 +44,6 @@ import (
 	"kaiju/platform/profiler/tracing"
 	"log/slog"
 	"path/filepath"
-	"slices"
 	"strings"
 	"sync/atomic"
 )
@@ -166,7 +165,7 @@ func (c *Cache) TagFilter(tags []string) []CachedContent {
 	out := []CachedContent{}
 	for i := range c.cache {
 		for j := range tags {
-			if slices.Contains(c.cache[i].Config.Tags, tags[j]) {
+			if c.cache[i].Config.Tags.Contains(tags[j]) {
 				out = append(out, c.cache[i])
 			}
 		}


### PR DESCRIPTION
This is a small refactor , the main reason of changing the type from a slice to a Set is that a set is more appropriate container for tags in this context as it automatically manages the duplicate tags , O(1) lookup time to check if a content has a tag.

a set defines the intent more correctly