### PR TITLE
Fix triggering alert sound on macOS with input (#672)

### DIFF
--- a/src/platform/windowing/cocoa_window.m
+++ b/src/platform/windowing/cocoa_window.m
@@ -223,7 +223,8 @@ static NSEvent* handleEvent(NSEvent* e) {
 				.type = WINDOW_EVENT_TYPE_KEYBOARD_BUTTON,
 				.keyboardButton = { e.keyCode, e.type==NSEventTypeKeyDown?WINDOW_EVENT_BUTTON_TYPE_DOWN:WINDOW_EVENT_BUTTON_TYPE_UP }
 			});
-			break;
+			shared_mem_flush_events(sm);
+			return nil;
 		default: break;
 	}
 


### PR DESCRIPTION
Fixes issue #672.

Tested on macOS Sonoma, it will remove the alert sound when entering text in an input.

Don't forget to turn the sound on when playing the video.

https://github.com/user-attachments/assets/2ce2a67e-210b-47e5-8f32-39db92ac944e

