### PR TITLE
fix: O(n²) work and data race in GenerateBVH caused indefinite blocking

### DIFF
--- a/src/rendering/loaders/kaiju_mesh/kaiju_mesh.go
+++ b/src/rendering/loaders/kaiju_mesh/kaiju_mesh.go
@@ -143,21 +143,19 @@ func (k KaijuMesh) GenerateBVH(threads *concurrent.Threads, transform *matrix.Tr
 	group := sync.WaitGroup{}
 	construct := func(from, to int) {
 		for i := from; i < to; i += 3 {
-			for i := 0; i < len(k.Indexes); i += 3 {
-				points := [3]matrix.Vec3{
-					k.Verts[k.Indexes[i]].Position,
-					k.Verts[k.Indexes[i+1]].Position,
-					k.Verts[k.Indexes[i+2]].Position,
-				}
-				tris[i/3] = collision.DetailedTriangleFromPoints(points)
+			points := [3]matrix.Vec3{
+				k.Verts[k.Indexes[i]].Position,
+				k.Verts[k.Indexes[i+1]].Position,
+				k.Verts[k.Indexes[i+2]].Position,
 			}
+			tris[i/3] = collision.DetailedTriangleFromPoints(points)
 		}
 		group.Done()
 	}
 	work := make([]func(int), len(tris))
 	group.Add(len(work))
 	for i := range work {
-		work[i] = func(int) { construct(i*3, (i+3)*3) }
+		work[i] = func(int) { construct(i*3, (i+1)*3) }
 	}
 	threads.AddWork(work)
 	group.Wait()


### PR DESCRIPTION
## Summary

- The inner `for i := 0` loop inside `construct` shadowed the outer loop variable, causing every work item to process **all** triangles instead of its assigned partition — resulting in O(n²) total work and concurrent data races on the `tris` slice
- Fixed the `(i+3)*3` range bound to `(i+1)*3` so each work item correctly covers exactly one triangle (`[i*3, i*3+3)`)

## Details

`GenerateBVH` partitions triangle construction across a thread pool. The `construct` closure was written with a nested loop:

```go
for i := from; i < to; i += 3 {       // outer loop
    for i := 0; i < len(k.Indexes); i += 3 {  // inner loop re-declares i!
        tris[i/3] = ...                        // writes ALL tris every outer iteration
    }
}
```

The inner `i` shadowed the outer `i`, completely ignoring `from`/`to`. Each work item iterated over every triangle `(to-from)/3` times, and with `len(tris)` concurrent goroutines doing the same, the total writes scaled as `O(n²)`. On top of that, every goroutine wrote to overlapping indices in `tris`, causing an unsynchronized data race.

The fix removes the inner loop and corrects the partition range, so each work item processes exactly the one triangle it owns.