### PR TITLE
feature/dynamic mesh and skip ui clean for inactive items.

### DIFF
--- a/src/engine/ui/ui.go
+++ b/src/engine/ui/ui.go
@@ -299,6 +299,9 @@ func (ui *UI) Clean() {
 	for !stabilized && maxIterations > 0 {
 		stabilized = true
 		for i := range tree {
+			if !tree[i].IsActive() {
+				continue
+			}
 			tree[i].cleanDirty()
 			tree[i].Layout().update()
 			tree[i].postLayoutUpdate()
@@ -307,6 +310,9 @@ func (ui *UI) Clean() {
 		maxIterations--
 	}
 	for i := range tree {
+		if !tree[i].IsActive() {
+			continue
+		}
 		tree[i].GenerateScissor()
 		tree[i].render()
 	}

--- a/src/rendering/gpu_device_mesh.go
+++ b/src/rendering/gpu_device_mesh.go
@@ -61,6 +61,49 @@ func (g *GPUDevice) MeshIsReady(mesh Mesh) bool {
 	return mesh.MeshId.vertexBuffer.IsValid()
 }
 
+// UpdateMeshVertices re-uploads vertex data to an existing mesh's GPU
+// buffer via a staging buffer copy. The vertex count must match the
+// original; use CreateMesh for topology changes.
+func (g *GPUDevice) UpdateMeshVertices(mesh *Mesh, verts []Vertex) {
+	defer tracing.NewRegion("GPUDevice.UpdateMeshVertices").End()
+	if uint32(len(verts)) != mesh.MeshId.vertexCount {
+		return
+	}
+	g.updateVertexBufferImpl(mesh.MeshId.vertexBuffer, verts)
+}
+
+// CreateDynamicMesh creates a mesh with a HOST_VISIBLE vertex buffer that
+// can be updated directly via MapMemory without staging buffers or GPU
+// synchronization. Use for meshes that change frequently (e.g. terrain
+// during brush edits). The index buffer is still DEVICE_LOCAL.
+func (g *GPUDevice) CreateDynamicMesh(mesh *Mesh, verts []Vertex, indices []uint32) {
+	defer tracing.NewRegion("GPUDevice.CreateDynamicMesh").End()
+	id := &mesh.MeshId
+	id.vertexCount = uint32(len(verts))
+	id.indexCount = uint32(len(indices))
+	id.vertexBuffer, id.vertexBufferMemory, _ = g.createDynamicVertexBufferImpl(verts)
+	id.indexBuffer, id.indexBufferMemory, _ = g.CreateIndexBuffer(indices)
+	runtime.AddCleanup(mesh, func(state MeshCleanup) {
+		d := state.device.Value()
+		if d == nil {
+			return
+		}
+		d.Painter.preRuns = append(d.Painter.preRuns, func() {
+			d.destroyMeshHandle(state.id)
+		})
+	}, MeshCleanup{mesh.MeshId, weak.Make(g)})
+}
+
+// UpdateDynamicMeshVertices writes vertex data directly to a HOST_VISIBLE
+// vertex buffer. No staging buffer, no command buffer, no fence wait.
+func (g *GPUDevice) UpdateDynamicMeshVertices(mesh *Mesh, verts []Vertex) {
+	defer tracing.NewRegion("GPUDevice.UpdateDynamicMeshVertices").End()
+	if uint32(len(verts)) != mesh.MeshId.vertexCount {
+		return
+	}
+	g.updateDynamicVertexBufferImpl(mesh.MeshId.vertexBufferMemory, verts)
+}
+
 func (g *GPUDevice) CreateMesh(mesh *Mesh, verts []Vertex, indices []uint32) {
 	defer tracing.NewRegion("GPUDevice.CreateMesh").End()
 	id := &mesh.MeshId

--- a/src/rendering/gpu_device_mesh_vulkan.go
+++ b/src/rendering/gpu_device_mesh_vulkan.go
@@ -77,6 +77,60 @@ func (g *GPUDevice) createVertexBufferImpl(verts []Vertex) (GPUBuffer, GPUDevice
 	return vertexBuffer, vertexBufferMemory, nil
 }
 
+func (g *GPUDevice) updateVertexBufferImpl(dst GPUBuffer, verts []Vertex) error {
+	vertBuff := klib.StructSliceToByteArray(verts)
+	if len(vertBuff) <= 0 {
+		return errors.New("buffer size is 0")
+	}
+	bufferSize := uintptr(len(vertBuff))
+	stagingBuffer, stagingBufferMemory, err := g.CreateBuffer(
+		bufferSize, GPUBufferUsageTransferSrcBit,
+		GPUMemoryPropertyHostVisibleBit|GPUMemoryPropertyHostCoherentBit)
+	if err != nil {
+		slog.Error("Failed to create staging buffer for vertex update")
+		return err
+	}
+	var data unsafe.Pointer
+	g.MapMemory(stagingBufferMemory, 0, bufferSize, 0, &data)
+	g.Memcopy(data, vertBuff)
+	g.UnmapMemory(stagingBufferMemory)
+	g.CopyBuffer(stagingBuffer, dst, bufferSize)
+	g.DestroyBuffer(stagingBuffer)
+	g.LogicalDevice.dbg.remove(stagingBuffer.handle)
+	g.FreeMemory(stagingBufferMemory)
+	g.LogicalDevice.dbg.remove(stagingBufferMemory.handle)
+	return nil
+}
+
+func (g *GPUDevice) createDynamicVertexBufferImpl(verts []Vertex) (GPUBuffer, GPUDeviceMemory, error) {
+	vertBuff := klib.StructSliceToByteArray(verts)
+	if len(vertBuff) <= 0 {
+		return GPUBuffer{}, GPUDeviceMemory{}, errors.New("buffer size is 0")
+	}
+	bufferSize := uintptr(len(vertBuff))
+	buffer, memory, err := g.CreateBuffer(
+		bufferSize, GPUBufferUsageVertexBufferBit,
+		GPUMemoryPropertyHostVisibleBit|GPUMemoryPropertyHostCoherentBit)
+	if err != nil {
+		slog.Error("Failed to create dynamic vertex buffer")
+		return buffer, memory, err
+	}
+	var data unsafe.Pointer
+	g.MapMemory(memory, 0, bufferSize, 0, &data)
+	g.Memcopy(data, vertBuff)
+	g.UnmapMemory(memory)
+	return buffer, memory, nil
+}
+
+func (g *GPUDevice) updateDynamicVertexBufferImpl(memory GPUDeviceMemory, verts []Vertex) {
+	vertBuff := klib.StructSliceToByteArray(verts)
+	bufferSize := uintptr(len(vertBuff))
+	var data unsafe.Pointer
+	g.MapMemory(memory, 0, bufferSize, 0, &data)
+	g.Memcopy(data, vertBuff)
+	g.UnmapMemory(memory)
+}
+
 func (g *GPUDevice) createIndexBufferImpl(indices []uint32) (GPUBuffer, GPUDeviceMemory, error) {
 	var indexBuffer GPUBuffer
 	var indexBufferMemory GPUDeviceMemory

--- a/src/rendering/mesh.go
+++ b/src/rendering/mesh.go
@@ -79,6 +79,7 @@ type Mesh struct {
 	pendingVerts   []Vertex
 	pendingIndexes []uint32
 	bounds         collision.AABB
+	dynamic        bool
 }
 
 func NewMesh(key string, verts []Vertex, indexes []uint32) *Mesh {
@@ -99,17 +100,36 @@ func NewMesh(key string, verts []Vertex, indexes []uint32) *Mesh {
 	return m
 }
 
+func NewDynamicMesh(key string, verts []Vertex, indexes []uint32) *Mesh {
+	m := NewMesh(key, verts, indexes)
+	m.dynamic = true
+	return m
+}
+
 func (m *Mesh) SetKey(key string) {
 	m.key = key
 }
 
 func (m *Mesh) DelayedCreate(device *GPUDevice) {
 	defer tracing.NewRegion("Mesh.DelayedCreate").End()
-	if len(m.pendingVerts) > 0 {
-		device.CreateMesh(m, m.pendingVerts, m.pendingIndexes)
-		m.pendingVerts = make([]Vertex, 0)
-		m.pendingIndexes = make([]uint32, 0)
+	if len(m.pendingVerts) == 0 {
+		return
 	}
+	if m.IsReady() {
+		if m.dynamic {
+			device.UpdateDynamicMeshVertices(m, m.pendingVerts)
+		} else {
+			device.UpdateMeshVertices(m, m.pendingVerts)
+		}
+	} else {
+		if m.dynamic {
+			device.CreateDynamicMesh(m, m.pendingVerts, m.pendingIndexes)
+		} else {
+			device.CreateMesh(m, m.pendingVerts, m.pendingIndexes)
+		}
+	}
+	m.pendingVerts = make([]Vertex, 0)
+	m.pendingIndexes = make([]uint32, 0)
 }
 
 func (m Mesh) Key() string            { return m.key }

--- a/src/rendering/mesh_cache.go
+++ b/src/rendering/mesh_cache.go
@@ -102,6 +102,33 @@ func (m *MeshCache) Mesh(key string, verts []Vertex, indexes []uint32) *Mesh {
 	}
 }
 
+// DynamicMesh creates or retrieves a mesh backed by a HOST_VISIBLE vertex
+// buffer, suitable for frequent CPU updates without GPU synchronization.
+func (m *MeshCache) DynamicMesh(key string, verts []Vertex, indexes []uint32) *Mesh {
+	defer tracing.NewRegion("MeshCache.DynamicMesh").End()
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if mesh, ok := m.meshes[key]; ok {
+		return mesh
+	}
+	mesh := NewDynamicMesh(key, verts, indexes)
+	m.pendingMeshes = append(m.pendingMeshes, mesh)
+	m.meshes[key] = mesh
+	return mesh
+}
+
+// UpdateMeshVertices queues a vertex data re-upload for an existing mesh.
+// The vertex count must match the original. The update is processed in
+// the next CreatePending call alongside new mesh creations.
+func (m *MeshCache) UpdateMeshVertices(key string, verts []Vertex) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if mesh, ok := m.meshes[key]; ok && mesh.IsReady() {
+		mesh.pendingVerts = verts
+		m.pendingMeshes = append(m.pendingMeshes, mesh)
+	}
+}
+
 func (m *MeshCache) CreatePending() {
 	defer tracing.NewRegion("MeshCache.CreatePending").End()
 	m.mutex.Lock()

--- a/src/rendering/render_id.vk.go
+++ b/src/rendering/render_id.vk.go
@@ -108,6 +108,8 @@ func (m MeshId) IsValid() bool {
 	return m.vertexBuffer.IsValid() && m.indexBuffer.IsValid()
 }
 
+func (m MeshId) VertexCount() uint32 { return m.vertexCount }
+
 func (d *ShaderDriverData) setup(sd *ShaderDataCompiled) {
 	d.Stride = sd.Stride()
 	d.AttributeDescriptions = sd.ToAttributeDescription(baseVertexAttributeCount)


### PR DESCRIPTION
Some potential improvements, courtesy of my project and claude's insistence that there wasn't another, better way. My understanding of graphics libraries consists of older OpenGL standards, so please let me know if there is already a better way to do this in kaiju.

I ran into issues with frequent mesh updating and the GC, and needed something different than a DEVICE_LOCAL mesh. CreateDynamicMesh provides a HOST_VISIBLE type mesh, which allows for frequent updates.

Also, skipped cleaning the inactive UI tree items. I hope I didn't overlook something here, and that it isn't a problem that I also included this in the same PR.