### PR TITLE
Use meta key on macOS and enhance input navigation

### DIFF
--- a/src/editor/editor.go
+++ b/src/editor/editor.go
@@ -37,6 +37,9 @@
 package editor
 
 import (
+	"log/slog"
+	"time"
+
 	"kaijuengine.com/build"
 	"kaijuengine.com/editor/editor_embedded_content"
 	"kaijuengine.com/editor/editor_events"
@@ -64,8 +67,6 @@ import (
 	"kaijuengine.com/matrix"
 	"kaijuengine.com/platform/hid"
 	"kaijuengine.com/platform/profiler/tracing"
-	"log/slog"
-	"time"
 )
 
 // Editor is the entry point structure for the entire editor. It acts as the
@@ -211,7 +212,7 @@ func (ed *Editor) update(deltaTime float64) {
 		return
 	}
 	kb := &ed.host.Window.Keyboard
-	if kb.HasCtrl() && !ed.IsInputFocused() {
+	if kb.HasCtrlOrMeta() && !ed.IsInputFocused() {
 		if kb.KeyDown(hid.KeyboardKeyZ) {
 			if !kb.HasShift() {
 				ed.history.Undo()
@@ -237,7 +238,7 @@ func (ed *Editor) update(deltaTime float64) {
 		return
 	}
 	if kb.KeyDown(hid.KeyboardKeyF5) {
-		if kb.HasCtrl() {
+		if kb.HasCtrlOrMeta() {
 			if kb.HasShift() {
 				ed.BuildAndRun(project.GameBuildModeRelease)
 			} else {
@@ -255,6 +256,9 @@ func (ed *Editor) update(deltaTime float64) {
 func processWorkspaceHotkeys(ed *Editor, kb *hid.Keyboard) {
 	for _, hk := range ed.currentWorkspace.Hotkeys() {
 		if hk.Ctrl && !kb.HasCtrl() {
+			continue
+		}
+		if hk.Meta && !kb.HasMeta() {
 			continue
 		}
 		if hk.Shift && !kb.HasShift() {

--- a/src/editor/editor_overlay/file_browser/file_browser_overlay.go
+++ b/src/editor/editor_overlay/file_browser/file_browser_overlay.go
@@ -38,6 +38,13 @@ package file_browser
 
 import (
 	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"unicode"
+
 	"kaijuengine.com/editor/editor_overlay/input_prompt"
 	"kaijuengine.com/engine"
 	"kaijuengine.com/engine/ui"
@@ -47,12 +54,6 @@ import (
 	"kaijuengine.com/platform/filesystem"
 	"kaijuengine.com/platform/hid"
 	"kaijuengine.com/platform/profiler/tracing"
-	"log/slog"
-	"os"
-	"path/filepath"
-	"runtime"
-	"slices"
-	"unicode"
 )
 
 type FileBrowser struct {
@@ -412,12 +413,12 @@ func (fb *FileBrowser) selectEntry(e *document.Element) {
 			fb.doc.SetElementClassesWithoutApply(target, "entry", "selected")
 			fb.selected = append(fb.selected, target)
 		}
-	} else if kb.HasCtrl() && slices.Contains(fb.selected, e) {
+	} else if kb.HasCtrlOrMeta() && slices.Contains(fb.selected, e) {
 		idx := slices.Index(fb.selected, e)
 		fb.selected = klib.RemoveUnordered(fb.selected, idx)
 		fb.doc.SetElementClassesWithoutApply(e, "entry")
 	} else {
-		if !fb.config.MultiSelect || !kb.HasCtrl() {
+		if !fb.config.MultiSelect || !kb.HasCtrlOrMeta() {
 			fb.clearSelection()
 		}
 		fb.doc.SetElementClassesWithoutApply(e, "entry", "selected")

--- a/src/editor/editor_project_setup.go
+++ b/src/editor/editor_project_setup.go
@@ -39,12 +39,13 @@ package editor
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+
 	"kaijuengine.com/editor/editor_overlay/confirm_prompt"
 	"kaijuengine.com/editor/editor_overlay/new_project"
 	"kaijuengine.com/editor/project"
 	"kaijuengine.com/klib"
 	"kaijuengine.com/platform/profiler/tracing"
-	"log/slog"
 )
 
 func (ed *Editor) setProjectName(name string) {
@@ -108,7 +109,7 @@ func (ed *Editor) openProject(path string) {
 	// to force updating engine code in projects. This makes it easier than
 	// bumping the engine version to do the same thing (or deleting kaiju src)
 	kb := &ed.host.Window.Keyboard
-	forceReplace := kb.HasShift() || kb.HasCtrl()
+	forceReplace := kb.HasShift() || kb.HasCtrlOrMeta()
 	if projectVersion != EditorVersion || !hasEngineSource || forceReplace {
 		title := "Upgrade project"
 		description := "Your project is for an older version of the editor, would you like to upgrade it? Please make sure you've backed up your project (with VCS for example) before proceeding."

--- a/src/editor/editor_stage_manager/editor_stage_view/editor_stage_transformation_manager.go
+++ b/src/editor/editor_stage_manager/editor_stage_view/editor_stage_transformation_manager.go
@@ -121,7 +121,7 @@ func (t *TransformationManager) Update(host *engine.Host) {
 		}
 	}
 	ss := t.snapSettings
-	snap := kb.HasCtrl()
+	snap := kb.HasCtrlOrMeta()
 	t.isBusy = t.translateTool.Update(host, snap, ss.TranslateIncrement) ||
 		t.rotationTool.Update(host, snap, ss.RotateIncrement) ||
 		t.scalingTool.Update(host, snap, ss.ScaleIncrement)

--- a/src/editor/editor_stage_manager/editor_stage_view/editor_stage_view.go
+++ b/src/editor/editor_stage_manager/editor_stage_view/editor_stage_view.go
@@ -37,12 +37,14 @@
 package editor_stage_view
 
 import (
+	"log/slog"
+	"weak"
+
 	"kaijuengine.com/editor/editor_controls"
 	"kaijuengine.com/editor/editor_stage_manager"
 	"kaijuengine.com/editor/editor_stage_manager/data_binding_renderer"
 	"kaijuengine.com/editor/editor_stage_manager/editor_stage_view/select_tool"
 	"kaijuengine.com/editor/editor_stage_manager/editor_stage_view/transform_tools"
-
 	"kaijuengine.com/editor/project"
 	"kaijuengine.com/engine"
 	"kaijuengine.com/engine/assets"
@@ -51,8 +53,6 @@ import (
 	"kaijuengine.com/platform/profiler/tracing"
 	"kaijuengine.com/registry/shader_data_registry"
 	"kaijuengine.com/rendering"
-	"log/slog"
-	"weak"
 )
 
 type StageView struct {
@@ -130,7 +130,7 @@ func (v *StageView) Update(deltaTime float64, proj *project.Project) bool {
 	kb := &v.host.Window.Keyboard
 	if kb.KeyDown(hid.KeyboardKeyDelete) {
 		v.manager.DestroySelected()
-	} else if kb.HasCtrl() && kb.KeyDown(hid.KeyboardKeyD) {
+	} else if kb.HasCtrlOrMeta() && kb.KeyDown(hid.KeyboardKeyD) {
 		v.DuplicateSelected(proj)
 		return true
 	}

--- a/src/editor/editor_stage_manager/editor_stage_view/stage_viewport_interaction.go
+++ b/src/editor/editor_stage_manager/editor_stage_view/stage_viewport_interaction.go
@@ -66,7 +66,7 @@ func (v *StageView) processViewportInteractions() {
 		ray := v.camera.RayCast(m)
 		if kb.HasShift() {
 			v.manager.TryAppendSelect(ray)
-		} else if kb.HasCtrl() {
+		} else if kb.HasCtrlOrMeta() {
 			v.manager.TryToggleSelect(ray)
 		} else {
 			v.manager.TrySelect(ray)

--- a/src/editor/editor_stage_manager/editor_stage_view/transform_tools/transform_tool.go
+++ b/src/editor/editor_stage_manager/editor_stage_view/transform_tools/transform_tool.go
@@ -37,6 +37,10 @@
 package transform_tools
 
 import (
+	"log/slog"
+	"slices"
+	"weak"
+
 	"kaijuengine.com/editor/editor_controls"
 	"kaijuengine.com/editor/editor_settings"
 	"kaijuengine.com/editor/editor_stage_manager/data_binding_renderer"
@@ -50,9 +54,6 @@ import (
 	"kaijuengine.com/platform/profiler/tracing"
 	"kaijuengine.com/registry/shader_data_registry"
 	"kaijuengine.com/rendering"
-	"log/slog"
-	"slices"
-	"weak"
 )
 
 type TransformTool struct {
@@ -434,7 +435,7 @@ func (t *TransformTool) updateDrag(host *engine.Host) {
 		t.lastHit = point.Add(delta)
 	}
 	if !t.lastHit.Equals(point) {
-		t.transform(delta, host.Window.Keyboard.HasCtrl())
+		t.transform(delta, host.Window.Keyboard.HasCtrlOrMeta())
 		t.lastHit = point
 		for _, e := range sel {
 			for _, db := range e.DataBindings() {

--- a/src/editor/editor_workspace/common_workspace/common_workspace_hotkey.go
+++ b/src/editor/editor_workspace/common_workspace/common_workspace_hotkey.go
@@ -41,6 +41,7 @@ import "kaijuengine.com/platform/hid"
 type HotKey struct {
 	Keys  []hid.KeyboardKey
 	Ctrl  bool
+	Meta  bool
 	Shift bool
 	Alt   bool
 	Call  func()

--- a/src/editor/editor_workspace/content_workspace/content_workspace.go
+++ b/src/editor/editor_workspace/content_workspace/content_workspace.go
@@ -39,6 +39,15 @@ package content_workspace
 import (
 	"errors"
 	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"weak"
+
 	"kaijuengine.com/editor/editor_events"
 	"kaijuengine.com/editor/editor_overlay/confirm_prompt"
 	"kaijuengine.com/editor/editor_overlay/context_menu"
@@ -53,14 +62,6 @@ import (
 	"kaijuengine.com/matrix"
 	"kaijuengine.com/platform/profiler/tracing"
 	"kaijuengine.com/rendering"
-	"log/slog"
-	"os"
-	"os/exec"
-	"path/filepath"
-	"runtime"
-	"slices"
-	"strings"
-	"weak"
 )
 
 type ContentWorkspace struct {
@@ -455,10 +456,10 @@ func (w *ContentWorkspace) clickEntry(e *document.Element) {
 			}
 			w.appendSelected(t)
 		}
-	} else if kb.HasCtrl() && slices.Contains(w.selectedContent, e) {
+	} else if kb.HasCtrlOrMeta() && slices.Contains(w.selectedContent, e) {
 		w.removeSelected(e)
 	} else {
-		if !kb.HasCtrl() {
+		if !kb.HasCtrlOrMeta() {
 			w.clearSelection()
 		}
 		w.appendSelected(e)

--- a/src/editor/editor_workspace/stage_workspace/stage_workspace_hierarchy_ui.go
+++ b/src/editor/editor_workspace/stage_workspace/stage_workspace_hierarchy_ui.go
@@ -118,7 +118,7 @@ func (hui *WorkspaceHierarchyUI) processHotkeys(host *engine.Host) {
 		} else {
 			hui.hierarchyArea.UI.Show()
 		}
-	} else if kb.HasCtrl() && kb.KeyDown(hid.KeyboardKeyT) {
+	} else if kb.HasCtrlOrMeta() && kb.KeyDown(hid.KeyboardKeyT) {
 		w := hui.workspace.Value()
 		w.stageView.Manager().CreateTemplateFromSelected(w.ed.Events(), w.ed.Project())
 	}
@@ -130,7 +130,7 @@ func (hui *WorkspaceHierarchyUI) selectEntity(e *document.Element) {
 	w := hui.workspace.Value()
 	kb := &w.Host.Window.Keyboard
 	man := w.stageView.Manager()
-	if kb.HasCtrl() {
+	if kb.HasCtrlOrMeta() {
 		man.SelectToggleEntityById(id)
 	} else if kb.HasShift() {
 		man.SelectWithChildrenOrSingleEntityById(id)

--- a/src/engine/ui/input.go
+++ b/src/engine/ui/input.go
@@ -395,7 +395,13 @@ func (input *Input) arrowMoveCursor(kb *hid.Keyboard, dir int) {
 	data := input.InputData()
 	currentPos := data.cursorOffset
 	newPos := data.cursorOffset + dir
-	if kb.HasCtrl() {
+	if kb.HasMeta() {
+		if dir < 0 {
+			newPos = 0
+		} else {
+			newPos = utf8.RuneCountInString(data.label.Text())
+		}
+	} else if kb.HasCtrl() || kb.HasAlt() {
 		newPos = input.findNextBreak(newPos, dir)
 	}
 	input.moveCursor(newPos)
@@ -788,7 +794,7 @@ func (input *Input) keyPressed(keyId int, keyState hid.KeyState) {
 			kb := &host.Window.Keyboard
 			c := kb.KeyToRune(keyId)
 			if c != 0 {
-				if !kb.HasCtrl() {
+				if !kb.HasCtrlOrMeta() {
 					if kb.IsToggleKeyOn(hid.KeyboardKeyCapsLock) {
 						input.InsertText(string(unicode.ToUpper(c)))
 					} else {
@@ -902,7 +908,10 @@ func (input *Input) backspace(kb *hid.Keyboard) {
 	ld := data.label.LabelData()
 	if data.highlight.entity.IsActive() {
 		input.deleteSelection(false)
-	} else if kb.HasCtrl() {
+	} else if kb.HasMeta() {
+		input.setSelect(0, data.cursorOffset)
+		input.deleteSelection(false)
+	} else if kb.HasCtrl() || kb.HasAlt() {
 		from := input.findNextBreak(data.cursorOffset-1, -1)
 		input.setSelect(from, data.cursorOffset)
 		input.deleteSelection(false)

--- a/src/platform/hid/keyboard.darwin.go
+++ b/src/platform/hid/keyboard.darwin.go
@@ -223,12 +223,10 @@ func ToKeyboardKey(nativeKey int) KeyboardKey {
 		return KeyboardKeyLeftAlt
 	case 0x3D:
 		return KeyboardKeyRightAlt
-	// macOS Command keys map to Ctrl for shortcuts (Cmd+C, Cmd+V, etc.)
-	// This allows engine's Ctrl+C/V/X clipboard shortcuts to work with Cmd key
 	case 0x37:
-		return KeyboardKeyLeftCtrl // Left Command → Left Ctrl
+		return KeyboardKeyLeftMeta
 	case 0x36:
-		return KeyboardKeyRightCtrl // Right Command → Right Ctrl
+		return KeyboardKeyRightMeta
 
 	// Special keys
 	case 0x39:

--- a/src/platform/hid/keyboard.go
+++ b/src/platform/hid/keyboard.go
@@ -38,6 +38,7 @@ package hid
 
 import (
 	"log/slog"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -63,6 +64,8 @@ const (
 	KeyboardKeyRightCtrl
 	KeyboardKeyLeftShift
 	KeyboardKeyRightShift
+	KeyboardKeyLeftMeta
+	KeyboardKeyRightMeta
 	KeyboardKeyA
 	KeyboardKeyB
 	KeyboardKeyC
@@ -225,6 +228,16 @@ func (k Keyboard) HasCtrl() bool {
 	return k.KeyHeld(KeyboardKeyLeftCtrl) || k.KeyHeld(KeyboardKeyRightCtrl)
 }
 
+// HasCtrlOrMeta checks if the meta key is pressed on Darwin, or the ctrl key on
+// Windows and Linux.
+func (k Keyboard) HasCtrlOrMeta() bool {
+	if runtime.GOOS == "darwin" {
+		return k.HasMeta()
+	}
+
+	return k.HasCtrl()
+}
+
 func (k Keyboard) HasShift() bool {
 	return k.KeyHeld(KeyboardKeyLeftShift) || k.KeyHeld(KeyboardKeyRightShift)
 }
@@ -233,8 +246,12 @@ func (k Keyboard) HasAlt() bool {
 	return k.KeyHeld(KeyboardKeyLeftAlt) || k.KeyHeld(KeyboardKeyRightAlt)
 }
 
+func (k Keyboard) HasMeta() bool {
+	return k.KeyHeld(KeyboardKeyLeftMeta) || k.KeyHeld(KeyboardKeyRightMeta)
+}
+
 func (k Keyboard) HasModifier() bool {
-	return k.HasCtrl() || k.HasShift() || k.HasAlt()
+	return k.HasCtrl() || k.HasMeta() || k.HasShift() || k.HasAlt()
 }
 
 func (k Keyboard) IsToggleKey(key KeyboardKey) bool {


### PR DESCRIPTION
This PR is a proposition. It enables using the `meta` key on macOS and keep `ctrl` as it should be.

CMD+left on a input will move the cursor at the beginning, same behavior for the right.
ALT+left on a input will move the cursor to the previous break work, for the right, to the next break word.

Any comments or suggestions are very welcomed 🙏🏼

By the way, my VSCode reorder the import, I don't know if it is good or not.