### PR TITLE
Create new key for textures on drag and drop if needed

### DIFF
--- a/src/rendering/texture_cache.go
+++ b/src/rendering/texture_cache.go
@@ -117,6 +117,7 @@ func (t *TextureCache) InsertRawTexture(key string, data []byte, width, height i
 	defer tracing.NewRegion("TextureCache.InsertTexture").End()
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
+	key = selectKey(key)
 	if texture, ok := t.textures[filter][key]; ok {
 		return texture, nil
 	}
@@ -134,7 +135,7 @@ func (t *TextureCache) InsertImageTexture(key string, imageData []byte, filter T
 	defer tracing.NewRegion("TextureCache.InsertImageTexture").End()
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
-	// Check if already exists
+	key = selectKey(key)
 	if texture, ok := t.textures[filter][key]; ok {
 		return texture, nil
 	}


### PR DESCRIPTION
Fix texture cache unique-key handling for inserted runtime textures

`InsertRawTexture` and `InsertImageTexture` were checking the cache before resolving `GenerateUniqueTextureKey` (`""`) into an actual UUID. That meant repeated calls intended to create fresh textures could reuse the same cache entry under the empty-string key, causing newly spawned images to display as copies of the first inserted texture.

This change normalizes the key with `selectKey(key)` before the cache lookup, so runtime-inserted textures get a real unique key prior to deduplication. That preserves normal cache reuse for explicit keys while making `GenerateUniqueTextureKey` behave as intended.