### PR TITLE
Center the window at launch on macOS

### DIFF
--- a/src/platform/windowing/cocoa_window.m
+++ b/src/platform/windowing/cocoa_window.m
@@ -302,6 +302,10 @@ void* cocoa_create_window(const char* title,
 
 			win.title = [NSString stringWithUTF8String:title];
 
+			if (x < 0 || y < 0) {
+				[win center];
+			}
+
 			// Window delegate (retained via associated object)
 			WindowDelegate* winDelegate = [WindowDelegate new];
 			objc_setAssociatedObject(win, "windowDelegate",
@@ -455,7 +459,6 @@ double cocoa_get_backing_scale_factor(void* nsWindow) {
 	if (!nsWindow) {
 		return result;
 	}
-/*
 	dispatch_sync(dispatch_get_main_queue(), ^{
 		@autoreleasepool {
 			NSWindow* window = (__bridge NSWindow*)nsWindow;
@@ -470,7 +473,6 @@ double cocoa_get_backing_scale_factor(void* nsWindow) {
 			}
 		}
 	});
-*/
 	return result;
 }
 


### PR DESCRIPTION
At the moment, the window is placed at the bottom left of the screen when the engine is launched.

The project initialise the window at the coordinate -1, -1, which is valide on macOS.

This PR centers the window, following Apple style, which places the window centered horizontally, but not really vertically.