### PR TITLE
feat(status-bar): add 'Open log file' to log-entry right-click menu

### DIFF
--- a/src/editor/global_interface/status_bar/status_bar.go
+++ b/src/editor/global_interface/status_bar/status_bar.go
@@ -37,6 +37,7 @@
 package status_bar
 
 import (
+	"log/slog"
 	"weak"
 
 	"kaijuengine.com/editor/common_interfaces"
@@ -47,6 +48,7 @@ import (
 	"kaijuengine.com/engine/ui"
 	"kaijuengine.com/engine/ui/markup"
 	"kaijuengine.com/engine/ui/markup/document"
+	"kaijuengine.com/platform/filesystem"
 	"kaijuengine.com/platform/profiler/tracing"
 )
 
@@ -169,6 +171,20 @@ func (b *StatusBar) rightClickLogEntry(e *document.Element) {
 		{
 			Label: "Copy to clipboard",
 			Call:  func() { b.uiMan.Host.Window.CopyToClipboard(text) },
+		},
+		{
+			Label: "Open log file",
+			Call: func() {
+				path, err := logging.LogFilePath()
+				if err != nil {
+					slog.Error("failed to locate the log file path", "error", err)
+					return
+				}
+				if err := filesystem.OpenFileBrowserToFolder(path); err != nil {
+					slog.Error("failed to open the log file",
+						"path", path, "error", err)
+				}
+			},
 		},
 	}
 	pos := b.uiMan.Host.Window.Mouse.ScreenPosition()

--- a/src/engine/systems/logging/logger.go
+++ b/src/engine/systems/logging/logger.go
@@ -132,6 +132,18 @@ func LogFolderPath() (string, error) {
 	return filepath.Join(appData, "logs"), nil
 }
 
+// LogFilePath returns the absolute path of the active log file that the
+// running editor/engine is appending to. The path is stable for the
+// lifetime of the process; across restarts the previous file is rotated
+// by renameOldLogFile before a new one is opened at the same path.
+func LogFilePath() (string, error) {
+	dir, err := LogFolderPath()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, logFileName), nil
+}
+
 func selectLogsFolder() (string, error) {
 	dir, err := LogFolderPath()
 	if err != nil {


### PR DESCRIPTION
## Summary

Closes #456 for the right-click "open log in text editor" ask in the issue title. Adds a second option to the existing status-bar log-entry context menu that opens `kaiju.log` in the user's default handler (which is a text editor on all three platforms).

## Why this matters

The issue (from @BrentFarris) bundled three asks together:

1. **"Open logs folder" menu bar item** — already shipped. `src/editor/editor_embedded_content/editor_content/editor/ui/global/menu_bar.go.html:113` has `<div ... onclick="clickLogs">Logs</div>` wired to `MenuBar.clickLogs` in `src/editor/global_interface/menu_bar/menu_bar.go:408-420`, which calls `filesystem.OpenFileBrowserToFolder(dir)` on `logging.LogFolderPath()`.
2. **Right-click log entry → open log in text editor** — this PR.
3. **Configurable `maxLogFileHistory`** (currently `10` at `src/engine/systems/logging/logger.go:58`) — out of scope here; needs editor settings persistence and a settings-workspace UI control. Happy to open a followup once you confirm that's still on the wishlist.

On all three platforms, the existing `filesystem.OpenFileBrowserToFolder` uses the OS default-handler command (`open` on darwin, `xdg-open` on linux, `cmd.exe /C start` on windows), which handles files and folders identically. So `OpenFileBrowserToFolder(path/to/kaiju.log)` opens the file in whichever application the user has associated with `.log`.

## Changes

- `src/engine/systems/logging/logger.go` — add exported `LogFilePath()` helper (sibling to the existing `LogFolderPath`) returning `{logs folder}/kaiju.log`. Rationale in the docstring: the path is stable for the lifetime of the process because rotation happens on startup via `renameOldLogFile`, not mid-run.
- `src/editor/global_interface/status_bar/status_bar.go` — extend `rightClickLogEntry` to include a new "Open log file" option alongside the existing "Copy to clipboard". New imports: `log/slog` (error logging on failure paths) and `kaijuengine.com/platform/filesystem`.

## Testing

- `go vet ./engine/systems/logging/ ./editor/global_interface/status_bar/` — clean.
- `go build ./engine/systems/logging/ ./editor/global_interface/status_bar/` — clean.
- `gofmt -l` — no diffs.
- Full-tree `go build ./...` fails locally on the MoltenVK / SoLoud linker step, but that's unrelated to this change (linker can't find the engine's native game libraries on my machine). Happy to iterate if CI surfaces anything.

## Screenshot

Not included — the change is a single additional entry in an existing `context_menu.Show(...)` list. Pre-PR the menu had one option ("Copy to clipboard"); post-PR it has two ("Copy to clipboard", "Open log file").

Closes #456

_This contribution was developed with AI assistance (Claude Code)._
