### PR TITLE
fix(css): use compound selector for primary button styles

### DIFF
--- a/src/engine/ui/markup/css/default.css
+++ b/src/engine/ui/markup/css/default.css
@@ -423,10 +423,10 @@ button:active, .button:active {
 	/* background-image: url("input_atlas.png");
 	background-position: 64px 0; */
 }
-button .primary, .button primary {
+button.primary, .button.primary {
 	background-color: #682A2D;
 }
-button .primary:hover, .button primary:hover {
+button.primary:hover, .button.primary:hover {
 	background-color: #881E1E;
 }
 /** Unconventional helpers **/


### PR DESCRIPTION
## Summary

Closes #703. The rule at `src/engine/ui/markup/css/default.css:426` is intended to style "a button that also has the `.primary` class", but it's written with a descendant combinator (space between `button` and `.primary`). In CSS, that instead matches `.primary` elements that are *inside* a button, which is not the intent.

As reported in the issue, the result is that the `:hover` rule on the descendant bleeds through to every button hover, so every button ends up red on hover rather than only the primary one.

## Fix

Use the compound-class form (no space between `button` and `.primary`):

```css
-button .primary, .button primary {
+button.primary, .button.primary {
    background-color: #682A2D;
}
-button .primary:hover, .button primary:hover {
+button.primary:hover, .button.primary:hover {
    background-color: #881E1E;
}
```

Also fixes the `.button primary` half of each pair, which was selecting an element with tag name `primary` inside `.button` (not what anyone wanted).

No other changes.

Closes #703
