### PR TITLE
Fix: reset search filter input after adding selected entity data

### DIFF
--- a/src/editor/editor_embedded_content/editor_content/editor/ui/workspace/stage_workspace.go.html
+++ b/src/editor/editor_embedded_content/editor_content/editor/ui/workspace/stage_workspace.go.html
@@ -377,7 +377,7 @@
 						</div>
 					</div>
 					<div><span>Add data, or </span><button class="pasteIcon" onclick="pasteEntityDataAsNew">&#xE14F;</button></div>
-					<input type="text" placeholder="Find entity data..." onchange="searchEntityData" />
+					<input id="entitySearchFilter" type="text" placeholder="Find entity data..." onchange="searchEntityData" />
 					<div id="entityDataList">
 						<div id="entityDataListTemplate" class="entityDataListEntry" onclick="addEntityData">Name...</div>
 					</div>

--- a/src/editor/editor_workspace/stage_workspace/stage_workspace_details_ui.go
+++ b/src/editor/editor_workspace/stage_workspace/stage_workspace_details_ui.go
@@ -365,10 +365,10 @@ func (dui *WorkspaceDetailsUI) searchEntityData(e *document.Element) {
 	defer tracing.NewRegion("WorkspaceDetailsUI.searchEntityData").End()
 	dui.entityDataList.UI.Show()
 	dui.entityDataListTemplate.UI.Hide()
-	q := strings.ToLower(e.UI.ToInput().Text())
+	filterText := strings.ToLower(e.UI.ToInput().Text())
 	for _, c := range dui.entityDataList.Children[1:] {
 		name := strings.ToLower(c.InnerLabel().Text())
-		if q != "" && strings.Contains(name, q) {
+		if filterText != "" && strings.Contains(name, filterText) {
 			c.UI.Show()
 		} else {
 			c.UI.Hide()
@@ -380,29 +380,33 @@ func (dui *WorkspaceDetailsUI) searchEntityData(e *document.Element) {
 func (dui *WorkspaceDetailsUI) addEntityData(e *document.Element) {
 	defer tracing.NewRegion("WorkspaceDetailsUI.addEntityData").End()
 	dui.addEntityDataBykey(e.InnerLabel().Text())
+	entitySearchFilter, ok := dui.workspace.Value().Doc.GetElementById("entitySearchFilter")
+	if ok {
+		entitySearchFilter.UI.ToInput().SetText("")
+	}
 }
 
 func (dui *WorkspaceDetailsUI) addEntityDataBykey(key string) (*entity_data_binding.EntityDataEntry, bool) {
 	defer tracing.NewRegion("WorkspaceDetailsUI.addEntityDataBykey").End()
-	w := dui.workspace.Value()
-	g, ok := w.ed.Project().EntityDataBinding(key)
+	stageWorkspace := dui.workspace.Value()
+	generatedType, ok := stageWorkspace.ed.Project().EntityDataBinding(key)
 	if !ok {
 		slog.Error("failed to locate the entity binding data", "key", key)
 		return nil, false
 	}
-	sel := w.stageView.Manager().Selection()
+	selectedStageEntity := stageWorkspace.stageView.Manager().Selection()
 	// TODO:  Multi-select stuff
-	target := sel[0]
-	de := w.attachEntityData(target, g)
-	dui.createDataBindingEntry(de, dui.boundEntityDataTemplate)
-	data_binding_renderer.ShowSpecific(de, weak.Make(w.Host), target)
+	target := selectedStageEntity[0]
+	entityDataEntry := stageWorkspace.attachEntityData(target, generatedType)
+	dui.createDataBindingEntry(entityDataEntry, dui.boundEntityDataTemplate)
+	data_binding_renderer.ShowSpecific(entityDataEntry, weak.Make(stageWorkspace.Host), target)
 	dui.entityDataList.UI.Hide()
-	w.ed.History().Add(&EntityDataAttachHistory{
+	stageWorkspace.ed.History().Add(&EntityDataAttachHistory{
 		DetailsWorkspace: dui,
 		Entity:           target,
-		Data:             de,
+		Data:             entityDataEntry,
 	})
-	return de, true
+	return entityDataEntry, true
 }
 
 func (dui *WorkspaceDetailsUI) createDataBindingEntry(g *entity_data_binding.EntityDataEntry, tpl *document.Element) {


### PR DESCRIPTION
In order to get access to the search field element I needed to invoke a weak pointer to `workspace`. However I don't feel that's the intended way to have access to another element inside an element action callback.
@BrentFarris 
Maybe you can direct me to a kaiju conventional way?

```go
entitySearchFilter, ok := dui.workspace.Value().Doc.GetElementById("entitySearchFilter")
if ok {
entitySearchFilter.UI.ToInput().SetText("")
}
```