### PR TITLE
Fix/#624/orthographic camera rotation

### DIFF
--- a/src/editor/editor_stage_manager/data_binding_renderer/camera_entity_data_renderer.go
+++ b/src/editor/editor_stage_manager/data_binding_renderer/camera_entity_data_renderer.go
@@ -76,7 +76,20 @@ func (c *CameraEntityDataRenderer) Attached(host *engine.Host, manager *editor_s
 		slog.Error("there is an internal error in state for the editor's CameraEntityDataRenderer, show was called before any hide happened. Double selected the same target?")
 		c.Detatched(host, manager, target, data)
 	}
-	w, h := float32(host.Window.Width()), float32(host.Window.Height())
+	// w, h := float32(host.Window.Width()), float32(host.Window.Height())
+	var w, h float32 = 0.1, 0.1
+	if val := data.FieldValueByName("Width"); val != nil {
+		if f, ok := val.(float32); ok && f > 0 {
+			w = f
+		}
+	}
+
+	if val := data.FieldValueByName("Height"); val != nil {
+		if f, ok := val.(float32); ok && f > 0 {
+			h = f
+		}
+	}
+
 	camType := data.FieldValueByName("Type").(int)
 
 	identity := matrix.Mat4Identity()
@@ -98,6 +111,7 @@ func (c *CameraEntityDataRenderer) Attached(host *engine.Host, manager *editor_s
 		Transform:  &target.Transform,
 		ViewCuller: &host.Cameras.Primary,
 	})
+	arrowSd.Deactivate()
 
 	var cam cameras.Camera
 	switch engine_entity_data_camera.CameraType(camType) {
@@ -159,6 +173,7 @@ func (c *CameraEntityDataRenderer) Detatched(host *engine.Host, manager *editor_
 	if d, ok := c.Frustums[target]; ok {
 		d.sd.Destroy()
 		d.icon.Destroy()
+		d.arrowSd.Destroy()
 		host.MeshCache().RemoveMesh(d.key)
 		delete(c.Frustums, target)
 	}
@@ -168,6 +183,7 @@ func (c *CameraEntityDataRenderer) Show(host *engine.Host, target *editor_stage_
 	defer tracing.NewRegion("CameraEntityDataRenderer.Show").End()
 	if d, ok := c.Frustums[target]; ok {
 		d.sd.Activate()
+		d.arrowSd.Activate()
 	}
 }
 
@@ -175,6 +191,7 @@ func (c *CameraEntityDataRenderer) Hide(host *engine.Host, target *editor_stage_
 	defer tracing.NewRegion("CameraEntityDataRenderer.Hide").End()
 	if d, ok := c.Frustums[target]; ok {
 		d.sd.Deactivate()
+		d.arrowSd.Deactivate()
 	}
 }
 
@@ -183,10 +200,13 @@ func (c *CameraEntityDataRenderer) Update(host *engine.Host, target *editor_stag
 		w := float32(data.FieldValueByName("Width").(float32))
 		h := float32(data.FieldValueByName("Height").(float32))
 		if w <= 0 {
-			w = float32(host.Window.Width())
+			w = 0.1
 		}
 		if h <= 0 {
-			h = float32(host.Window.Height())
+			h = 0.1
+		}
+		if w == 0 || h == 0 {
+			slog.Warn("camera width or height is zero , might cause problem", "width", w, "height", h)
 		}
 		var cam cameras.Camera
 		camType := engine_entity_data_camera.CameraType(data.FieldValueByName("Type").(int))

--- a/src/editor/editor_stage_manager/data_binding_renderer/camera_entity_data_renderer.go
+++ b/src/editor/editor_stage_manager/data_binding_renderer/camera_entity_data_renderer.go
@@ -52,6 +52,15 @@ import (
 	"kaijuengine.com/rendering"
 )
 
+const (
+	minimumCameraWidth          = 0.1
+	minimumCameraHeight         = 0.1
+	translationGizmoShaftHeight = 1.5
+	translationGizmoShaftRadius = 0.025
+	translationGizmoArrowHeight = 0.35
+	translationGizmoArrowRadius = 0.175
+)
+
 func init() {
 	AddRenderer(engine_entity_data_camera.BindingKey(), &CameraEntityDataRenderer{
 		Frustums: make(map[*editor_stage_manager.StageEntity]cameraDataBindingDrawing),
@@ -76,33 +85,38 @@ func (c *CameraEntityDataRenderer) Attached(host *engine.Host, manager *editor_s
 		slog.Error("there is an internal error in state for the editor's CameraEntityDataRenderer, show was called before any hide happened. Double selected the same target?")
 		c.Detatched(host, manager, target, data)
 	}
-	// w, h := float32(host.Window.Width()), float32(host.Window.Height())
-	var w, h float32 = 0.1, 0.1
+
+	var w, h float32 = minimumCameraWidth, minimumCameraHeight
 	if val := data.FieldValueByName("Width"); val != nil {
-		if f, ok := val.(float32); ok && f > 0 {
+		if f, ok := val.(float32); ok && f >= minimumCameraWidth {
 			w = f
 		}
 	}
 
 	if val := data.FieldValueByName("Height"); val != nil {
-		if f, ok := val.(float32); ok && f > 0 {
+		if f, ok := val.(float32); ok && f > minimumCameraHeight {
 			h = f
 		}
 	}
 
-	camType := data.FieldValueByName("Type").(int)
+	var camType int = 0
+	if val := data.FieldValueByName("Type"); val != nil {
+		if f, ok := val.(int); ok && f >= 0 {
+			camType = f
+		}
+	}
 
 	identity := matrix.Mat4Identity()
 	identity.Rotate(matrix.NewVec3(90, 0, 0))
 
 	//* key name generation log needs to be confirmed
 	m := rendering.NewMeshArrowWithTransform(host.MeshCache(),
-		1.5, 0.0125,
-		0.35, 0.175, 10, identity, fmt.Sprintf("%s", target.Name()))
+		translationGizmoShaftHeight, translationGizmoShaftRadius,
+		translationGizmoArrowHeight, translationGizmoArrowRadius, 10, identity, fmt.Sprintf("%s", target.Name()))
 
 	mat, _ := host.MaterialCache().Material("gizmo_overlay.material")
 	arrowSd := shader_data_registry.Create("unlit").(*shader_data_registry.ShaderDataUnlit)
-	arrowSd.Color = matrix.ColorYellow()
+	arrowSd.Color = matrix.ColorCadetBlue()
 
 	host.Drawings.AddDrawing(rendering.Drawing{
 		Material:   mat,
@@ -197,15 +211,17 @@ func (c *CameraEntityDataRenderer) Hide(host *engine.Host, target *editor_stage_
 
 func (c *CameraEntityDataRenderer) Update(host *engine.Host, target *editor_stage_manager.StageEntity, data *entity_data_binding.EntityDataEntry) {
 	if t, ok := c.Frustums[target]; ok {
-		w := float32(data.FieldValueByName("Width").(float32))
-		h := float32(data.FieldValueByName("Height").(float32))
-		if w <= 0 {
-			w = 0.1
+		// Assumption: width and height field will be present on the cameraEntityData
+		w := data.FieldValueByName("Width").(float32)
+		h := data.FieldValueByName("Height").(float32)
+
+		if w < minimumCameraWidth {
+			w = minimumCameraWidth
 		}
-		if h <= 0 {
-			h = 0.1
+		if h < minimumCameraHeight {
+			h = minimumCameraHeight
 		}
-		if w == 0 || h == 0 {
+		if w <= 0 || h <= 0 {
 			slog.Warn("camera width or height is zero , might cause problem", "width", w, "height", h)
 		}
 		var cam cameras.Camera

--- a/src/editor/editor_stage_manager/data_binding_renderer/camera_entity_data_renderer.go
+++ b/src/editor/editor_stage_manager/data_binding_renderer/camera_entity_data_renderer.go
@@ -62,9 +62,10 @@ type CameraEntityDataRenderer struct {
 }
 
 type cameraDataBindingDrawing struct {
-	key  string
-	sd   rendering.DrawInstance
-	icon rendering.DrawInstance
+	key     string
+	sd      rendering.DrawInstance
+	icon    rendering.DrawInstance
+	arrowSd rendering.DrawInstance
 }
 
 func (c *CameraEntityDataRenderer) Attached(host *engine.Host, manager *editor_stage_manager.StageManager, target *editor_stage_manager.StageEntity, data *entity_data_binding.EntityDataEntry) {
@@ -75,7 +76,43 @@ func (c *CameraEntityDataRenderer) Attached(host *engine.Host, manager *editor_s
 		c.Detatched(host, manager, target, data)
 	}
 	w, h := float32(host.Window.Width()), float32(host.Window.Height())
-	cam := cameras.NewStandardCamera(w, h, w, h, target.Transform.Position())
+	var camType int
+	for _, val := range data.Fields {
+		if val.Name == "Type" {
+			camType = val.Value.(int)
+			break
+		}
+	}
+
+	m := rendering.NewMeshArrow(host.MeshCache(),
+		1.5, 0.0125,
+		0.35, 0.175, 10)
+	mat, _ := host.MaterialCache().Material("gizmo_overlay.material")
+	arrowSd := shader_data_registry.Create("unlit").(*shader_data_registry.ShaderDataUnlit)
+	arrowSd.Color = matrix.ColorYellow()
+	// slog.Info("transforms", arrowSd.Transform())
+	// arrowSd.Transform().AddRotation(matrix.NewVec3(90, 0, 0))
+
+	host.Drawings.AddDrawing(rendering.Drawing{
+		Material:   mat,
+		Mesh:       m,
+		ShaderData: arrowSd,
+		Transform:  &target.Transform,
+		ViewCuller: &host.Cameras.Primary,
+	})
+
+	var cam cameras.Camera
+	switch engine_entity_data_camera.CameraType(camType) {
+	case engine_entity_data_camera.CameraTypeOrthographic:
+		cam = cameras.NewStandardCameraOrthographic(w, h, w, h, target.Transform.Position())
+	case engine_entity_data_camera.CameraTypeTurntable:
+		cam = cameras.ToTurntable(cameras.NewStandardCamera(w, h, w, h, target.Transform.Position()))
+	case engine_entity_data_camera.CameraTypePerspective:
+		fallthrough
+	default:
+		cam = cameras.NewStandardCamera(w, h, w, h, target.Transform.Position())
+	}
+
 	cam.SetProperties(
 		data.FieldValueByName("FOV").(float32),
 		data.FieldValueByName("NearPlane").(float32),
@@ -99,16 +136,18 @@ func (c *CameraEntityDataRenderer) Attached(host *engine.Host, manager *editor_s
 		ViewCuller: &host.Cameras.Primary,
 	})
 	sd.Deactivate()
-	c.Frustums[target] = cameraDataBindingDrawing{frustum.Key(), sd, icon}
+	c.Frustums[target] = cameraDataBindingDrawing{frustum.Key(), sd, icon, arrowSd}
 	target.OnActivate.Add(func() {
 		if d, ok := c.Frustums[target]; ok {
 			d.icon.Activate()
 			d.sd.Activate()
+			d.arrowSd.Activate()
 		}
 	})
 	target.OnDeactivate.Add(func() {
 		if d, ok := c.Frustums[target]; ok {
 			d.icon.Deactivate()
+			d.arrowSd.Deactivate()
 			d.sd.Deactivate()
 		}
 	})

--- a/src/editor/editor_stage_manager/data_binding_renderer/camera_entity_data_renderer.go
+++ b/src/editor/editor_stage_manager/data_binding_renderer/camera_entity_data_renderer.go
@@ -37,6 +37,7 @@
 package data_binding_renderer
 
 import (
+	"fmt"
 	"log/slog"
 
 	"kaijuengine.com/editor/codegen/entity_data_binding"
@@ -76,22 +77,19 @@ func (c *CameraEntityDataRenderer) Attached(host *engine.Host, manager *editor_s
 		c.Detatched(host, manager, target, data)
 	}
 	w, h := float32(host.Window.Width()), float32(host.Window.Height())
-	var camType int
-	for _, val := range data.Fields {
-		if val.Name == "Type" {
-			camType = val.Value.(int)
-			break
-		}
-	}
+	camType := data.FieldValueByName("Type").(int)
 
-	m := rendering.NewMeshArrow(host.MeshCache(),
+	identity := matrix.Mat4Identity()
+	identity.Rotate(matrix.NewVec3(90, 0, 0))
+
+	//* key name generation log needs to be confirmed
+	m := rendering.NewMeshArrowWithTransform(host.MeshCache(),
 		1.5, 0.0125,
-		0.35, 0.175, 10)
+		0.35, 0.175, 10, identity, fmt.Sprintf("%s", target.Name()))
+
 	mat, _ := host.MaterialCache().Material("gizmo_overlay.material")
 	arrowSd := shader_data_registry.Create("unlit").(*shader_data_registry.ShaderDataUnlit)
 	arrowSd.Color = matrix.ColorYellow()
-	// slog.Info("transforms", arrowSd.Transform())
-	// arrowSd.Transform().AddRotation(matrix.NewVec3(90, 0, 0))
 
 	host.Drawings.AddDrawing(rendering.Drawing{
 		Material:   mat,

--- a/src/rendering/mesh.go
+++ b/src/rendering/mesh.go
@@ -1255,12 +1255,12 @@ func NewMeshCone(cache *MeshCache, height, baseRadius float32, segments int, cap
 	return cache.Mesh(key, verts, indices)
 }
 
-func NewMeshArrow(cache *MeshCache, shaftLength, shaftRadius, tipHeight, tipRadius float32, segments int) *Mesh {
+func NewMeshArrowWithTransform(cache *MeshCache, shaftLength, shaftRadius, tipHeight, tipRadius float32, segments int, transform matrix.Mat4, uid string) *Mesh {
 	defer tracing.NewRegion("rendering.NewMeshArrow").End()
 	if segments < 3 {
 		segments = 3
 	}
-	key := fmt.Sprintf("arrow_%.2f_%.2f_%.2f_%.2f_%d", shaftLength, shaftRadius, tipHeight, tipRadius, segments)
+	key := fmt.Sprintf("arrow_%.2f_%.2f_%.2f_%.2f_%d_%s", shaftLength, shaftRadius, tipHeight, tipRadius, segments, uid)
 	if mesh, ok := cache.FindMesh(key); ok {
 		return mesh
 	}
@@ -1273,6 +1273,11 @@ func NewMeshArrow(cache *MeshCache, shaftLength, shaftRadius, tipHeight, tipRadi
 		tipVerts[i].Position[matrix.Vy] += shaftLength
 	}
 	verts := append(shaftVerts, tipVerts...)
+
+	for i := range verts {
+		verts[i].Position = matrix.Mat4MultiplyVec4(transform, verts[i].Position.AsVec4()).AsVec3()
+	}
+
 	indices := make([]uint32, 0, len(shaftIndices)+len(tipIndices))
 	indices = append(indices, shaftIndices...)
 	offset := uint32(len(shaftVerts))
@@ -1280,6 +1285,11 @@ func NewMeshArrow(cache *MeshCache, shaftLength, shaftRadius, tipHeight, tipRadi
 		indices = append(indices, tipIndices[i]+offset)
 	}
 	return cache.Mesh(key, verts, indices)
+}
+
+func NewMeshArrow(cache *MeshCache, shaftLength, shaftRadius, tipHeight, tipRadius float32, segments int) *Mesh {
+	return NewMeshArrowWithTransform(cache, shaftLength, shaftRadius,
+		tipHeight, tipRadius, segments, matrix.Mat4Identity(), "")
 }
 
 func meshCylinder(height, radius float32, segments int, capped bool) ([]Vertex, []uint32) {


### PR DESCRIPTION
with reference to: #624 

There was no problem with orthographic camera as discussed in the issue, but needed visual indication.

Added Arrow to show the camera looking direction
Fixed frustum rendering logic for orthogonal cameras with width and height == 0


<img width="667" height="467" alt="Screenshot 2026-04-19 at 7 28 20 PM" src="https://github.com/user-attachments/assets/d187dec7-419f-4ef5-b646-6500455c8ebe" />
