### PR TITLE
feat(screen count): implement screen count on windows

### DIFF
--- a/src/platform/windowing/cocoa_window.h
+++ b/src/platform/windowing/cocoa_window.h
@@ -27,6 +27,8 @@ int cocoa_get_screen_pixel_height(void* nsWindow);
 // Get backing scale factor
 double cocoa_get_backing_scale_factor(void* nsWindow);
 
+int cocoa_screen_count(void* nsWindow);
+
 // Window position and size
 void cocoa_get_position(void* nsWindow, int* x, int* y);
 void cocoa_set_position(void* nsWindow, int x, int y);

--- a/src/platform/windowing/cocoa_window.m
+++ b/src/platform/windowing/cocoa_window.m
@@ -476,6 +476,11 @@ double cocoa_get_backing_scale_factor(void* nsWindow) {
 	return result;
 }
 
+int cocoa_screen_count(void* nsWindow) {
+	(void)nsWindow;
+	return 1; // TODO
+}
+
 void cocoa_get_position(void* nsWindow, int* x, int* y) {
 	if (!nsWindow) return;
 
@@ -625,14 +630,14 @@ void cocoa_get_bundle_resource_path(const char* resourceName, void** outPath) {
 	@autoreleasepool {
 		NSString* name = [NSString stringWithUTF8String:resourceName];
 		NSString* path = [[NSBundle mainBundle] pathForResource:name ofType:nil];
-		
+
 		if (path == nil) {
 			// Try with extension separated
 			NSString* extension = [name pathExtension];
 			NSString* basename = [name stringByDeletingPathExtension];
 			path = [[NSBundle mainBundle] pathForResource:basename ofType:extension];
 		}
-		
+
 		if (path != nil) {
 			*outPath = (void*)strdup([path UTF8String]);
 		} else {
@@ -649,7 +654,7 @@ void cocoa_remove_border(void* nsWindow) {
 			NSWindow* window = (__bridge NSWindow*)(nsWindow);
 			NSWindowStyleMask styleMask = [window styleMask];
 			// Remove title bar and border decorations
-			styleMask &= ~(NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | 
+			styleMask &= ~(NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
 						   NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable);
 			styleMask |= NSWindowStyleMaskBorderless;
 			[window setStyleMask:styleMask];
@@ -666,7 +671,7 @@ void cocoa_add_border(void* nsWindow) {
 			NSWindowStyleMask styleMask = [window styleMask];
 			// Add title bar and border decorations
 			styleMask &= ~NSWindowStyleMaskBorderless;
-			styleMask |= (NSWindowStyleMaskTitled | NSWindowStyleMaskClosable | 
+			styleMask |= (NSWindowStyleMaskTitled | NSWindowStyleMaskClosable |
 						  NSWindowStyleMaskMiniaturizable | NSWindowStyleMaskResizable);
 			[window setStyleMask:styleMask];
 		}

--- a/src/platform/windowing/win32.c
+++ b/src/platform/windowing/win32.c
@@ -842,6 +842,11 @@ float window_dpi(void* hwnd) {
 	return ((float)GetDpiForWindow(hwnd));
 }
 
+int screen_count(void* hwnd) {
+	(void)hwnd;
+	return GetSystemMetrics(SM_CMONITORS);
+}
+
 int screen_width_mm(void* hwnd) {
     HDC hdc = GetDC(hwnd);
     if (hdc == NULL) {

--- a/src/platform/windowing/win32.h
+++ b/src/platform/windowing/win32.h
@@ -57,6 +57,7 @@ void window_cursor_size_we(void* hwnd);
 float window_dpi(void* hwnd);
 int screen_width_mm(void* hwnd);
 int screen_height_mm(void* hwnd);
+int screen_count(void* hwnd);
 void window_focus(void* hwnd);
 void window_position(void* hwnd, int* x, int* y);
 void window_set_position(void* hwnd, int x, int y);

--- a/src/platform/windowing/window.darwin.go
+++ b/src/platform/windowing/window.darwin.go
@@ -187,6 +187,10 @@ func (w *Window) screenSizeMM() (int, int, error) {
 
 func (w *Window) invalidateMonitorCache() {}
 
+func (w *Window) monitorCount() int {
+	return int(C.cocoa_screen_count(w.instance))
+}
+
 func (w *Window) dotsPerMillimeter() float64 {
 	if w.instance == nil {
 		return 0

--- a/src/platform/windowing/window.go
+++ b/src/platform/windowing/window.go
@@ -261,6 +261,15 @@ func (w *Window) DotsPerMillimeter() float64 {
 	return w.dotsPerMillimeter()
 }
 
+// NOTE: currently only implemented on windows
+func (w *Window) MonitorCount() int {
+	count := w.monitorCount()
+	if count < 1 {
+		return 1
+	}
+	return count
+}
+
 func (w *Window) SizeMM() (int, int, error) {
 	return w.sizeMM()
 }

--- a/src/platform/windowing/window.x11.go
+++ b/src/platform/windowing/window.x11.go
@@ -69,6 +69,7 @@ package windowing
 #cgo noescape window_set_cursor_position
 #cgo noescape window_set_icon
 #cgo noescape window_invalidate_monitor_cache
+#cgo noescape screen_count
 
 #include <stdlib.h>
 #include "windowing.h"
@@ -192,6 +193,10 @@ func (w *Window) hideCursor() {
 
 func (w *Window) invalidateMonitorCache() {
 	C.window_invalidate_monitor_cache(w.handle)
+}
+
+func (w *Window) monitorCount() int {
+	return int(C.screen_count(w.handle))
 }
 
 func (w *Window) dotsPerMillimeter() float64 {

--- a/src/platform/windowing/window_android.go
+++ b/src/platform/windowing/window_android.go
@@ -113,6 +113,10 @@ func (w *Window) clipboardContents() string {
 
 func (w *Window) invalidateMonitorCache() {}
 
+func (w *Window) monitorCount() int {
+	return 1
+}
+
 func (w *Window) dotsPerMillimeter() float64 {
 	wmm, hmm, err := w.screenSizeMM()
 	if err != nil || wmm == 0 || hmm == 0 {

--- a/src/platform/windowing/window_windows.go
+++ b/src/platform/windowing/window_windows.go
@@ -60,6 +60,7 @@ import (
 #cgo noescape window_dpi
 #cgo noescape screen_width_mm
 #cgo noescape screen_height_mm
+#cgo noescape screen_count
 #cgo noescape window_focus
 #cgo noescape window_position
 #cgo noescape window_set_position
@@ -167,6 +168,10 @@ func (w *Window) invalidateMonitorCache() {}
 func (w *Window) dotsPerMillimeter() float64 {
 	dpi := float64(C.window_dpi(w.handle))
 	return dpi / 25.4
+}
+
+func (w *Window) monitorCount() int {
+	return int(C.screen_count(w.handle))
 }
 
 func (w *Window) sizeMM() (int, int, error) {

--- a/src/platform/windowing/x11.c
+++ b/src/platform/windowing/x11.c
@@ -639,6 +639,11 @@ int window_height_mm(void* state) {
 	return XDisplayHeightMM(s->d, sid);
 }
 
+int screen_count(void* state) {
+	(void)state;
+	return 1; // TODO
+}
+
 void window_cursor_standard(void* state) {
 	X11State* s = state;
 	Cursor c = XcursorLibraryLoadCursor(s->d, "arrow");
@@ -782,7 +787,7 @@ void window_set_windowed(void* state, int width, int height) {
     ev.data.l[1] = XInternAtom(s->d, "_NET_WM_STATE_FULLSCREEN", False);
     ev.data.l[2] = 0;
     ev.data.l[3] = 1;
-    XSendEvent(s->d, DefaultRootWindow(s->d), False, 
+    XSendEvent(s->d, DefaultRootWindow(s->d), False,
                SubstructureRedirectMask | SubstructureNotifyMask, (XEvent*)&ev);
     XWindowChanges changes;
     changes.x = s->sm.savedState.rect.left;
@@ -834,7 +839,7 @@ void window_set_icon(void* state, int width, int height, const unsigned char* rg
 		unsigned char a = rgba[i * 4 + 3];
 		iconData[2 + i] = ((unsigned long)a << 24) | ((unsigned long)b << 16) | ((unsigned long)g << 8) | r;
 	}
-	XChangeProperty(s->d, s->w, netWmIcon, XA_CARDINAL, 32, PropModeReplace, 
+	XChangeProperty(s->d, s->w, netWmIcon, XA_CARDINAL, 32, PropModeReplace,
 		(unsigned char*)iconData, dataLen);
 	XFlush(s->d);
 	free(iconData);

--- a/src/platform/windowing/x11.h
+++ b/src/platform/windowing/x11.h
@@ -107,6 +107,7 @@ void window_set_position(void* state, int x, int y);
 void window_set_size(void* state, int width, int height);
 int window_width_mm(void* state);
 int window_height_mm(void* state);
+int screen_count(void* state);
 void window_invalidate_monitor_cache(void* state);
 void window_cursor_standard(void* state);
 void window_cursor_ibeam(void* state);


### PR DESCRIPTION
pr summary:
- exposes screen count on windows
- other platforms have placeholders and always return `1`
- limitation is documented in comment of `MonitorCount()` comment

NOTE: this is intended as a pr before introducing multi-monitor positioning