### PR TITLE
feat(css-units): add css units

### DIFF
--- a/src/engine/ui/markup/css/helpers/numbers.go
+++ b/src/engine/ui/markup/css/helpers/numbers.go
@@ -46,6 +46,8 @@ import (
 
 type WindowDimensions interface {
 	DotsPerMillimeter() float64
+	Width() int
+	Height() int
 }
 
 var arithmeticMap = map[string]func(int, int) int{
@@ -95,19 +97,38 @@ func ArithmeticString(args []string) (int, error) {
 func NumFromLengthWithFont(str string, window WindowDimensions, fontSize float32) float32 {
 	dpmm := window.DotsPerMillimeter()
 	var suffix string
-	if str[len(str)-1] == '%' {
+	switch {
+	case strings.HasSuffix(str, "vmin"):
+		suffix = "vmin"
+		str = str[:len(str)-4]
+	case strings.HasSuffix(str, "vmax"):
+		suffix = "vmax"
+		str = str[:len(str)-4]
+	case strings.HasSuffix(str, "rem"):
+		suffix = "rem"
+		str = str[:len(str)-3]
+	case strings.HasSuffix(str, "vw"):
+		suffix = "vw"
+		str = str[:len(str)-2]
+	case strings.HasSuffix(str, "vh"):
+		suffix = "vh"
+		str = str[:len(str)-2]
+	case strings.HasSuffix(str, "ch"):
+		suffix = "ch"
+		str = str[:len(str)-2]
+	case strings.HasSuffix(str, "px"),
+		strings.HasSuffix(str, "em"),
+		strings.HasSuffix(str, "ex"),
+		strings.HasSuffix(str, "cm"),
+		strings.HasSuffix(str, "mm"),
+		strings.HasSuffix(str, "in"),
+		strings.HasSuffix(str, "pt"),
+		strings.HasSuffix(str, "pc"):
+		suffix = str[len(str)-2:]
+		str = str[:len(str)-2]
+	case strings.HasSuffix(str, "%"):
 		suffix = "%"
 		str = str[:len(str)-1]
-	} else if len(str) > 2 {
-		validSuffixes := []string{"px", "em", "ex", "cm", "mm", "in", "pt", "pc"}
-		valid := false
-		for i := range validSuffixes {
-			valid = valid || strings.HasSuffix(str, validSuffixes[i])
-		}
-		if valid {
-			suffix = str[len(str)-2:]
-			str = str[:len(str)-2]
-		}
 	}
 	var size float32
 	fmt.Sscanf(str, "%f", &size)
@@ -121,6 +142,34 @@ func NumFromLengthWithFont(str string, window WindowDimensions, fontSize float32
 		fallthrough
 	case "em":
 		size = size * fontSize
+	case "rem":
+		// TODO:
+		// Root font size support is not yet wired through style inheritance.
+		// For now rem is based on the engine default root em size.
+		size = size * rendering.DefaultFontEMSize
+	case "ch":
+		// TODO:
+		// Approximation until font metric support is available:
+		// 1ch ~= 0.5em
+		size = size * fontSize * 0.5
+	case "vw":
+		size = float32(window.Width()) * (size / 100)
+	case "vh":
+		size = float32(window.Height()) * (size / 100)
+	case "vmin":
+		w := float32(window.Width())
+		h := float32(window.Height())
+		if h < w {
+			w = h
+		}
+		size = w * (size / 100)
+	case "vmax":
+		w := float32(window.Width())
+		h := float32(window.Height())
+		if h > w {
+			w = h
+		}
+		size = w * (size / 100)
 	case "cm":
 		size = float32(dpmm) * float32(size*10)
 	case "mm":
@@ -137,6 +186,8 @@ func NumFromLengthWithFont(str string, window WindowDimensions, fontSize float32
 	return size
 }
 
+// NumFromLength resolves CSS lengths with the default font size context.
+// For properties that depend on the current element font, use NumFromLengthWithFont.
 func NumFromLength(str string, window WindowDimensions) float32 {
 	return NumFromLengthWithFont(str, window, rendering.DefaultFontEMSize)
 }

--- a/src/engine/ui/markup/css/helpers/numbers.go
+++ b/src/engine/ui/markup/css/helpers/numbers.go
@@ -96,26 +96,44 @@ func ArithmeticString(args []string) (int, error) {
 
 func NumFromLengthWithFont(str string, window WindowDimensions, fontSize float32) float32 {
 	dpmm := window.DotsPerMillimeter()
-	var suffix string
+	parse := func(raw string, cut int) float32 {
+		var v float32
+		fmt.Sscanf(raw[:len(raw)-cut], "%f", &v)
+		return v
+	}
 	switch {
 	case strings.HasSuffix(str, "vmin"):
-		suffix = "vmin"
-		str = str[:len(str)-4]
+		size := parse(str, 4)
+		w := float32(window.Width())
+		h := float32(window.Height())
+		if h < w {
+			w = h
+		}
+		return w * (size / 100)
 	case strings.HasSuffix(str, "vmax"):
-		suffix = "vmax"
-		str = str[:len(str)-4]
+		size := parse(str, 4)
+		w := float32(window.Width())
+		h := float32(window.Height())
+		if h > w {
+			w = h
+		}
+		return w * (size / 100)
 	case strings.HasSuffix(str, "rem"):
-		suffix = "rem"
-		str = str[:len(str)-3]
+		size := parse(str, 3)
+		// Root font size support is not yet wired through style inheritance.
+		// For now rem is based on the engine default root em size.
+		return size * rendering.DefaultFontEMSize
 	case strings.HasSuffix(str, "vw"):
-		suffix = "vw"
-		str = str[:len(str)-2]
+		size := parse(str, 2)
+		return float32(window.Width()) * (size / 100)
 	case strings.HasSuffix(str, "vh"):
-		suffix = "vh"
-		str = str[:len(str)-2]
+		size := parse(str, 2)
+		return float32(window.Height()) * (size / 100)
 	case strings.HasSuffix(str, "ch"):
-		suffix = "ch"
-		str = str[:len(str)-2]
+		size := parse(str, 2)
+		// Approximation until font metric support is available:
+		// 1ch ~= 0.5em
+		return size * fontSize * 0.5
 	case strings.HasSuffix(str, "px"),
 		strings.HasSuffix(str, "em"),
 		strings.HasSuffix(str, "ex"),
@@ -124,66 +142,28 @@ func NumFromLengthWithFont(str string, window WindowDimensions, fontSize float32
 		strings.HasSuffix(str, "in"),
 		strings.HasSuffix(str, "pt"),
 		strings.HasSuffix(str, "pc"):
-		suffix = str[len(str)-2:]
-		str = str[:len(str)-2]
+		size := parse(str, 2)
+		switch str[len(str)-2:] {
+		case "px":
+			return size
+		case "em", "ex":
+			return size * fontSize
+		case "cm":
+			return float32(dpmm) * float32(size*10)
+		case "mm":
+			return float32(dpmm) * size
+		case "in":
+			return float32(dpmm) * float32(size*25.4)
+		case "pt":
+			return float32(dpmm) * float32(size*25.4/72)
+		case "pc":
+			return float32(dpmm) * float32(size*25.4/6)
+		}
 	case strings.HasSuffix(str, "%"):
-		suffix = "%"
-		str = str[:len(str)-1]
+		size := parse(str, 1)
+		return size / 100
 	}
-	var size float32
-	fmt.Sscanf(str, "%f", &size)
-	switch suffix {
-	case "%":
-		size = size / 100
-	case "px":
-		// Read value is the size
-	case "ex":
-		// Relative to the font size of a lowercase letter like a, c, m, or o
-		fallthrough
-	case "em":
-		size = size * fontSize
-	case "rem":
-		// TODO:
-		// Root font size support is not yet wired through style inheritance.
-		// For now rem is based on the engine default root em size.
-		size = size * rendering.DefaultFontEMSize
-	case "ch":
-		// TODO:
-		// Approximation until font metric support is available:
-		// 1ch ~= 0.5em
-		size = size * fontSize * 0.5
-	case "vw":
-		size = float32(window.Width()) * (size / 100)
-	case "vh":
-		size = float32(window.Height()) * (size / 100)
-	case "vmin":
-		w := float32(window.Width())
-		h := float32(window.Height())
-		if h < w {
-			w = h
-		}
-		size = w * (size / 100)
-	case "vmax":
-		w := float32(window.Width())
-		h := float32(window.Height())
-		if h > w {
-			w = h
-		}
-		size = w * (size / 100)
-	case "cm":
-		size = float32(dpmm) * float32(size*10)
-	case "mm":
-		size = float32(dpmm) * float32(size)
-	case "in":
-		size = float32(dpmm) * float32(size*25.4)
-	case "pt":
-		size = float32(dpmm) * float32(size*25.4/72)
-	case "pc":
-		size = float32(dpmm) * float32(size*25.4/6)
-	default:
-		size = 0
-	}
-	return size
+	return 0
 }
 
 // NumFromLength resolves CSS lengths with the default font size context.

--- a/src/engine/ui/markup/css/helpers/numbers.go
+++ b/src/engine/ui/markup/css/helpers/numbers.go
@@ -38,6 +38,7 @@ package helpers
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"strings"
 
@@ -99,6 +100,9 @@ func NumFromLengthWithFont(str string, window WindowDimensions, fontSize float32
 	parse := func(raw string, cut int) float32 {
 		var v float32
 		fmt.Sscanf(raw[:len(raw)-cut], "%f", &v)
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			return 0
+		}
 		return v
 	}
 	switch {

--- a/src/engine/ui/markup/css/helpers/numbers_test.go
+++ b/src/engine/ui/markup/css/helpers/numbers_test.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"math"
 	"testing"
 
 	"kaijuengine.com/rendering"
@@ -59,5 +60,90 @@ func TestNumFromLength_DefaultFontContext(t *testing.T) {
 	want := float32(2) * rendering.DefaultFontEMSize
 	if got != want {
 		t.Fatalf("NumFromLength(%q) = %v, want %v", "2em", got, want)
+	}
+}
+
+func TestNumFromLengthWithFont_LeadingDecimalUnits(t *testing.T) {
+	w := testWindow{dpmm: 2, width: 1000, height: 500}
+	fontSize := float32(20)
+
+	tests := []struct {
+		name string
+		in   string
+		want float32
+	}{
+		{name: "vw", in: ".2vw", want: 2},
+		{name: "rem", in: ".2rem", want: 0.2 * rendering.DefaultFontEMSize},
+		{name: "ch", in: ".2ch", want: 2}, // 0.2 * (0.5 * 20)
+		{name: "cm", in: ".2cm", want: 4}, // 0.2 * 10mm * dpmm(2)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NumFromLengthWithFont(tt.in, w, fontSize)
+			if got != tt.want {
+				t.Fatalf("NumFromLengthWithFont(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNumFromLengthWithFont_GarbageOrIllFormattedInput(t *testing.T) {
+	w := testWindow{dpmm: 2, width: 1000, height: 500}
+	fontSize := float32(20)
+
+	tests := []struct {
+		name string
+		in   string
+		want float32
+	}{
+		{name: "empty string", in: "", want: 0},
+		{name: "only unit", in: "px", want: 0},
+		{name: "garbage text", in: "hello", want: 0},
+		{name: "unknown unit", in: "12abc", want: 0},
+		{name: "double percent", in: "50%%", want: 0.5},
+		{name: "space separated number unit", in: "10 px", want: 10},
+		{name: "mixed alpha and numeric", in: "1o0px", want: 1},
+		{name: "sign only", in: "-", want: 0},
+		{name: "dot only", in: ".", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("NumFromLengthWithFont(%q) panicked: %v", tt.in, r)
+				}
+			}()
+			got := NumFromLengthWithFont(tt.in, w, fontSize)
+			if got != tt.want {
+				t.Fatalf("NumFromLengthWithFont(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNumFromLengthWithFont_NonFiniteInput(t *testing.T) {
+	w := testWindow{dpmm: 2, width: 1000, height: 500}
+	fontSize := float32(20)
+
+	tests := []string{
+		"NaNpx",
+		"+Infpx",
+		"-Infpx",
+	}
+
+	for _, in := range tests {
+		t.Run(in, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("NumFromLengthWithFont(%q) panicked: %v", in, r)
+				}
+			}()
+			got := NumFromLengthWithFont(in, w, fontSize)
+			if math.IsNaN(float64(got)) || math.IsInf(float64(got), 0) {
+				t.Fatalf("NumFromLengthWithFont(%q) produced non-finite result: %v", in, got)
+			}
+		})
 	}
 }

--- a/src/engine/ui/markup/css/helpers/numbers_test.go
+++ b/src/engine/ui/markup/css/helpers/numbers_test.go
@@ -1,0 +1,63 @@
+package helpers
+
+import (
+	"testing"
+
+	"kaijuengine.com/rendering"
+)
+
+type testWindow struct {
+	dpmm   float64
+	width  int
+	height int
+}
+
+func (w testWindow) DotsPerMillimeter() float64 { return w.dpmm }
+func (w testWindow) Width() int                 { return w.width }
+func (w testWindow) Height() int                { return w.height }
+
+func TestNumFromLengthWithFont_Units(t *testing.T) {
+	w := testWindow{dpmm: 2, width: 1000, height: 500}
+	fontSize := float32(20)
+
+	tests := []struct {
+		name string
+		in   string
+		want float32
+	}{
+		{name: "percent", in: "75%", want: 0.75},
+		{name: "px", in: "100px", want: 100},
+		{name: "em", in: "3em", want: 60},
+		{name: "ex", in: "6ex", want: 120},
+		{name: "cm", in: "4cm", want: 80},
+		{name: "mm", in: "40mm", want: 80},
+		{name: "in", in: "1.5in", want: 76.2},
+		{name: "pt", in: "72pt", want: 50.8},
+		{name: "pc", in: "6pc", want: 50.8},
+		{name: "rem", in: "2rem", want: 2 * rendering.DefaultFontEMSize},
+		{name: "vw", in: "30vw", want: 300},
+		{name: "vh", in: "10vh", want: 50},
+		{name: "vmin", in: "20vmin", want: 100},
+		{name: "vmax", in: "20vmax", want: 200},
+		{name: "ch", in: "20ch", want: 200}, // 20 * (0.5 * 20)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NumFromLengthWithFont(tt.in, w, fontSize)
+			if got != tt.want {
+				t.Fatalf("NumFromLengthWithFont(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNumFromLength_DefaultFontContext(t *testing.T) {
+	w := testWindow{dpmm: 2, width: 1000, height: 500}
+
+	got := NumFromLength("2em", w)
+	want := float32(2) * rendering.DefaultFontEMSize
+	if got != want {
+		t.Fatalf("NumFromLength(%q) = %v, want %v", "2em", got, want)
+	}
+}

--- a/src/engine/ui/markup/css/rules/parser_test.go
+++ b/src/engine/ui/markup/css/rules/parser_test.go
@@ -50,6 +50,8 @@ const testCSSVarInCalc = `:root { --ed-menu-bar-height: 24px; }
 type dummyWindow struct{}
 
 func (dummyWindow) DotsPerMillimeter() float64 { return 1 }
+func (dummyWindow) Width() int                 { return 0 }
+func (dummyWindow) Height() int                { return 0 }
 
 func TestParseNarrowTag(t *testing.T) {
 	s := NewStyleSheet()


### PR DESCRIPTION
pr summary:
- add missing css units
- use approximations based on current engine implementaion for `ch` and `rem`
- add tests to confirm correct units