### PR TITLE
feat(usability): add contrast in ui preview

### DIFF
--- a/src/editor/editor_embedded_content/editor_content/editor/ui/workspace/ui_workspace.go.html
+++ b/src/editor/editor_embedded_content/editor_content/editor/ui/workspace/ui_workspace.go.html
@@ -2,12 +2,16 @@
 <html>
 	<head>
 		<style>
+			body {
+				background-color: #1b1b1b;
+			}
 			#previewArea {
 				width: revert;
 				overflow: hidden;
 				left: 50%;
 				top: calc(50% - 12px);
 				transform: translate(-50% -50%);
+				background-color: #2c2c2c;
 			}
 			#previewHelp {
 				width: 100%;

--- a/src/editor/editor_embedded_content/editor_content/editor/ui/workspace/ui_workspace.go.html
+++ b/src/editor/editor_embedded_content/editor_content/editor/ui/workspace/ui_workspace.go.html
@@ -10,7 +10,7 @@
 				overflow: hidden;
 				left: 50%;
 				top: calc(50% - 12px);
-				transform: translate(-50% -50%);
+				transform: translate(-50%, -50%);
 				background-color: #2c2c2c;
 			}
 			#previewHelp {


### PR DESCRIPTION
pr summary:
- add contrast between background and ui preview-area
- add a missing ,

<img width="1270" height="721" alt="Screenshot 2026-04-30 001057" src="https://github.com/user-attachments/assets/cc3c4731-65de-4ca1-8be4-50bfe37bf4cc" />
