### PR TITLE
Add View > Show/Hide Grid Toggle to Editor Menu

### DIFF
--- a/src/.claude/settings.local.json
+++ b/src/.claude/settings.local.json
@@ -1,0 +1,8 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go build *)",
+      "Bash(echo \"build_exit=$?\")"
+    ]
+  }
+}

--- a/src/.claude/settings.local.json
+++ b/src/.claude/settings.local.json
@@ -1,8 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(go build *)",
-      "Bash(echo \"build_exit=$?\")"
-    ]
-  }
-}

--- a/src/editor/editor_embedded_content/editor_content/editor/ui/global/menu_bar.go.html
+++ b/src/editor/editor_embedded_content/editor_content/editor/ui/global/menu_bar.go.html
@@ -59,6 +59,7 @@
 			<span class="menuEntry" data-target="filePopup" onclick="clickFile">File</span>
 			<span class="menuEntry" data-target="editPopup" onclick="clickEdit">Edit</span>
 			<span class="menuEntry" data-target="createPopup" onclick="clickCreate">Create</span>
+			<span class="menuEntry" data-target="viewPopup" onclick="clickView">View</span>
 			<span class="menuEntry" data-target="helpPopup" onclick="clickHelp">Help</span>
 			<span id="tabStage" group="tabs" class="workspaceTab edPanelBgHoverable tabSelected" onclick="clickStage">Stage</span>
 			<span id="tabContent" group="tabs" class="workspaceTab edPanelBgHoverable" onclick="clickContent">Content</span>
@@ -107,6 +108,9 @@
 			<div class="popupEntry" onclick="clickNewCamera">Camera</div>
 			<div class="popupEntry" onclick="clickNewEntity">Entity</div>
 			<div class="popupEntry" onclick="clickNewLight">Light</div>
+		</div>
+		<div id="viewPopup" class="popup" onmiss="popupMiss">
+			<div id="gridToggleEntry" class="popupEntry" onclick="clickToggleGrid">{{if .ShowGrid}}Hide Grid{{else}}Show Grid{{end}}</div>
 		</div>
 		<div id="helpPopup" class="popup" onmiss="popupMiss">
 			<div class="popupEntry" onclick="clickSponsors">Sponsors</div>

--- a/src/editor/editor_menu_bar_handler.go
+++ b/src/editor/editor_menu_bar_handler.go
@@ -312,6 +312,21 @@ func (ed *Editor) CreateHtmlUiFile(name string) {
 	}
 }
 
+// SetGridVisible records the developer's preference for the editor viewport
+// grid, persists it to the global editor settings, and applies the change to
+// the live stage view if one is initialized.
+func (ed *Editor) SetGridVisible(visible bool) {
+	defer tracing.NewRegion("Editor.SetGridVisible").End()
+	if ed.settings.ShowGrid == visible {
+		return
+	}
+	ed.settings.ShowGrid = visible
+	if err := ed.settings.Save(); err != nil {
+		slog.Error("failed to save editor settings after grid toggle", "error", err)
+	}
+	ed.stageView.SetGridVisible(visible)
+}
+
 func (ed *Editor) CreateCssStylesheetFile(name string) {
 	sb := strings.Builder{}
 	sb.WriteString("/* ")

--- a/src/editor/editor_settings/editor_settings.go
+++ b/src/editor/editor_settings/editor_settings.go
@@ -61,6 +61,7 @@ type Settings struct {
 	MeshEditor     string
 	AudioEditor    string
 	UIScrollSpeed  float32 `default:"20" label:"UI Scroll Speed"`
+	ShowGrid       bool    `default:"false" label:"Show Viewport Grid"`
 	EditorCamera   EditorCameraSettings
 	Snapping       SnapSettings
 	BuildTools     BuildToolSettings
@@ -91,6 +92,7 @@ func (s *Settings) setDefaults() {
 	s.RefreshRate = 60
 	s.CodeEditor = "code"
 	s.UIScrollSpeed = 20
+	s.ShowGrid = false
 	s.EditorCamera.ZoomSpeed = 120
 	s.EditorCamera.FlySpeed = 10
 	s.EditorCamera.FlyXSensitivity = 0.2

--- a/src/editor/editor_stage_manager/editor_stage_view/editor_stage_view.go
+++ b/src/editor/editor_stage_manager/editor_stage_view/editor_stage_view.go
@@ -60,6 +60,7 @@ type StageView struct {
 	camera        editor_controls.EditorCamera
 	gridTransform matrix.Transform
 	gridShader    *shader_data_registry.ShaderDataGrid
+	gridVisible   bool
 	manager       editor_stage_manager.StageManager
 	transformTool transform_tools.TransformTool
 	selectTool    select_tool.SelectTool
@@ -80,11 +81,13 @@ func (v *StageView) Initialize(host *engine.Host, ed EditorStageViewWorkspaceInt
 	defer tracing.NewRegion("StageView.Initialize").End()
 	v.manager.Initialize(host, ed.History(), ed)
 	v.host = host
+	v.gridVisible = ed.Settings().ShowGrid
 	v.manager.NewStage()
 	v.transformTool.Initialize(host, v, ed.History(), &ed.Settings().Snapping)
 	v.transformMan.Initialize(v, ed.History(), &ed.Settings().Snapping)
 	v.selectTool.Init(host, &v.manager)
 	v.createViewportGrid()
+	v.applyGridVisibility()
 	v.setupCamera(ed)
 	// Data binding visualizers
 	weakHost := weak.Make(host)
@@ -98,12 +101,33 @@ func (v *StageView) Initialize(host *engine.Host, ed EditorStageViewWorkspaceInt
 
 func (v *StageView) Open() {
 	defer tracing.NewRegion("StageView.Open").End()
-	v.gridShader.Activate()
+	v.applyGridVisibility()
 }
 
 func (v *StageView) Close() {
 	defer tracing.NewRegion("StageView.Close").End()
 	v.gridShader.Deactivate()
+}
+
+// IsGridVisible returns whether the editor viewport grid is currently shown.
+func (v *StageView) IsGridVisible() bool { return v.gridVisible }
+
+// SetGridVisible toggles the editor viewport grid. The change is applied
+// immediately to the live drawing; persistence is the caller's responsibility.
+func (v *StageView) SetGridVisible(visible bool) {
+	v.gridVisible = visible
+	v.applyGridVisibility()
+}
+
+func (v *StageView) applyGridVisibility() {
+	if v.gridShader == nil {
+		return
+	}
+	if v.gridVisible {
+		v.gridShader.Activate()
+	} else {
+		v.gridShader.Deactivate()
+	}
 }
 
 // Update will update the stage view and return `true` if the view is taking

--- a/src/editor/global_interface/menu_bar/menu_bar.go
+++ b/src/editor/global_interface/menu_bar/menu_bar.go
@@ -64,18 +64,25 @@ type MenuBar struct {
 	handler       MenuBarHandler
 }
 
+type menuBarTemplateData struct {
+	ShowGrid bool
+}
+
 func (b *MenuBar) Initialize(host *engine.Host, handler MenuBarHandler) error {
 	defer tracing.NewRegion("MenuBar.Initialize").End()
 	b.handler = handler
 	b.uiMan.Init(host)
 	var err error
+	tplData := menuBarTemplateData{ShowGrid: handler.Settings().ShowGrid}
 	b.doc, err = markup.DocumentFromHTMLAsset(&b.uiMan, "editor/ui/global/menu_bar.go.html",
-		nil, map[string]func(*document.Element){
+		tplData, map[string]func(*document.Element){
 			"clickLogo":                b.openMenuTarget,
 			"clickFile":                b.openMenuTarget,
 			"clickEdit":                b.openMenuTarget,
 			"clickCreate":              b.openMenuTarget,
+			"clickView":                b.openMenuTarget,
 			"clickHelp":                b.openMenuTarget,
+			"clickToggleGrid":          b.clickToggleGrid,
 			"clickStage":               b.clickStage,
 			"clickContent":             b.clickContent,
 			"clickShading":             b.clickShading,
@@ -513,6 +520,20 @@ func (b *MenuBar) clickSponsors(*document.Element) {
 	b.hidePopups()
 	b.handler.BlurInterface()
 	sponsors.Show(b.uiMan.Host, b.handler.FocusInterface)
+}
+
+func (b *MenuBar) clickToggleGrid(e *document.Element) {
+	defer tracing.NewRegion("MenuBar.clickToggleGrid").End()
+	visible := !b.handler.Settings().ShowGrid
+	b.handler.SetGridVisible(visible)
+	if lbl := e.InnerLabel(); lbl != nil {
+		if visible {
+			lbl.SetText("Hide Grid")
+		} else {
+			lbl.SetText("Show Grid")
+		}
+	}
+	b.hidePopups()
 }
 
 func (b *MenuBar) popupMiss(e *document.Element) {

--- a/src/editor/global_interface/menu_bar/menu_bar_handler.go
+++ b/src/editor/global_interface/menu_bar/menu_bar_handler.go
@@ -72,4 +72,5 @@ type MenuBarHandler interface {
 	CreatePluginProject(path string)
 	CreateHtmlUiFile(name string)
 	CreateCssStylesheetFile(name string)
+	SetGridVisible(visible bool)
 }


### PR DESCRIPTION
A simple change to the menu that adds a View tab with an option to Hide or Show the editor grid.