### PR TITLE
fix(window): fix crash when minimizing window

### DIFF
--- a/src/rendering/gpu_device.go
+++ b/src/rendering/gpu_device.go
@@ -138,11 +138,15 @@ func (g *GPUDevice) createGlobalUniforms() error {
 }
 
 func (g *GPUDevice) destroyGlobalUniforms() {
-	for i := 0; i < maxFramesInFlight; i++ {
-		g.DestroyBuffer(g.globalUniformBuffers[i])
-		g.LogicalDevice.dbg.remove(g.globalUniformBuffers[i].handle)
-		g.FreeMemory(g.globalUniformBuffersMemory[i])
-		g.LogicalDevice.dbg.remove(g.globalUniformBuffersMemory[i].handle)
+	for i := range maxFramesInFlight {
+		if g.globalUniformBuffers[i].IsValid() {
+			g.DestroyBuffer(g.globalUniformBuffers[i])
+			g.globalUniformBuffers[i].Reset()
+		}
+		if g.globalUniformBuffersMemory[i].IsValid() {
+			g.FreeMemory(g.globalUniformBuffersMemory[i])
+			g.globalUniformBuffersMemory[i].Reset()
+		}
 	}
 }
 

--- a/src/rendering/gpu_logical_device_vulkan.go
+++ b/src/rendering/gpu_logical_device_vulkan.go
@@ -192,12 +192,16 @@ func (g *GPULogicalDevice) freeTextureImpl(texId *TextureId) {
 
 func (g *GPULogicalDevice) remakeSwapChainImpl(window RenderingContainer, inst *GPUApplicationInstance, device *GPUDevice) error {
 	defer tracing.NewRegion("GPULogicalDevice.remakeSwapChainImpl").End()
-	// This will destroy the existing swap chain
-	device.CreateSwapChain(window, inst)
-	device.destroyGlobalUniforms()
+
+	// This will destroy and replace the existing swap chain when possible
+	_ = device.CreateSwapChain(window, inst)
 	if !g.SwapChain.IsValid() {
+		// minimized/invalid extents can leave the swap chain invalid
+		// Keep previous uniform handles intact until we can complete a valid rebuild
 		return nil // TODO:  Is this correct?
 	}
+	// Valid swap chain -> tear down old global uniforms before rebuilding
+	device.destroyGlobalUniforms()
 	slog.Info("recreated vulkan swap chain")
 	if err := g.SwapChain.SetupImageViews(device); err != nil {
 		return err
@@ -214,7 +218,9 @@ func (g *GPULogicalDevice) remakeSwapChainImpl(window RenderingContainer, inst *
 	if err := device.createGlobalUniforms(); err != nil {
 		return err
 	}
-	g.SwapChain.SetupSyncObjects(device)
+	if err := g.SwapChain.SetupSyncObjects(device); err != nil {
+		return err
+	}
 	passes := make([]*RenderPass, 0, len(g.renderPassCache))
 	for _, v := range g.renderPassCache {
 		passes = append(passes, v)

--- a/src/rendering/gpu_swap_chain.go
+++ b/src/rendering/gpu_swap_chain.go
@@ -37,6 +37,7 @@
 package rendering
 
 import (
+	"fmt"
 	"log/slog"
 
 	"kaijuengine.com/engine/assets"
@@ -174,6 +175,12 @@ func (g *GPUSwapChain) SetupRenderPass(device *GPUDevice, assets assets.Database
 
 func (g *GPUSwapChain) SetupSyncObjects(device *GPUDevice) error {
 	defer tracing.NewRegion("GPUSwapChain.SetupSyncObjects").End()
+	if len(g.Images) == 0 {
+		return fmt.Errorf("cannot set up sync objects for empty swap chain")
+	}
+	if len(g.Images) > maxFramesInFlight {
+		return fmt.Errorf("swap chain image count (%d) exceeds max frames in flight (%d)", len(g.Images), maxFramesInFlight)
+	}
 	g.resetSyncObjects(device)
 	err := g.setupSyncObjectsImpl(device)
 	if err != nil {


### PR DESCRIPTION
pr summary:
- fix crash when minimizing editor window
- add some error handling7logging
- add some comments

NOTE: the fix was basicly only that `device.destroyGlobalUniforms()` was called before checking `g.SwapChain.IsValid()`. I can remove the other changes, but I think they would be useful for future development