### PR TITLE
feat(file-drop): allow dropping folders in window (windows)

### DIFF
--- a/src/editor/editor_workspace/content_workspace/content_workspace.go
+++ b/src/editor/editor_workspace/content_workspace/content_workspace.go
@@ -229,10 +229,35 @@ func (w *ContentWorkspace) importPaths(paths []string) {
 func ImportPaths(paths []string, pfs *project_file_system.FileSystem, cache *content_database.Cache) []string {
 	defer tracing.NewRegion("ContentWorkspace.ImportPaths").End()
 	index := []string{}
+	importPaths := make([]string, 0, len(paths))
 	for i := range paths {
-		res, err := content_database.Import(paths[i], pfs, cache, "")
+		info, err := os.Stat(paths[i])
 		if err != nil {
-			slog.Error("failed to import content", "path", paths[i], "error", err)
+			slog.Error("failed to stat import path", "path", paths[i], "error", err)
+			continue
+		}
+		if !info.IsDir() {
+			importPaths = klib.AppendUnique(importPaths, paths[i])
+			continue
+		}
+		if err = filepath.WalkDir(paths[i], func(path string, d os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				slog.Warn("failed while walking dropped folder", "path", path, "error", walkErr)
+				return nil
+			}
+			if d.IsDir() {
+				return nil
+			}
+			importPaths = klib.AppendUnique(importPaths, path)
+			return nil
+		}); err != nil {
+			slog.Warn("failed to walk dropped folder", "path", paths[i], "error", err)
+		}
+	}
+	for i := range importPaths {
+		res, err := content_database.Import(importPaths[i], pfs, cache, "")
+		if err != nil {
+			slog.Error("failed to import content", "path", importPaths[i], "error", err)
 			continue
 		}
 		for j := range res {


### PR DESCRIPTION
pr summary:
- follow-up to #729
- allows folder-drop (windows)


NOTE: dropping folders with multiple images (exp 5) is very slow. 
TODO: need to look at import logic (also ui freezes during import)