### PR TITLE
feat(css-background): implement css background support basics

### DIFF
--- a/src/engine/ui/markup/css/properties/css_background.go
+++ b/src/engine/ui/markup/css/properties/css_background.go
@@ -38,6 +38,7 @@ package properties
 
 import (
 	"errors"
+	"strings"
 
 	"kaijuengine.com/engine"
 	"kaijuengine.com/engine/ui"
@@ -46,7 +47,43 @@ import (
 )
 
 func (p Background) Process(panel *ui.Panel, elm *document.Element, values []rules.PropertyValue, host *engine.Host) error {
-	problems := []error{errors.New("Background not implemented")}
+	if len(values) == 0 {
+		return errors.New("background requires at least 1 value")
+	}
 
-	return problems[0]
+	// Support:
+	// 1) Single color token:
+	//    background: #314052;
+	//    background: rgb(49, 64, 82);
+	// 2) Single image token:
+	//    background: url("panel_bg.png");
+	// 3) Multi-token values that include a color token:
+	//    background: no-repeat center/cover #314052;
+	//    background: fixed url("panel_bg.png") #202733;
+	//
+	// NOTE: this is intentionally partial shorthand support. Non-color/non-url
+	// components are not fully expanded into individual background-* properties.
+	//
+	// Not supported:
+	// - multiple background layers (comma-separated values)
+	// - position/size parsing via slash syntax (e.g. center / cover)
+	// - repeat/attachment/origin/clip token decomposition
+	if len(values) == 1 {
+		v := values[0]
+		if strings.HasPrefix(v.Str, "url(") || (v.IsFunction() && v.Str == "url") {
+			return BackgroundImage{}.Process(panel, elm, values, host)
+		}
+		return BackgroundColor{}.Process(panel, elm, values, host)
+	}
+
+	// CSS allows the color token to appear among other tokens.
+	// Example: background: url("panel.png") no-repeat center / cover #314052;
+	// Scan from right-to-left and apply the first parseable color.
+	for i := len(values) - 1; i >= 0; i-- {
+		if err := (BackgroundColor{}).Process(panel, elm, []rules.PropertyValue{values[i]}, host); err == nil {
+			return nil
+		}
+	}
+
+	return errors.New("background shorthand is only partially supported; expected a color and/or url(...)")
 }


### PR DESCRIPTION
pr summary:
- support css background color
- support css background image url (not tested because idk how kaiju syntax differs)



tested on:
[demo-file.html](https://github.com/user-attachments/files/27283866/demo-file.html)


NOTE: aspekt ratio element seems to have an issue with background, but that is not related to this pr (will figure that out later)