### PR TITLE
fix(css): simplify padding Preprocess()

### DIFF
--- a/src/engine/ui/markup/css/properties/css_padding.go
+++ b/src/engine/ui/markup/css/properties/css_padding.go
@@ -64,6 +64,7 @@ func paddingSizeFromString(elm *document.Element, str string, idx matrix.VectorC
 	default:
 		size = helpers.NumFromLength(str, window)
 	}
+
 	current[idx] = size
 	return current, nil
 }
@@ -80,23 +81,18 @@ func (Padding) Preprocess(values []rules.PropertyValue, rules []rules.Rule) ([]r
 	case 3:
 		values = append(values, values[1])
 	}
+
 	for i := 1; i < len(rules); i++ {
-		removeRule := false
 		switch rules[i].Property {
 		case "padding-top":
 			values[0] = rules[i].Values[0]
-			removeRule = true
 		case "padding-right":
 			values[1] = rules[i].Values[0]
-			removeRule = true
 		case "padding-bottom":
 			values[2] = rules[i].Values[0]
-			removeRule = true
 		case "padding-left":
 			values[3] = rules[i].Values[0]
-			removeRule = true
-		}
-		if removeRule {
+		default:
 			rules = slices.Delete(rules, i, i+1)
 			i--
 		}
@@ -105,6 +101,7 @@ func (Padding) Preprocess(values []rules.PropertyValue, rules []rules.Rule) ([]r
 }
 
 // length|initial|inherit
+// TODO: this error handling is broken
 func (Padding) Process(panel *ui.Panel, elm *document.Element, values []rules.PropertyValue, host *engine.Host) error {
 	var err error
 	if len(values) == 1 {


### PR DESCRIPTION
pr summary:
- remove `removeRule` variable
- add comment for TODO because the error handling fails silently