### PR TITLE
fix(context-menu): reposition

### DIFF
--- a/src/editor/editor.go
+++ b/src/editor/editor.go
@@ -45,6 +45,7 @@ import (
 	"kaijuengine.com/editor/editor_events"
 	"kaijuengine.com/editor/editor_logging"
 	"kaijuengine.com/editor/editor_overlay/ai_prompt"
+	"kaijuengine.com/editor/editor_overlay/context_menu"
 	"kaijuengine.com/editor/editor_plugin"
 	"kaijuengine.com/editor/editor_settings"
 	"kaijuengine.com/editor/editor_stage_manager/editor_stage_view"
@@ -211,6 +212,10 @@ func (ed *Editor) postProjectLoad() {
 
 func (ed *Editor) update(deltaTime float64) {
 	if ed.blurred {
+		return
+	}
+	if context_menu.IsOpen() {
+		ed.currentWorkspace.Update(deltaTime)
 		return
 	}
 	kb := &ed.host.Window.Keyboard

--- a/src/editor/editor_overlay/context_menu/context_menu_overlay.go
+++ b/src/editor/editor_overlay/context_menu/context_menu_overlay.go
@@ -50,6 +50,10 @@ import (
 
 var existing *ContextMenu
 
+func IsOpen() bool {
+	return existing != nil
+}
+
 type ContextMenu struct {
 	doc     *document.Document
 	uiMan   ui.Manager

--- a/src/editor/editor_workspace/content_workspace/content_workspace.go
+++ b/src/editor/editor_workspace/content_workspace/content_workspace.go
@@ -724,6 +724,10 @@ func (w *ContentWorkspace) completeDeleteOfSelectedContent() {
 
 func (w *ContentWorkspace) entryMouseEnter(e *document.Element) {
 	defer tracing.NewRegion("ContentWorkspace.entryMouseEnter").End()
+	if context_menu.IsOpen() {
+		w.tooltip.UI.Hide()
+		return
+	}
 	ui := w.tooltip.UI
 	id := e.Attribute("id")
 	cc, err := w.cache.Read(id)
@@ -743,6 +747,10 @@ func (w *ContentWorkspace) entryMouseEnter(e *document.Element) {
 
 func (w *ContentWorkspace) entryMouseMove(e *document.Element) {
 	defer tracing.NewRegion("ContentWorkspace.entryMouseMove").End()
+	if context_menu.IsOpen() {
+		w.tooltip.UI.Hide()
+		return
+	}
 	ui := w.tooltip.UI
 	if !ui.Entity().IsActive() {
 		ui.Show()
@@ -818,8 +826,8 @@ func (w *ContentWorkspace) rightClickContent(e *document.Element) {
 			},
 		})
 	}
-	w.editor.BlurInterface()
-	context_menu.Show(w.Host, options, w.Host.Window.Cursor.ScreenPosition(), w.editor.FocusInterface)
+
+	context_menu.Show(w.Host, options, w.Host.Window.Cursor.ScreenPosition(), nil)
 }
 
 func (w *ContentWorkspace) clickClearSelection(e *document.Element) {


### PR DESCRIPTION
pr summary:
- fix bug: when doing right click in on content in content workspace whlie context menu is already open it would nor reposition

demo:

https://github.com/user-attachments/assets/7333ad50-b7ed-4f2c-8063-dccecef01b2a

