### PR TITLE
feat(import): imported file extension

### DIFF
--- a/src/editor/project/project_database/content_database/content_database.go
+++ b/src/editor/project/project_database/content_database/content_database.go
@@ -115,7 +115,7 @@ func Import(path string, fs *project_file_system.FileSystem, cache *Cache, linke
 	dependencyMap := map[string][]ImportResult{}
 	for i := range proc.Variants {
 		res[i].Category = cat
-		res[i].generateUniqueFileId(fs)
+		res[i].generateUniqueFileId(fs, filepath.Ext(path))
 		if useLinkedId && linkedId == "" {
 			linkedId = res[i].Id
 		}

--- a/src/editor/project/project_database/content_database/content_database_import.go
+++ b/src/editor/project/project_database/content_database/content_database_import.go
@@ -101,10 +101,14 @@ func (r *ImportResult) ConfigPath() project_file_system.ConfigPath {
 	return r.ContentPath().ToConfigPath()
 }
 
-func (r *ImportResult) generateUniqueFileId(fs *project_file_system.FileSystem) string {
+func (r *ImportResult) generateUniqueFileId(fs *project_file_system.FileSystem, ext string) string {
 	defer tracing.NewRegion("ImportResult.generateUniqueFileId").End()
+	ext = strings.TrimSpace(ext)
+	if ext != "" && !strings.HasPrefix(ext, ".") {
+		ext = "." + ext
+	}
 	for {
-		r.Id = uuid.NewString()
+		r.Id = uuid.NewString() + ext
 		if _, err := fs.Stat(r.ContentPath().String()); err == nil {
 			continue
 		}


### PR DESCRIPTION
pr summary:
- imported files get their file extension to enable syntax hightlighting when opening with editor

NOTE: during testing I realized that changing GUID can crash/deadlock the editor, but that was already before this pr. will look into that