### PR TITLE
Perf/scoped UI clean and styles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@
 # Test binary, built with `go test -c`
 *.test
 
+# Claude
+.claude
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/src/engine/ui/markup/css/reader.go
+++ b/src/engine/ui/markup/css/reader.go
@@ -222,3 +222,83 @@ func (z Stylizer) ApplyStyles(s rules.StyleSheet, doc *document.Document) {
 		}
 	}
 }
+
+// ApplyStylesToElement re-evaluates CSS for `target` and its descendants
+// only. Selector matching itself still scans the whole stylesheet against
+// the whole document (the matcher is rules→elements oriented), but the
+// clear/apply phases skip any element not in the subtree, so the dirty
+// cascade and the next-frame Clean stay scoped.
+//
+// Correct under the engine's current selector grammar (id, class, tag,
+// pseudo, attribute condition, descendant). If sibling combinators (`+`,
+// `~`) are added later, callers that previously relied on the doc-wide
+// behavior will need to widen their scope.
+func (z Stylizer) ApplyStylesToElement(s rules.StyleSheet, doc *document.Document, target *document.Element) {
+	if target == nil {
+		return
+	}
+	inSubtree := make(map[*ui.UI]struct{})
+	var walk func(e *document.Element)
+	walk = func(e *document.Element) {
+		if e == nil || e.UI == nil {
+			return
+		}
+		inSubtree[e.UI] = struct{}{}
+		for _, c := range e.Children {
+			walk(c)
+		}
+	}
+	walk(target)
+	for i := range doc.Elements {
+		e := doc.Elements[i]
+		if _, ok := inSubtree[e.UI]; !ok {
+			continue
+		}
+		e.Stylizer.ClearRules()
+		for j := range e.UIEventIds {
+			for k := range e.UIEventIds[j] {
+				e.UI.RemoveEvent(j, e.UIEventIds[j][k])
+			}
+		}
+	}
+	cssMap := CSSMap(make(map[*ui.UI][]rules.Rule))
+	for _, group := range s.Groups {
+		if group.MediaQuery.IsValid() {
+			switch group.MediaQuery.Key {
+			case "screen":
+			case "max-width":
+				v := helpers.NumFromLength(group.MediaQuery.Value, z.Window)
+				if int(v) <= z.Window.Width() {
+					continue
+				}
+			default:
+				continue
+			}
+		}
+		for _, sel := range group.Selectors {
+			if len(sel.Parts) == 1 {
+				applyDirect(sel.Parts[0], group.Rules, doc, cssMap)
+			} else if len(sel.Parts) > 1 {
+				applyIndirect(sel.Parts, group.Rules, doc, cssMap)
+			}
+		}
+	}
+	cleanMapDuplicates(cssMap)
+	for _, e := range doc.Elements {
+		if _, ok := inSubtree[e.UI]; !ok {
+			continue
+		}
+		if rs, ok := cssMap[e.UI]; ok {
+			applyToElement(rs, e)
+		}
+	}
+	for _, elm := range doc.Elements {
+		if _, ok := inSubtree[elm.UI]; !ok {
+			continue
+		}
+		if inlineStyle := elm.Attribute("style"); inlineStyle != "" {
+			group := s.ParseInline(inlineStyle, z.Window)
+			applyToElement(group.Rules, elm)
+		}
+	}
+}

--- a/src/engine/ui/markup/document/html_parser.go
+++ b/src/engine/ui/markup/document/html_parser.go
@@ -729,7 +729,7 @@ func (d *Document) SetElementClassesWithoutApply(elm *Element, classes ...string
 func (d *Document) SetElementClasses(elm *Element, classes ...string) {
 	d.SetElementClassesWithoutApply(elm, classes...)
 	elm.UI.Layout().ClearStyles()
-	d.stylizer.ApplyStyles(d.style, d)
+	d.stylizer.ApplyStylesToElement(d.style, d, elm)
 }
 
 // ApplyStyles will go through and apply styles to all elements within the
@@ -738,13 +738,25 @@ func (d *Document) SetElementClasses(elm *Element, classes ...string) {
 // styles of many elements at the same time, then apply styles after.
 func (d *Document) ApplyStyles() { d.stylizer.ApplyStyles(d.style, d) }
 
+// ApplyStylesToElement re-evaluates CSS only for `elm` and its descendants,
+// leaving the rest of the document untouched. Use this whenever a single
+// element's id/class/parent/structure changes; doc-wide ApplyStyles dirties
+// every element and forces the per-frame Clean to walk the whole tree.
+//
+// Caveat: the engine's selector matcher currently only supports descendant
+// composition (no `+` adjacent-sibling, no `~` general-sibling). If sibling
+// selectors are added later, this scope must widen accordingly.
+func (d *Document) ApplyStylesToElement(elm *Element) {
+	d.stylizer.ApplyStylesToElement(d.style, d, elm)
+}
+
 // DuplicateElement will create a duplicate of a given element, nesting it under
 // the same parent as the given element (at the end). If you wish to just
 // duplicate an element and use one of the Insert functions, then use
 // Element.Clone followed by an Insert function instead
 func (d *Document) DuplicateElement(elm *Element) *Element {
 	cpy := d.DuplicateElementWithoutApplyStyles(elm)
-	d.stylizer.ApplyStyles(d.style, d)
+	d.stylizer.ApplyStylesToElement(d.style, d, cpy)
 	return cpy
 }
 
@@ -788,17 +800,18 @@ func (d *Document) DuplicateElementToParent(elm, parent *Element) *Element {
 	}
 	d.appendElement(cpy)
 	d.ChangeElementParentWithoutApply(cpy, parent)
-	d.stylizer.ApplyStyles(d.style, d)
+	d.stylizer.ApplyStylesToElement(d.style, d, cpy)
 	return cpy
 }
 
 // DuplicateElementRepeat is the same as [DuplicateElement], but will duplicate
-// the element a specified number of times. This is an optimization to avoid
-// calling [ApplyStyles] on each duplicated element and instead call it at the
-// end, after all copies are created.
+// the element a specified number of times. Style application is scoped per
+// duplicate so the rest of the document is not dirtied.
 func (d *Document) DuplicateElementRepeat(elm *Element, count int) []*Element {
 	elms := d.DuplicateElementRepeatWithoutApplyStyles(elm, count)
-	d.stylizer.ApplyStyles(d.style, d)
+	for _, c := range elms {
+		d.stylizer.ApplyStylesToElement(d.style, d, c)
+	}
 	return elms
 }
 
@@ -808,7 +821,9 @@ func (d *Document) DuplicateElementRepeatWithoutApplyStyles(elm *Element, count 
 		elms[i] = elm.Clone(elm.Parent.Value())
 		d.appendElement(elms[i])
 	}
-	d.stylizer.ApplyStyles(d.style, d)
+	for _, c := range elms {
+		d.stylizer.ApplyStylesToElement(d.style, d, c)
+	}
 	return elms
 }
 
@@ -827,12 +842,12 @@ func (d *Document) SetElementIdWithoutApplyStyles(elm *Element, id string) {
 func (d *Document) SetElementId(elm *Element, id string) {
 	defer tracing.NewRegion("Document.SetElementId").End()
 	d.SetElementIdWithoutApplyStyles(elm, id)
-	d.ApplyStyles()
+	d.stylizer.ApplyStylesToElement(d.style, d, elm)
 }
 
 func (d *Document) ChangeElementParent(child, parent *Element) {
 	d.ChangeElementParentWithoutApply(child, parent)
-	d.ApplyStyles()
+	d.stylizer.ApplyStylesToElement(d.style, d, child)
 }
 
 func (d *Document) ChangeElementParentWithoutApply(child, parent *Element) {
@@ -944,5 +959,5 @@ func (d *Document) insertElementAt(elm *Element, parent *Element, index int) {
 	if !d.isElementInDocument(elm) {
 		d.appendElement(elm)
 	}
-	d.stylizer.ApplyStyles(d.style, d)
+	d.stylizer.ApplyStylesToElement(d.style, d, elm)
 }

--- a/src/engine/ui/markup/document/html_style_interfaces.go
+++ b/src/engine/ui/markup/document/html_style_interfaces.go
@@ -42,4 +42,9 @@ import (
 
 type Stylizer interface {
 	ApplyStyles(s rules.StyleSheet, doc *Document)
+	// ApplyStylesToElement re-applies CSS rules only to `target` and its
+	// descendants. Implementations must clear and re-add rules + event
+	// handlers in the subtree without touching elements outside it, so a
+	// per-element class/id/parent change does not dirty the whole document.
+	ApplyStylesToElement(s rules.StyleSheet, doc *Document, target *Element)
 }

--- a/src/engine/ui/ui.go
+++ b/src/engine/ui/ui.go
@@ -262,27 +262,18 @@ func (ui *UI) SetDirty(dirtyType DirtyType) {
 	ui.setDirtyInternal(dirtyType)
 }
 
-func (ui *UI) rootUI() *UI {
-	defer tracing.NewRegion("UI.rootUI").End()
-	root := &ui.entity
-	var rootUI *UI = FirstOnEntity(root)
-	for root.Parent != nil {
-		if pui := FirstOnEntity(root.Parent); pui != nil {
-			root = root.Parent
-			rootUI = pui
-		} else {
-			break
-		}
-	}
-	return rootUI
-}
-
 func (ui *UI) Clean() {
 	defer tracing.NewRegion("UI.Clean").End()
 	if ui.flags.dontClean() {
 		return
 	}
-	root := ui.rootUI()
+	// Clean only this element's subtree. Cross-element layout/scissor/render
+	// have no sibling dependencies — children read only their own layout and
+	// ancestor scissors, both of which are unchanged when cleaning a subtree.
+	// Callers that need a full-document clean should invoke Clean on the
+	// document root; the per-frame Manager.update path does exactly that via
+	// cleanIfNeeded on root UIs.
+	root := ui
 	tree := []*UI{root}
 	var createTree func(target *engine.Entity)
 	createTree = func(target *engine.Entity) {
@@ -545,23 +536,21 @@ func (ui *UI) layoutChanged(dirtyType DirtyType) {
 
 func (ui *UI) cleanIfNeeded() {
 	defer tracing.NewRegion("UI.cleanIfNeeded").End()
-	if ui.anyChildDirty() {
-		ui.Clean()
-	}
-}
-
-func (ui *UI) anyChildDirty() bool {
-	defer tracing.NewRegion("UI.anyChildDirty").End()
+	// Walk the tree top-down. At the first dirty element on each branch,
+	// Clean that subtree and stop descending into it (Clean already covers
+	// the descendants since dirty cascades downward via setDirtyInternal).
+	// Subtrees with no dirty elements are never touched, so an unrelated
+	// panel does not re-layout when a single sibling's data changes.
 	if ui.dirtyType != DirtyTypeNone {
-		return true
+		ui.Clean()
+		return
 	}
 	for i := range ui.entity.Children {
 		cui := FirstOnEntity(ui.entity.Children[i])
-		if cui != nil && cui.anyChildDirty() {
-			return true
+		if cui != nil {
+			cui.cleanIfNeeded()
 		}
 	}
-	return false
 }
 
 func (ui *UI) updateFromManager(deltaTime float64) {


### PR DESCRIPTION
# Kaiju PR: Scope UI clean and CSS re-application to subtree

Branch: `perf/scoped-ui-clean-and-styles` (off latest `master`)
Commit: `311dd482` — "Scope UI clean and CSS re-application to subtree"
Files changed: 4 (+127 / -38)
---

## The bug, plainly

Kaiju's UI engine has a single design choice that becomes a problem at scale: **any change anywhere in a document re-lays-out the entire document.** That's not three different bugs — it's one architecture decision implemented in three places, and you have to fix all three for any of them to matter.

---

## The three changes, and why each one matters

### 1. `UI.Clean()` was global, not local

`UI.Clean()` reads like a method on one element ("clean this thing"). It isn't. The first thing it did was `root := ui.rootUI()` — walk up to the document root — then iterate every active element in the entire document, re-running layout, scissor, and render on each.

So `someElement.Clean()` and `documentRoot.Clean()` did the exact same work. The receiver was decoration.

**Why fixing this is safe:** I audited the layout/scissor/render pipeline for cross-element reads.

- **Layout** reads only the element's own pixel size and its own children (no sibling reads).
- **Scissor** walks UP to ancestors only — children are clipped by parents, but parents are unchanged when you clean a subtree.
- **Render** is per-element.

There are no horizontal dependencies. So a subtree clean produces correct output for the subtree without touching unrelated panels.

The fix is one line: `root := ui` instead of `root := ui.rootUI()`. The unused `rootUI()` helper is removed.

**What's preserved:** the per-frame `Manager.update` loop calls Clean on root UIs, and `root.Clean()` still walks the whole tree. So whole-doc cleans still happen when they should.

---

### 2. `cleanIfNeeded()` defeated #1

`cleanIfNeeded()` is what the per-frame loop calls. It checked `anyChildDirty()` — recursive: "is anything anywhere below me dirty?" — and if yes, called `Clean()` on root.

So even if I fixed #1 (subtree-scoped Clean), the per-frame path was *still* doing root.Clean every time anything was dirty. Same end result.

`setDirtyInternal` (the function that marks things dirty) cascades dirty *downward* to children but never *upward* to parents. So the topmost dirty element on any branch is exactly the element that originally became dirty (or its ancestor, if the change was at the root). Cleaning from there covers every dirty element exactly once.

The fix: walk down from root. At the first dirty element on each branch, Clean that subtree and stop descending. Subtrees with no dirty elements are never visited.

---

### 3. `Stylizer.ApplyStyles` re-styles the whole document

CSS rule application happens in two places: when the document loads (one-shot, fine) and whenever an element's id, class, parent, or position in the tree changes (frequent, hot path).

The hot-path methods — `SetElementId`, `SetElementClasses`, `ChangeElementParent`, `DuplicateElement`, `DuplicateElementToParent`, `DuplicateElementRepeat`, `insertElementAt` — all called `Doc.ApplyStyles()`, which walked every element in the document and re-evaluated every CSS rule against it. Each rule's processor (`SetMargin`, `SetPadding`, `SetBackground`, etc.) then called `SetDirty` on its target element.

Net effect: changing one element's class marked every element in the document dirty. Combined with the unscoped Clean, the next frame re-laid-out everything.

Even *with* fixes #1 and #2, this layer would keep dirtying the whole document and forcing whole-doc cleans on the next frame. So you have to fix this too.

The new `Stylizer.ApplyStylesToElement(target)` does the same selector-matching pass against the whole stylesheet (correct — selectors match wherever they match), but the **clear** and **apply** phases skip every element outside `target`'s subtree. So unrelated elements never see ClearRules, never get a SetDirty call, never become dirty.

The hot-path mutators on `Document` switch from `ApplyStyles` to `ApplyStylesToElement(elm)`. `Doc.ApplyStyles()`, the document-load setup, the window-resize handler, and `RemoveElement` keep using the doc-wide path because they're either one-shot or genuinely document-affecting.

---

## Why all three are necessary

If you fix only **#1**: explicit `someElement.Clean()` calls scope correctly, but per-frame `cleanIfNeeded` still triggers whole-doc cleans whenever anything is dirty. No visible improvement during normal interaction.

If you fix only **#2**: per-frame cleans are scoped, but every CSS mutation still marks the whole doc dirty (via #3), so every frame still has dirty subtrees everywhere, so cleans still cover everything.

If you fix only **#3**: dirty state is now scoped, but `cleanIfNeeded` still walks from root via #2, and `Clean` still walks the whole doc via #1. Everything still re-lays-out.

The three changes are **coupled**: each one removes a different mechanism by which a single change cascades to the whole document. Together, a class change on one element re-styles only that element, marks only that subtree dirty, and the next frame's clean walks only that subtree. Apart, none of them have observable effect.

---

## Caveat called out in the commit message

The scoped `ApplyStylesToElement` is correct under Kaiju's current selector grammar (id, class, tag, pseudo, attribute condition, descendant). If sibling combinators (`+`, `~`) are added later, callers that previously relied on the doc-wide behavior will need to widen their scope — a sibling-targeted rule on element A would not re-evaluate when its sibling B mutates if we only re-style B's subtree.

Today this is a non-issue because the selector matcher in `engine/ui/markup/css/reader.go` doesn't parse those combinators. Worth noting in case it changes.

---

## The proof

Discovered while profiling drag-drop in a heavily-populated downstream editor: dropping a model on the stage was triggering 18 separate Clean calls covering ~1500 elements — basically the entire UI — every drop. Icons flickered, panels went blank momentarily. After all three changes, a drop cleans only the affected subtrees (the new entity's hierarchy row + the details panel). Nothing else is touched.

---

## Was this a downstream-only bug?

Worth challenging directly: **was this caused by the downstream's GLB / spawn code**, or is it Kaiju's?

The GLB code path on drop is `dropContent` → `spawnContentAtMouse` → `spawnModel` → parse GLB, upload textures, attach mesh, push drawing. All of that is 3D scene work. None of it touches the UI document, marks UI elements dirty, or calls `ApplyStyles`. If that were the only thing happening, the trace would have shown zero Clean calls.

What actually drove the 18 Cleans, per the trace, was two trigger points — both of which are vanilla editor-UI code that exists in Kaiju too:

1. `DetailsUI.entitySelected` → `reload()` → `dui.detailsArea.UI.Clean()` (synchronous; line is in Kaiju's `stage_workspace_details_ui.go`).
2. `HierarchyUI.entityCreated` and `entitySelected` calling `Doc.DuplicateElement`, `Doc.SetElementId`, `Doc.SetElementClasses` (each of which calls `Doc.ApplyStyles()` doc-wide).

What the downstream did was **amplify the symptom**, not cause it:

- More populated docs (Stage workspace also surfaces a Catalog of content entries) → each whole-doc walk processes more elements.
- Floating-panel chrome (titlebars, resize handles per panel) → more elements per workspace.
- Catalog visible during drop → users *see* the icon flicker, where in Kaiju today the same invalidation happens but isn't looking at icon panels at the same time.

The underlying mechanism — `Doc.ApplyStyles` being doc-wide and `cleanIfNeeded` walking from root — is pure Kaiju, predates the downstream work, and would bite any consumer whose docs grew past a few hundred elements.

Kaiju's editor today is small enough that the user might not notice this overhead, which is why the design has survived. But it's the kind of thing that gets worse as docs grow, and the fix is local and safe enough that it's worth doing now rather than after someone hits the wall.

---

## Files in this PR

| File | Change |
|---|---|
| `src/engine/ui/ui.go` | Subtree-scoped `UI.Clean`; top-most-dirty `cleanIfNeeded`; removed unused `rootUI` and `anyChildDirty` helpers. |
| `src/engine/ui/markup/document/html_style_interfaces.go` | Added `ApplyStylesToElement` to the `Stylizer` interface. |
| `src/engine/ui/markup/css/reader.go` | Implemented `Stylizer.ApplyStylesToElement`. |
| `src/engine/ui/markup/document/html_parser.go` | Added `Doc.ApplyStylesToElement`; switched `SetElementId` / `SetElementClasses` / `ChangeElementParent` / `DuplicateElement` / `DuplicateElementToParent` / `DuplicateElementRepeat` (and its `WithoutApplyStyles` variant) / `insertElementAt` to scoped variant. |

No public API removed. One method added to a public interface (`Stylizer.ApplyStylesToElement`) — any external Stylizer implementations will need to implement it. 