### PR TITLE
Fix filepath construction in shader window

### DIFF
--- a/src/editor/editor_workspace/shading_workspace/shader_designer/shader_window.go
+++ b/src/editor/editor_workspace/shading_workspace/shader_designer/shader_window.go
@@ -335,7 +335,7 @@ func importShaderLayout(pfs *project_file_system.FileSystem, shader rendering.Sh
 	}
 	for i := range list {
 		if list[i].path != "" {
-			s := filepath.Join(pfs.Name(), "/", strings.TrimPrefix(filepath.ToSlash(list[i].path), shaderSrcFolder))
+			s := filepath.Join(pfs.Name(), strings.TrimPrefix(filepath.ToSlash(list[i].path), shaderSrcFolder))
 			c, err := glsl.Parse(s, list[i].flags)
 			if err != nil {
 				return shader, err

--- a/src/editor/editor_workspace/shading_workspace/shader_designer/shader_window.go
+++ b/src/editor/editor_workspace/shading_workspace/shader_designer/shader_window.go
@@ -335,7 +335,7 @@ func importShaderLayout(pfs *project_file_system.FileSystem, shader rendering.Sh
 	}
 	for i := range list {
 		if list[i].path != "" {
-			s := filepath.Join(pfs.Name(), strings.TrimPrefix(filepath.ToSlash(list[i].path), shaderSrcFolder)) + "/"
+			s := filepath.Join(pfs.Name(), "/", strings.TrimPrefix(filepath.ToSlash(list[i].path), shaderSrcFolder))
 			c, err := glsl.Parse(s, list[i].flags)
 			if err != nil {
 				return shader, err


### PR DESCRIPTION
Fix the filepath for shader importer when saving shader with source files in database\src\render\shader.

time=2026-05-12T09:46:34.240+02:00 level=ERROR msg="failed to read the file" file=C:\....\\database\src\render\shader\worldmap.vert/ error="open .......\\database\\src\\render\\shader\\worldmap.vert/: Katalognamnet är felaktigt." (Invalid filepath)