### PR TITLE
Typo F64 IsNan IsNaN

### DIFF
--- a/src/matrix/float64.go
+++ b/src/matrix/float64.go
@@ -105,7 +105,7 @@ func Pow(x Float, y Float) Float {
 	return math.Pow(x, y)
 }
 
-func IsNan(x Float) bool {
+func IsNaN(x Float) bool {
 	return math.IsNaN(x)
 }
 


### PR DESCRIPTION
There seems to be some issues with the float64 build ATM, one of them being the func name `IsNaN` in common interface and in `float32`, but `IsNan` (lowercase n) in `float64`. 

```
# kaijuengine.com/matrix
matrix/vec2.go:273:9: undefined: IsNaN
matrix/vec3.go:435:9: undefined: IsNaN
```