### PR TITLE
Fix errors serialize PathFunc EmitterConfig, particle IDs

### DIFF
--- a/src/editor/editor_stage_manager/data_binding_renderer/particle_system_entity_data_renderer.go
+++ b/src/editor/editor_stage_manager/data_binding_renderer/particle_system_entity_data_renderer.go
@@ -42,6 +42,7 @@ import (
 	"kaijuengine.com/editor/codegen/entity_data_binding"
 	"kaijuengine.com/editor/editor_stage_manager"
 	"kaijuengine.com/engine"
+	"kaijuengine.com/engine_entity_data/content_id"
 	"kaijuengine.com/engine_entity_data/engine_entity_data_particles"
 	"kaijuengine.com/platform/profiler/tracing"
 	"kaijuengine.com/rendering"
@@ -103,13 +104,17 @@ func (c *ParticleSystemEntityDataRenderer) Hide(host *engine.Host, target *edito
 
 func (c *ParticleSystemEntityDataRenderer) Update(host *engine.Host, target *editor_stage_manager.StageEntity, data *entity_data_binding.EntityDataEntry) {
 	if g, ok := c.Systems[target]; ok {
-		id := data.FieldValueByName("Id").(string)
-		if g.id == id && target.Transform.IsDirty() {
+		id, ok := data.FieldValueByName("Id").(content_id.ParticleSystem)
+		if !ok {
+			slog.Error("particle system id failure", "id", id)
 			return
 		}
-		g.id = id
+		if g.id == string(id) && target.Transform.IsDirty() {
+			return
+		}
+		g.id = string(id)
 		g.system.Clear()
-		spec, err := vfx.LoadSpec(host, id)
+		spec, err := vfx.LoadSpec(host, string(id))
 		if err != nil {
 			slog.Error("invlaid particle system id specified", "id", id, "error", err)
 			return

--- a/src/rendering/vfx/emitter.go
+++ b/src/rendering/vfx/emitter.go
@@ -76,7 +76,7 @@ type EmitterConfig struct {
 	OpacityMinMax    matrix.Vec2
 	Color            matrix.Color
 	PathFuncName     string                      `options:"PathFuncName"`
-	PathFunc         func(t float64) matrix.Vec3 `visible:"hidden"`
+	PathFunc         func(t float64) matrix.Vec3 `visible:"hidden" json:"-"`
 	PathFuncOffset   float64
 	PathFuncScale    float32
 	PathFuncSpeed    float32


### PR DESCRIPTION
Two issues with particles 

```
time=2026-05-15T18:41:30.145+02:00 level=INFO msg="compiling the project with tags" tags=debug
time=2026-05-15T18:41:30.940+02:00 level=INFO msg="project executable successfully compiled"
time=2026-05-15T18:42:05.030+02:00 level=ERROR msg="failed to serialize the particle system" error="json: unsupported type: func(float64) matrix.Vec3"
time=2026-05-15T18:42:07.163+02:00 level=ERROR msg="failed to serialize the particle system" error="json: unsupported type: func(float64) matrix.Vec3"
```

After that fix:

```
time=2026-05-15T18:45:03.013+02:00 level=INFO msg="particle system successfully saved"
time=2026-05-15T18:45:03.890+02:00 level=INFO msg="particle system successfully saved"
panic: interface conversion: interface {} is content_id.ParticleSystem, not string

goroutine 21 [running, locked to thread]:
kaijuengine.com/editor/editor_stage_manager/data_binding_renderer.(*ParticleSystemEntityDataRenderer).Update(0x107b427e0?, 0xc0001c1b08, 0xc001942708, 0xc000a225b0)
```

Dodged the `error="json: unsupported type: func(float64) matrix.Vec3"` by setting `json:"-"`, unsure on what strategy to go for here. Can't serialize the func, but will it make sense ever without it when unserializing? 
