### PR TITLE
Add nil check in mesh import

### DIFF
--- a/src/editor/project/project_database/content_database/content_database_mesh.go
+++ b/src/editor/project/project_database/content_database/content_database_mesh.go
@@ -154,6 +154,7 @@ func (Mesh) Import(src string, _ *project_file_system.FileSystem) (ProcessedImpo
 		}
 		p.Variants = append(p.Variants, v)
 		if res.Meshes[i].Node == nil {
+			slog.Warn("import mesh failure on node", "index", i, "name", res.Meshes[i].Name)
 			continue
 		}
 		isAnimated := res.IsTreeAnimated(int(res.Meshes[i].Node.Id))

--- a/src/editor/project/project_database/content_database/content_database_mesh.go
+++ b/src/editor/project/project_database/content_database/content_database_mesh.go
@@ -153,6 +153,9 @@ func (Mesh) Import(src string, _ *project_file_system.FileSystem) (ProcessedImpo
 			Data: kd,
 		}
 		p.Variants = append(p.Variants, v)
+		if res.Meshes[i].Node == nil {
+			continue
+		}
 		isAnimated := res.IsTreeAnimated(int(res.Meshes[i].Node.Id))
 		postProcData[v.Name] = meshImportPostProcData{
 			mesh:         res.Meshes[i],


### PR DESCRIPTION
 Getting panic when importing `monkey.obj`

```
time=2026-05-15T19:09:14.579+02:00 level=INFO msg="compiling the project with tags" tags=debug
time=2026-05-15T19:09:15.449+02:00 level=INFO msg="project executable successfully compiled"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x102ba31bd]

goroutine 114 [running]:
kaijuengine.com/editor/project/project_database/content_database.Mesh.Import({}, {0xc000ff26c0, 0x3c}, 0x102e700d4?)
	/Users/jacob/Documents/kaiju/kaiju/src/editor/project/project_database/content_database/content_database_mesh.go:156 +0xb9d
kaijuengine.com/editor/project/project_database/content_database.Import({0xc000ff26c0, 0x3c}, 0xc0002ec0e0, 0xc0002ec0e8, {0x0, 0x0})
	/Users/jacob/Documents/kaiju/kaiju/src/editor/project/project_database/content_database/content_database.go:108 +0x2be
kaijuengine.com/editor/editor_workspace/content_workspace.ImportPaths.func2()
	/Users/jacob/Documents/kaiju/kaiju/src/editor/editor_workspace/content_workspace/content_workspace.go:264 +0xb4
```

Addded a nil check. We could return error also, but with the `continue` the import seems to work (see the mesh in editor).

Does this suggest that 1) Suzanne model is bricked or 2) something in the OBJ import fails-ish and some parts are nil?