### PR TITLE
#791 Fix console scroll stick

### DIFF
--- a/src/engine/systems/console/console.go
+++ b/src/engine/systems/console/console.go
@@ -256,6 +256,12 @@ func (c *Console) update(deltaTime float64) {
 	host := c.host.Value()
 	debug.EnsureNotNil(host)
 	kb := &host.Window.Keyboard
+
+	lblParent, ok := c.doc.GetElementById("consoleContent")
+	if ok && matrix.Abs(matrix.Float(lblParent.UIPanel.ScrollY())-lblParent.UIPanel.MaxScroll()[1]) < 50 {
+		lblParent.UIPanel.SetScrollY(matrix.FloatMax)
+	}
+
 	if !kb.HasModifier() && kb.KeyDown(hid.KeyboardKeyF1) {
 		c.toggle()
 	} else if kb.KeyDown(hid.KeyboardKeyUp) {


### PR DESCRIPTION
Fix scroll sticking to bottom on scroll to bottom. Non-stick on scroll up again, and on typing e.g. `help` which has a tall output, larger than hotnum 50. 

Is there a way to get the line height if Panel? See there is one for Label. Could make this a bit less hotnummed 