### PR TITLE
Begin console individual labels, colors & reuse

### DIFF
--- a/src/engine/systems/console/console.go
+++ b/src/engine/systems/console/console.go
@@ -164,7 +164,7 @@ func (c *Console) ExecCommand(key, arg string) (string, error) {
 
 func (c *Console) Write(message string) {
 	lbl := c.outputLabel()
-	lbl.SetText(lbl.Text() + "\n" + message)
+	lbl.SetText(message)
 }
 
 func (c *Console) help(*engine.Host, string) string {
@@ -187,7 +187,20 @@ func (c *Console) clear(*engine.Host, string) string {
 
 func (c *Console) outputLabel() *ui.Label {
 	cc, _ := c.doc.GetElementById("consoleContent")
-	return ui.FirstOnEntity(cc.Children[0].UI.Entity()).ToLabel()
+	if l := len(cc.Children); l > 1000 {
+		var last *ui.Label
+		for i := 1; i < l; i++ {
+			lbl := ui.FirstOnEntity(cc.Children[i-1].UI.Entity()).ToLabel()
+			last = ui.FirstOnEntity(cc.Children[i].UI.Entity()).ToLabel()
+			lbl.SetText(last.Text())
+		}
+		return last
+	}
+	new := cc.Children[len(cc.Children)-1]
+	cc.Children = append(cc.Children, new.Clone(cc))
+	lbl := cc.Children[len(cc.Children)-1].UI.ToLabel()
+	lbl.SetColor(matrix.ColorAquamarine())
+	return lbl
 }
 
 func (c *Console) submit(input *ui.Input) {
@@ -214,9 +227,9 @@ func (c *Console) submit(input *ui.Input) {
 	lblParent, _ := c.doc.GetElementById("consoleContent")
 	lbl := c.outputLabel()
 	if res != "" {
-		lbl.SetText(lbl.Text() + "\n" + cmdStr + "\n" + res)
+		lbl.SetText(cmdStr + "\n" + res)
 	} else {
-		lbl.SetText(lbl.Text() + "\n" + cmdStr)
+		lbl.SetText(cmdStr)
 	}
 	lblParent.UIPanel.SetScrollY(matrix.FloatMax)
 }

--- a/src/engine/systems/console/console.go
+++ b/src/engine/systems/console/console.go
@@ -167,6 +167,20 @@ func (c *Console) Write(message string) {
 	lbl.SetText(message)
 }
 
+func (c *Console) WriteColor(message string, color matrix.Color) {
+	lbl := c.outputLabel()
+	lbl.SetText(message)
+	lbl.EnforceFGColor(color)
+}
+
+func (c *Console) WriteError(message string) {
+	c.WriteColor(message, matrix.ColorRed())
+}
+
+func (c *Console) WriteSuccess(message string) {
+	c.WriteColor(message, matrix.ColorGreen())
+}
+
 func (c *Console) help(*engine.Host, string) string {
 	sb := strings.Builder{}
 	sb.WriteString("Available Commands:\n")
@@ -192,14 +206,16 @@ func (c *Console) outputLabel() *ui.Label {
 		for i := 1; i < l; i++ {
 			lbl := ui.FirstOnEntity(cc.Children[i-1].UI.Entity()).ToLabel()
 			last = ui.FirstOnEntity(cc.Children[i].UI.Entity()).ToLabel()
+			lbl.UnEnforceFGColor()
+			lbl.EnforceFGColor(last.GetColor())
 			lbl.SetText(last.Text())
 		}
+		last.UnEnforceFGColor()
 		return last
 	}
-	new := cc.Children[len(cc.Children)-1]
-	cc.Children = append(cc.Children, new.Clone(cc))
-	lbl := cc.Children[len(cc.Children)-1].UI.ToLabel()
-	lbl.SetColor(matrix.ColorAquamarine())
+	new := cc.Children[len(cc.Children)-1].Clone(cc)
+	cc.Children = append(cc.Children, new)
+	lbl := new.UI.ToLabel()
 	return lbl
 }
 

--- a/src/engine/systems/console/console.go
+++ b/src/engine/systems/console/console.go
@@ -195,7 +195,11 @@ func (c *Console) help(*engine.Host, string) string {
 }
 
 func (c *Console) clear(*engine.Host, string) string {
-	c.outputLabel().SetText("")
+	cc, _ := c.doc.GetElementById("consoleContent")
+	for _, c := range cc.Children {
+		c.UI.Entity().Deactivate()
+	}
+	cc.UIPanel.SetScrollY(0)
 	return ""
 }
 
@@ -214,7 +218,7 @@ func (c *Console) outputLabel() *ui.Label {
 		return last
 	}
 	new := cc.Children[len(cc.Children)-1].Clone(cc)
-	cc.Children = append(cc.Children, new)
+	cc.UIPanel.AddChild(new.UI)
 	lbl := new.UI.ToLabel()
 	return lbl
 }

--- a/src/engine/ui/label.go
+++ b/src/engine/ui/label.go
@@ -314,6 +314,10 @@ func (label *Label) setLabelScissors() {
 	}
 }
 
+func (label *Label) GetColor() matrix.Color {
+	return label.LabelData().fgColor
+}
+
 func (label *Label) SetColor(newColor matrix.Color) {
 	ld := label.LabelData()
 	if ld.isForcedFGColor || ld.fgColor.Equals(newColor) {


### PR DESCRIPTION
See #791 & #809 

Begin try making console rows/entries individual labels, to:
- Support individual entry colors, style
- Possibly improve console scroll-stick-to-bottom logic



Current limitations:
- ~~`lbl.SetColor(matrix.ColorAquamarine())` isn't showing, unsure why. I've tried other approaches than using `.Clone` on an element, like building manually, but gotten stuck in nil pointer issues~~ 

> Fixed in 90cc0598dc0795c2da8f8340355dcb99d80cf9b4. Had to use `EnforceFGColor`, otherwise the entries got their color from parent (`setChildTextColor(elm, color)` override)


- Hard coded `1000` limit on the entries, no history of past

Thoughts:
- I guess it's possible (as discussed in #809) to keep a history (`[]string`?), detect scroll up at the top and then shift currently showing entries downward. However, would this make the scroll look "discrete" and not "continuous" (shift/scroll _whole_ rows, not fractions)?
- Would the scroll bar at the side reflect the real number of entries if we cap visually? Maybe that's not an issue?


Feedback welcome! 


<img width="671" height="385" alt="image" src="https://github.com/user-attachments/assets/30419d38-fd41-4d3f-a964-c93a6ceab5e1" />
