### PR TITLE
Add oklab/oklch color + tests

### DIFF
--- a/src/matrix/color.go
+++ b/src/matrix/color.go
@@ -85,6 +85,7 @@ func OklabToColor(l, a, b, alpha Float) Color {
 		} else {
 			c[i] = 12.92 * c[i]
 		}
+		c[i] = Max(Min(c[i], 1), 0) // Naive clamping, could instead reduce chroma until no overflow
 	}
 	return c
 }

--- a/src/matrix/color.go
+++ b/src/matrix/color.go
@@ -9,6 +9,7 @@ package matrix
 import (
 	"encoding/binary"
 	"fmt"
+	"math"
 	"strings"
 )
 
@@ -49,6 +50,43 @@ func NewColor(r, g, b, a Float) Color {
 
 func NewColor8(r, g, b, a uint8) Color8 {
 	return Color8{r, g, b, a}
+}
+
+// https://bottosson.github.io/posts/oklab/#the-oklab-color-space
+// h (hue) is in degrees
+func OklchToColor(l, c, h, alpha Float) Color {
+	a := c * Cos(Float(h)*((2*math.Pi)/360.0))
+	b := c * Sin(Float(h)*((2*math.Pi)/360.0))
+	return OklabToColor(l, a, b, alpha)
+}
+
+// https://bottosson.github.io/posts/oklab/#converting-from-linear-srgb-to-oklab
+func OklabToColor(l, a, b, alpha Float) Color {
+	var l_ Float = l + 0.3963377774*a + 0.2158037573*b
+	var m_ Float = l - 0.1055613458*a - 0.0638541728*b
+	var s_ Float = l - 0.0894841775*a - 1.2914855480*b
+
+	l__ := l_ * l_ * l_
+	a__ := m_ * m_ * m_
+	b__ := s_ * s_ * s_
+
+	c := Color{
+		+4.0767416621*l__ - 3.3077115913*a__ + 0.2309699292*b__,
+		-1.2684380046*l__ + 2.6097574011*a__ - 0.3413193965*b__,
+		-0.0041960863*l__ - 0.7034186147*a__ + 1.7076147010*b__,
+		alpha,
+	}
+
+	// https://bottosson.github.io/posts/colorwrong/#what-can-we-do%3F
+	// Oklab uses linear sRGB, convert to display sRGB
+	for i := range c[:3] {
+		if c[i] >= 0.0031308 {
+			c[i] = (1.055)*Pow(c[i], (1.0/2.4)) - 0.055
+		} else {
+			c[i] = 12.92 * c[i]
+		}
+	}
+	return c
 }
 
 func ColorFromColor8(c Color8) Color {

--- a/src/matrix/color_test.go
+++ b/src/matrix/color_test.go
@@ -7,6 +7,7 @@
 package matrix
 
 import (
+	"fmt"
 	"math"
 	"testing"
 )
@@ -60,6 +61,53 @@ func TestColorRGBInt(t *testing.T) {
 	}
 	if !Approx(c.A(), 1.0) {
 		t.Errorf("A should be 1.0, got %v", c.A())
+	}
+}
+
+// https://oklch.com/#0.7,0.1,71,100
+func TestColorOklabOklch(t *testing.T) {
+	half := 0.5 * 255
+	colors := []Color{
+		OklabToColor(0.7, 0.03, 0.09, 1),
+		ColorRGBAInt(198.0, 148.0, 85.0, 255),
+
+		OklabToColor(0.7, 0.03, -0.1, 0.6),
+		ColorRGBAInt(154, 149, 218, 0.6*255),
+
+		OklabToColor(0.7, 0.09, 0.05, 1),
+		ColorRGBAInt(213, 134, 121, 255),
+
+		OklabToColor(0.7, 0.09, 0.05, 0.5),
+		ColorRGBAInt(215, 133, 121, int(half)),
+
+		OklchToColor(1, 0, 0, 1),
+		ColorRGBAInt(255, 255, 255, 255),
+
+		OklchToColor(1, 0, 180, 1),
+		ColorRGBAInt(255, 255, 255, 255),
+
+		OklchToColor(0.7, 0.1, 312, 1),
+		ColorRGBAInt(179, 140, 204, 255),
+
+		OklchToColor(0.7, 0.1, 37, 1),
+		ColorRGBAInt(212, 136, 114, 255),
+
+		OklchToColor(0.595, 0.1, 108, 1),
+		ColorRGBAInt(133, 131, 53, 255),
+	}
+
+	for i := 0; i < len(colors); i += 2 {
+		o := colors[i]
+		rgb := colors[i+1]
+		t.Run(fmt.Sprintf("oklab_%v", o), func(t *testing.T) {
+			t.Parallel()
+			for i, c := range o {
+				rgbValue := rgb[i]
+				if !ApproxTo(c, rgbValue, 0.02) {
+					t.Errorf("got %f, want %f", c, rgbValue)
+				}
+			}
+		})
 	}
 }
 

--- a/src/matrix/color_test.go
+++ b/src/matrix/color_test.go
@@ -109,6 +109,11 @@ func TestColorOklabOklch(t *testing.T) {
 			}
 		})
 	}
+	// Test clamping, this color doesn't have a true RGB equivalent
+	co := OklchToColor(0.9, 0.103, 29.05, 1)
+	if !Approx(co[0], 1.0) {
+		t.Error("oklch clamping failure, want 1.0")
+	}
 }
 
 // ============================================================================


### PR DESCRIPTION
Initially thought of adding this for CSS reasons: many CSS component libraries use `oklch` and Kaiju having it would bring usage of such components closer. 

However, the CSS syntax of `oklch(59.69% 0.156 49.77 / .5)` (with `%` and `/`) felt tricky to support ATM. Saving that for the future. For now adding general Oklab + Oklch support here in the `matrix` package. 

Oklab sources: 
1. Oklch to Oklab https://bottosson.github.io/posts/oklab/#the-oklab-color-space
2. Oklab to linear sRGB https://bottosson.github.io/posts/oklab/#converting-from-linear-srgb-to-oklab
3. Linear sRGB to display RGB https://bottosson.github.io/posts/colorwrong/#what-can-we-do%3F

See also
- https://oklch.com/#0.7,0.103,29.05,50
- https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/color_value/oklch
- https://tailwindcss.com/docs/color (Tailwind usage of `oklch`)

Run the tests with `go test -run TestColorOklab kaijuengine.com/matrix -v` 
 
Thoughts on adding this? 