### PR TITLE
Added file drag and drop support for MacOS

### DIFF
--- a/src/platform/windowing/cocoa_window.h
+++ b/src/platform/windowing/cocoa_window.h
@@ -80,4 +80,9 @@ bool cocoa_get_caps_lock_toggle_key_state(void);
 
 void cocoa_run_app(void);
 
+// File drop (drag-and-drop from Finder)
+#if KAIJU_ENABLE_FILEDROP
+void cocoa_set_file_drop_enabled(void* nsView, bool enabled);
+#endif
+
 #endif // COCOA_WINDOW_H

--- a/src/platform/windowing/cocoa_window.m
+++ b/src/platform/windowing/cocoa_window.m
@@ -11,9 +11,19 @@
 #include "cocoa_window.h"
 #include "window_event.h"
 
+#pragma mark - File drop bridge (defined in window_darwin_filedrop.go)
+
+#if KAIJU_ENABLE_FILEDROP
+extern void goProcessFileDropDarwin(uint64_t goWindow, int32_t x, int32_t y, void* paths, uint32_t pathCount);
+static inline SharedMem* getSharedMem(NSWindow* window);
+#endif
+
 #pragma mark - Metal View
 
 @interface MetalView : NSView
+#if KAIJU_ENABLE_FILEDROP
+<NSDraggingDestination>
+#endif
 @end
 
 @implementation MetalView
@@ -32,6 +42,60 @@
 }
 - (CALayer*)makeBackingLayer { return [[CAMetalLayer alloc] init]; }
 - (BOOL)wantsUpdateLayer { return YES; }
+
+#if KAIJU_ENABLE_FILEDROP
+- (NSDragOperation)draggingEntered:(id<NSDraggingInfo>)sender {
+	NSPasteboard* pb = [sender draggingPasteboard];
+	if ([[pb types] containsObject:NSPasteboardTypeFileURL]) {
+		return NSDragOperationCopy;
+	}
+	return NSDragOperationNone;
+}
+
+- (NSDragOperation)draggingUpdated:(id<NSDraggingInfo>)sender {
+	return [self draggingEntered:sender];
+}
+
+- (BOOL)prepareForDragOperation:(id<NSDraggingInfo>)sender {
+	return YES;
+}
+
+- (BOOL)performDragOperation:(id<NSDraggingInfo>)sender {
+	NSWindow* win = self.window;
+	if (!win) return NO;
+	SharedMem* sm = getSharedMem(win);
+	if (!sm) return NO;
+
+	NSArray<NSURL*>* urls = [[sender draggingPasteboard]
+		readObjectsForClasses:@[[NSURL class]] options:nil];
+	if (urls.count == 0) return NO;
+
+	uint32_t pathCount = (uint32_t)urls.count;
+	char** paths = (char**)calloc(pathCount, sizeof(char*));
+	if (!paths) return NO;
+
+	uint32_t actual = 0;
+	for (NSURL* u in urls) {
+		const char* utf8 = [[u path] UTF8String];
+		if (!utf8) continue;
+		paths[actual++] = strdup(utf8);
+	}
+
+	NSPoint loc = [self convertPoint:[sender draggingLocation] fromView:nil];
+	int32_t x = (int32_t)loc.x;
+	int32_t y = sm->windowHeight - (int32_t)loc.y;
+
+	if (actual > 0) {
+		goProcessFileDropDarwin((uint64_t)(uintptr_t)sm->goWindow, x, y, paths, actual);
+	}
+
+	for (uint32_t i = 0; i < actual; ++i) {
+		free(paths[i]);
+	}
+	free(paths);
+	return actual > 0;
+}
+#endif
 @end
 
 #pragma mark - App Delegate
@@ -782,6 +846,23 @@ bool cocoa_get_caps_lock_toggle_key_state(void) {
         return (flags & NSEventModifierFlagCapsLock) != 0;
     }
 }
+
+#if KAIJU_ENABLE_FILEDROP
+void cocoa_set_file_drop_enabled(void* nsView, bool enabled) {
+	if (!nsView) return;
+
+	dispatch_async(dispatch_get_main_queue(), ^{
+		@autoreleasepool {
+			NSView* view = (__bridge NSView*)nsView;
+			if (enabled) {
+				[view registerForDraggedTypes:@[NSPasteboardTypeFileURL]];
+			} else {
+				[view unregisterDraggedTypes];
+			}
+		}
+	});
+}
+#endif
 
 void cocoa_set_icon(void* nsWindow, int width, int height, const uint8_t* pixelData) {
 	if (!pixelData || width <= 0 || height <= 0) {

--- a/src/platform/windowing/window.darwin.go
+++ b/src/platform/windowing/window.darwin.go
@@ -260,9 +260,6 @@ func (w *Window) setIcon(img image.Image) {
 	C.cocoa_set_icon(w.instance, C.int(width), C.int(height), (*C.uint8_t)(&rgba.Pix[0]))
 }
 
-// TODO: placeholder
-func (w *Window) setFileDropEnabled(enabled bool) {}
-
 // App asset read (private)
 // On macOS, application assets are stored in the app bundle's Resources folder.
 // This function reads files from Contents/Resources/ in the .app bundle.

--- a/src/platform/windowing/window_darwin_filedrop.go
+++ b/src/platform/windowing/window_darwin_filedrop.go
@@ -1,0 +1,34 @@
+//go:build darwin && (editor || filedrop)
+
+/******************************************************************************/
+/* window_darwin_filedrop.go                                                  */
+/******************************************************************************/
+/* MIT License, Copyright (c) 2015-present Brent Farris, (John 4:13-14)       */
+/******************************************************************************/
+
+package windowing
+
+import "unsafe"
+
+/*
+#cgo CFLAGS: -DKAIJU_ENABLE_FILEDROP=1
+
+#include "cocoa_window.h"
+*/
+import "C"
+
+//export goProcessFileDropDarwin
+func goProcessFileDropDarwin(goWindow C.uint64_t, x C.int32_t, y C.int32_t, paths unsafe.Pointer, pathCount C.uint32_t) {
+	ptrs := unsafe.Slice((**C.char)(paths), int(pathCount))
+	goPaths := make([]string, 0, int(pathCount))
+	for i := range ptrs {
+		if ptrs[i] != nil {
+			goPaths = append(goPaths, C.GoString(ptrs[i]))
+		}
+	}
+	queueNativeFileDropEvent(uint64(goWindow), int(x), int(y), goPaths)
+}
+
+func (w *Window) setFileDropEnabled(enabled bool) {
+	C.cocoa_set_file_drop_enabled(w.handle, C.bool(enabled))
+}


### PR DESCRIPTION
### Summary

- Brings the macOS editor up to parity with the Windows file-drop path. Dragging files from Finder into the editor window now fires `Window.OnFileDrop`, routed through the existing `FileDropRouter` (no changes needed in upper layers).
- Implements `NSDraggingDestination` on the Metal-backed content view: registers `NSPasteboardTypeFileURL`, accepts the drop as `NSDragOperationCopy`, converts NSURLs to UTF-8 paths, and forwards them with client-area Y-down coordinates to match the Windows convention.
- Adds a new `window_darwin_filedrop.go` mirroring `window_windows_filedrop.go`: provides the real `setFileDropEnabled` and the cgo-exported `goProcessFileDropDarwin` callback. Gated by the same `editor || filedrop` build tag and `KAIJU_ENABLE_FILEDROP` macro that Windows uses, so non-editor builds remain unaffected.
- Removes the no-op `setFileDropEnabled` stub from `window.darwin.go` that previously made enabling file drop a silent no-op on macOS.

### Testing done

- [x]  On macOS editor build, drag a single file from Finder into the stage viewport → confirm it imports as content.
- [x]  Drag multiple files in one drop → confirm all are imported.
- [x]  Drag a folder → confirm it routes through the same pipeline as on Windows.
