### PR TITLE
fix: flex layout fixes when using complex column and row based flex

### DIFF
--- a/src/engine/ui/layout.go
+++ b/src/engine/ui/layout.go
@@ -198,7 +198,11 @@ func (l *Layout) Scale(width, height float32) bool {
 	}
 	size := matrix.Vec3{width, height, 1.0}
 	if l.ui.Entity().Parent != nil {
-		size.DivideAssign(l.ui.Entity().Parent.Transform.WorldScale())
+		parentScale := l.ui.Entity().Parent.Transform.WorldScale()
+		if matrix.Approx(parentScale.X(), 0) || matrix.Approx(parentScale.Y(), 0) {
+			return false
+		}
+		size.DivideAssign(parentScale)
 	}
 	l.ui.Entity().Transform.ScaleWithoutChildren(size)
 	l.ui.layoutChanged(DirtyTypeResize)
@@ -210,9 +214,16 @@ func (l *Layout) ScaleWidth(width float32) bool {
 	if matrix.ApproxTo(ps[matrix.Vx], width, fractionOfPixel) {
 		return false
 	}
+	if matrix.Approx(width, 0) {
+		return false
+	}
 	size := matrix.Vec3{width, ps.Height(), 1.0}
 	if l.ui.Entity().Parent != nil {
-		size.DivideAssign(l.ui.Entity().Parent.Transform.WorldScale())
+		parentScale := l.ui.Entity().Parent.Transform.WorldScale()
+		if matrix.Approx(parentScale.X(), 0) || matrix.Approx(parentScale.Y(), 0) {
+			return false
+		}
+		size.DivideAssign(parentScale)
 	}
 	l.ui.Entity().Transform.ScaleWithoutChildren(size)
 	l.prepare()
@@ -230,7 +241,11 @@ func (l *Layout) ScaleHeight(height float32) bool {
 	}
 	size := matrix.Vec3{ps.Width(), height, 1.0}
 	if l.ui.Entity().Parent != nil {
-		size.DivideAssign(l.ui.Entity().Parent.Transform.WorldScale())
+		parentScale := l.ui.Entity().Parent.Transform.WorldScale()
+		if matrix.Approx(parentScale.X(), 0) || matrix.Approx(parentScale.Y(), 0) {
+			return false
+		}
+		size.DivideAssign(parentScale)
 	}
 	l.ui.Entity().Transform.ScaleWithoutChildren(size)
 	l.prepare()

--- a/src/engine/ui/markup/css/default.css
+++ b/src/engine/ui/markup/css/default.css
@@ -360,6 +360,9 @@ td {
 	display: table-cell;
 	vertical-align: inherit;
 }
+template {
+	display: none;
+}
 tfoot {
 	display: table-footer-group;
 	vertical-align: middle;

--- a/src/engine/ui/markup/css/properties/css_flex.go
+++ b/src/engine/ui/markup/css/properties/css_flex.go
@@ -42,15 +42,20 @@ func (p Flex) Process(panel *ui.Panel, elm *document.Element, values []rules.Pro
 			layout.SetFlexGrow(grow)
 			layout.SetFlexShrink(1)
 			layout.SetFlexBasis(0, false)
+			if grow > 0 {
+				panel.DontFitContent()
+			}
 			return nil
 		}
 		layout.SetFlexGrow(0)
 		layout.SetFlexShrink(1)
-		setFlexBasis(layout, values[0].Str, host)
+		setFlexBasis(panel, values[0].Str, host)
 		return nil
 	}
-	if grow, ok := parseFlexFloat(values[0].Str); ok {
-		layout.SetFlexGrow(grow)
+	var grow float32
+	if g, ok := parseFlexFloat(values[0].Str); ok {
+		grow = g
+		layout.SetFlexGrow(g)
 	} else {
 		return fmt.Errorf("invalid flex-grow value %q", values[0].Str)
 	}
@@ -62,9 +67,12 @@ func (p Flex) Process(panel *ui.Panel, elm *document.Element, values []rules.Pro
 		layout.SetFlexShrink(1)
 	}
 	if basisIdx < len(values) {
-		setFlexBasis(layout, values[basisIdx].Str, host)
+		setFlexBasis(panel, values[basisIdx].Str, host)
 	} else {
 		layout.SetFlexBasis(0, false)
+	}
+	if grow > 0 {
+		panel.DontFitContent()
 	}
 	return nil
 }

--- a/src/engine/ui/markup/css/properties/css_flex_basis.go
+++ b/src/engine/ui/markup/css/properties/css_flex_basis.go
@@ -17,6 +17,6 @@ func (p FlexBasis) Process(panel *ui.Panel, elm *document.Element, values []rule
 	if len(values) == 0 {
 		return nil
 	}
-	setFlexBasis(panel.Base().Layout(), values[0].Str, host)
+	setFlexBasis(panel, values[0].Str, host)
 	return nil
 }

--- a/src/engine/ui/markup/css/properties/css_flex_grow.go
+++ b/src/engine/ui/markup/css/properties/css_flex_grow.go
@@ -28,5 +28,8 @@ func (p FlexGrow) Process(panel *ui.Panel, elm *document.Element, values []rules
 		return fmt.Errorf("invalid flex-grow value %q", values[0].Str)
 	}
 	panel.Base().Layout().SetFlexGrow(grow)
+	if grow > 0 {
+		panel.DontFitContent()
+	}
 	return nil
 }

--- a/src/engine/ui/markup/css/properties/css_flex_helpers.go
+++ b/src/engine/ui/markup/css/properties/css_flex_helpers.go
@@ -21,8 +21,9 @@ func parseFlexFloat(value string) (float32, bool) {
 	return float32(f), err == nil
 }
 
-func setFlexBasis(layout *ui.Layout, value string, host *engine.Host) {
+func setFlexBasis(panel *ui.Panel, value string, host *engine.Host) {
 	value = strings.TrimSpace(value)
+	layout := panel.Base().Layout()
 	switch value {
 	case "", "auto", "initial", "inherit", "unset":
 		layout.SetFlexBasisAuto()

--- a/src/engine/ui/markup/css/properties/css_height.go
+++ b/src/engine/ui/markup/css/properties/css_height.go
@@ -28,11 +28,6 @@ func (p Height) Process(panel *ui.Panel, elm *document.Element, values []rules.P
 	panel.DontFitContentHeight()
 	l := panel.Base().Layout()
 	c := currentSizingConstraints(panel)
-	if c.HasBoxSizing() && !c.UsesBorderBox() {
-		height += l.Padding().Vertical() + l.Border().Vertical()
-	}
-
-	height = applyHeightConstraints(panel, height)
 	if strings.HasSuffix(values[0].Str, "%") {
 		if l.Ui().Entity().IsRoot() {
 			finalH := applyHeightConstraints(panel, float32(host.Window.Height())*height)
@@ -57,9 +52,6 @@ func (p Height) Process(panel *ui.Panel, elm *document.Element, values []rules.P
 			val.Args = append(val.Args, "height")
 			res, _ := functions.Calc{}.Process(panel, elm, val)
 			height = helpers.NumFromLength(res, host.Window)
-			if c.HasBoxSizing() && !c.UsesBorderBox() {
-				height += l.Padding().Vertical() + l.Border().Vertical()
-			}
 			height = applyHeightConstraints(panel, height)
 			l.ScaleHeight(height)
 			if c.HasAspectRatio() && c.AspectRatio > 0 {
@@ -67,7 +59,8 @@ func (p Height) Process(panel *ui.Panel, elm *document.Element, values []rules.P
 			}
 		}
 	} else {
-		panel.Base().Layout().ScaleHeight(height)
+		height = applyHeightConstraints(panel, height)
+		l.ScaleHeight(height)
 		if c.HasAspectRatio() && c.AspectRatio > 0 {
 			l.ScaleWidth(applyWidthConstraints(panel, height*c.AspectRatio))
 		}

--- a/src/engine/ui/markup/css/properties/css_overflow.go
+++ b/src/engine/ui/markup/css/properties/css_overflow.go
@@ -36,6 +36,7 @@ func (p Overflow) Process(panel *ui.Panel, elm *document.Element, values []rules
 		panel.SetOverflow(ui.OverflowScroll)
 		panel.Base().GenerateScissor()
 		panel.SetScrollDirection(ui.PanelScrollDirectionBoth)
+		panel.DontFitContent()
 	case "inherit":
 		if elm.Parent.Value() != nil {
 			parentPanel := elm.Parent.Value().UIPanel

--- a/src/engine/ui/markup/css/properties/css_overflow_x.go
+++ b/src/engine/ui/markup/css/properties/css_overflow_x.go
@@ -40,6 +40,7 @@ func (p OverflowX) Process(panel *ui.Panel, elm *document.Element, values []rule
 		panel.SetScrollDirection(panel.ScrollDirection() | ui.PanelScrollDirectionHorizontal)
 		panel.SetOverflow(ui.OverflowScroll)
 		panel.Base().GenerateScissor()
+		panel.DontFitContentWidth()
 	case "inherit":
 		if elm.Parent.Value() != nil {
 			parentPanel := elm.Parent.Value().UIPanel

--- a/src/engine/ui/markup/css/properties/css_overflow_y.go
+++ b/src/engine/ui/markup/css/properties/css_overflow_y.go
@@ -41,7 +41,6 @@ func (p OverflowY) Process(panel *ui.Panel, elm *document.Element, values []rule
 		panel.SetOverflow(ui.OverflowScroll)
 		panel.Base().GenerateScissor()
 		panel.DontFitContentHeight()
-		panel.DontFitContentHeight()
 	case "inherit":
 		if elm.Parent.Value() != nil {
 			parentPanel := elm.Parent.Value().UIPanel

--- a/src/engine/ui/markup/css/properties/css_overflow_y.go
+++ b/src/engine/ui/markup/css/properties/css_overflow_y.go
@@ -40,6 +40,8 @@ func (p OverflowY) Process(panel *ui.Panel, elm *document.Element, values []rule
 		panel.SetScrollDirection(panel.ScrollDirection() | ui.PanelScrollDirectionVertical)
 		panel.SetOverflow(ui.OverflowScroll)
 		panel.Base().GenerateScissor()
+		panel.DontFitContentHeight()
+		panel.DontFitContentHeight()
 	case "inherit":
 		if elm.Parent.Value() != nil {
 			parentPanel := elm.Parent.Value().UIPanel

--- a/src/engine/ui/markup/css/properties/css_width.go
+++ b/src/engine/ui/markup/css/properties/css_width.go
@@ -37,10 +37,6 @@ func (p Width) Process(panel *ui.Panel, elm *document.Element, values []rules.Pr
 	panel.DontFitContentWidth()
 	l := panel.Base().Layout()
 	c := currentSizingConstraints(panel)
-	if c.HasBoxSizing() && !c.UsesBorderBox() {
-		width += l.Padding().Horizontal() + l.Border().Horizontal()
-	}
-	width = applyWidthConstraints(panel, width)
 	if strings.HasSuffix(values[0].Str, "%") {
 		if l.Ui().Entity().IsRoot() {
 			finalW := applyWidthConstraints(panel, float32(host.Window.Width())*width)
@@ -83,9 +79,6 @@ func (p Width) Process(panel *ui.Panel, elm *document.Element, values []rules.Pr
 			val.Args = append(val.Args, "width")
 			res, _ := functions.Calc{}.Process(panel, elm, val)
 			width = helpers.NumFromLength(res, host.Window)
-			if c.HasBoxSizing() && !c.UsesBorderBox() {
-				width += l.Padding().Horizontal() + l.Border().Horizontal()
-			}
 			width = applyWidthConstraints(panel, width)
 			l.ScaleWidth(width)
 			if c.HasAspectRatio() && c.AspectRatio > 0 {
@@ -93,7 +86,8 @@ func (p Width) Process(panel *ui.Panel, elm *document.Element, values []rules.Pr
 			}
 		}
 	} else {
-		panel.Base().Layout().ScaleWidth(width)
+		width = applyWidthConstraints(panel, width)
+		l.ScaleWidth(width)
 		if c.HasAspectRatio() && c.AspectRatio > 0 {
 			l.ScaleHeight(applyHeightConstraints(panel, width/c.AspectRatio))
 		}


### PR DESCRIPTION
Was running into issues with column flex, trying to vertically center, even when set to flex-start, as well as general viewport sizing issues caused by a divide by 0 when it was checking world size