### PR TITLE
Change graviton init for mesh

### DIFF
--- a/src/engine/graviton/mesh_test.go
+++ b/src/engine/graviton/mesh_test.go
@@ -33,7 +33,8 @@ func TestStaticMeshBodyGeneratesBroadPhaseAABB(t *testing.T) {
 	system.Initialize()
 	body := system.NewBody()
 	body.Transform.SetPosition(matrix.Vec3{3, 0, 0})
-	body.SetStaticMesh(testTriangleMesh())
+	body.SetShapeMesh(testTriangleMesh())
+	body.SetStatic()
 	system.broadPhase.Rebuild(&system.bodies)
 	if len(system.broadPhase.proxies) != 1 {
 		t.Fatalf("expected 1 broad phase proxy, got %d", len(system.broadPhase.proxies))
@@ -53,7 +54,8 @@ func TestSystemRaycastHitsStaticMesh(t *testing.T) {
 	system.Initialize()
 	body := system.NewBody()
 	body.Transform.SetPosition(matrix.Vec3{3, 0, 0})
-	body.SetStaticMesh(testTriangleMesh())
+	body.SetShapeMesh(testTriangleMesh())
+	body.SetStatic()
 	hit, ok := system.Raycast(matrix.Vec3{3, 0, 1}, matrix.Vec3{3, 0, -1})
 	if !ok {
 		t.Fatal("expected raycast to hit mesh")

--- a/src/engine/graviton/narrow_phase_test.go
+++ b/src/engine/graviton/narrow_phase_test.go
@@ -311,7 +311,8 @@ func TestSystemDynamicSphereRestsOnStaticMeshFloor(t *testing.T) {
 	sphere.Collision.Shape = NewSphereShape(0.5)
 	sphere.Transform.SetPosition(matrix.Vec3{0, 0.5, 0})
 	floor := system.NewBody()
-	floor.SetStaticMesh(testMeshFloor())
+	floor.SetShapeMesh(testMeshFloor())
+	floor.SetStatic()
 	workGroup := concurrent.WorkGroup{}
 	workGroup.Init()
 	threads := concurrent.Threads{}
@@ -418,7 +419,8 @@ func testRigidBody(shape Shape, position matrix.Vec3) *RigidBody {
 func testStaticMeshBody(mesh *MeshCollision) *RigidBody {
 	body := &RigidBody{}
 	body.Transform.SetupRawTransform()
-	body.SetStaticMesh(mesh)
+	body.SetShapeMesh(mesh)
+	body.SetStatic()
 	return body
 }
 

--- a/src/engine/graviton/rigid_body.go
+++ b/src/engine/graviton/rigid_body.go
@@ -132,7 +132,7 @@ func (r *RigidBody) SetShape(shape Shape) {
 	r.ensureDefaultCollisionFilter()
 }
 
-func (r *RigidBody) SetStaticMesh(mesh *MeshCollision) {
+func (r *RigidBody) SetShapeMesh(mesh *MeshCollision) {
 	r.Collision.Mesh = mesh
 	r.Collision.Terrain = nil
 	bounds := NewAABB(matrix.Vec3Zero(), matrix.Vec3Zero())
@@ -141,7 +141,6 @@ func (r *RigidBody) SetStaticMesh(mesh *MeshCollision) {
 	}
 	r.Collision.Shape = NewMeshShape(bounds)
 	r.Collision.LocalAABB = bounds
-	r.SetStatic()
 	r.ensureDefaultCollisionFilter()
 }
 

--- a/src/engine_entity_data/engine_entity_data_physics/rigid_body_entity_data.go
+++ b/src/engine_entity_data/engine_entity_data_physics/rigid_body_entity_data.go
@@ -70,17 +70,17 @@ func (r RigidBodyEntityData) gravitonRigidBody(e *engine.Entity, host *engine.Ho
 	body.Transform.SetupRawTransform()
 	body.Transform.SetPosition(e.Transform.Position())
 	body.Transform.SetRotation(e.Transform.Rotation())
-	if r.Shape == ShapeMesh {
-		body.SetStaticMesh(r.gravitonMesh(host))
-		return body
-	}
-	if r.Shape == ShapeTerrain {
+	shape := r.gravitonShape(e.Transform.Scale())
+	switch r.Shape {
+	case ShapeTerrain:
 		body.SetStaticTerrain(r.gravitonTerrain(e))
 		return body
+	case ShapeMesh:
+		body.SetShapeMesh(r.gravitonMesh(host))
+	default:
+		body.SetShape(shape)
 	}
-	shape := r.gravitonShape(e.Transform.Scale())
 	// Scale is baked into the shape dimensions to match the existing behavior.
-	body.SetShape(shape)
 	if r.IsStatic {
 		body.SetStatic()
 	} else {


### PR DESCRIPTION
Spent some more time on #835, had some problems with `ShapeMesh` in Graviton:

- Made some changes in `func (r RigidBodyEntityData) gravitonRigidBody` for mesh specifically, looked like the `ShapeMesh` were unconditionally set to static? In-game I couldn't get them moving.  
- Changed `SetStaticMesh` to `SetShapeMesh` (same but without the `SetStatic`part), and in above let `ShapeMesh` run through the same flow as the rest (static/dynamic setup)
- Aligned the tests (`go test kaijuengine.com/engine/graviton/ -v` OK)

I can verify in game that the `ShapeMesh` now move around, and other types can collide with them. I've not been able to get two `ShapeMesh` to collide with each other though.

No hurry looking through this at all, just thought I could add an update.
