### PR TITLE
feat: camera zoom to cursor position

### DIFF
--- a/src/editor/editor_controls/editor_camera.go
+++ b/src/editor/editor_controls/editor_camera.go
@@ -7,6 +7,7 @@
 package editor_controls
 
 import (
+	"log/slog"
 	"math"
 
 	"kaijuengine.com/editor/editor_settings"
@@ -475,8 +476,12 @@ func (e *EditorCamera) update3d(host *engine.Host, _ float64) (changed bool) {
 		}
 		zoomFloor := klib.ClampAbs(mouse.Scroll().Y(), e.Settings.ZoomSpeed)
 		if hid.Keyboard.KeyHeld(host.Window.Keyboard, hid.KeyboardKeyLeftAlt) {
-			hitPoint, _ := tc.ForwardPlaneHit(mp, tc.LookAt())
-			tc.DollyTo(zoomFloor*scale, hitPoint)
+			hitPoint, ok := tc.ForwardPlaneHit(mp, tc.LookAt())
+			if ok {
+				tc.DollyTo(zoomFloor*scale, hitPoint)
+			} else {
+				slog.Warn("CameraCursor Zoom: mouse screen to world conversion failed")
+			}
 		} else {
 			tc.Dolly(zoomFloor * scale)
 		}

--- a/src/editor/editor_controls/editor_camera.go
+++ b/src/editor/editor_controls/editor_camera.go
@@ -474,7 +474,12 @@ func (e *EditorCamera) update3d(host *engine.Host, _ float64) (changed bool) {
 			scale *= zoom / 1.0
 		}
 		zoomFloor := klib.ClampAbs(mouse.Scroll().Y(), e.Settings.ZoomSpeed)
-		tc.Dolly(zoomFloor * scale)
+		if hid.Keyboard.KeyHeld(host.Window.Keyboard, hid.KeyboardKeyLeftAlt) {
+			hitPoint, _ := tc.ForwardPlaneHit(mp, tc.LookAt())
+			tc.DollyTo(zoomFloor*scale, hitPoint)
+		} else {
+			tc.Dolly(zoomFloor * scale)
+		}
 		changed = true
 	}
 	e.lastMousePos = mp

--- a/src/engine/cameras/turntable_camera.go
+++ b/src/engine/cameras/turntable_camera.go
@@ -90,6 +90,24 @@ func (c *TurntableCamera) Dolly(delta float32) {
 	c.SetZoom(zoom)
 }
 
+// Dolly moves the camera closer/further from a target point by the given delta
+func (c *TurntableCamera) DollyTo(delta float32, targetPoint matrix.Vec3) {
+	defer tracing.NewRegion("TurntableCamera.Dolly").End()
+	newZoom := c.zoom
+	oldZoom := c.zoom
+	diff := c.position.Subtract(c.lookAt)
+	length := diff.Length()
+	newZoom += delta * length
+	if c.position.Z() <= 0.0 {
+		newZoom += 0.001
+	}
+	zoomRatio := newZoom / oldZoom
+
+	newLookAt := targetPoint.Add(c.lookAt.Subtract(targetPoint).Scale(zoomRatio))
+	c.SetLookAt(newLookAt)
+	c.SetZoom(newZoom)
+}
+
 // Orbit orbits the camera around the look at point by the given delta.
 func (c *TurntableCamera) Orbit(delta matrix.Vec3) {
 	defer tracing.NewRegion("TurntableCamera.Orbit").End()


### PR DESCRIPTION
With reference to #726 

in this PR , the camera can now zoom in and out with a specific cursor point as target

to so hold `left alt` + `mouse scroll` to perform.

Here is a video of the feature

https://github.com/user-attachments/assets/fd72f521-24db-4c98-89f3-8ab545ac49da

