### PR TITLE
Fixing clearing styles on panel #756

### DIFF
--- a/src/engine/ui/layout.go
+++ b/src/engine/ui/layout.go
@@ -86,9 +86,6 @@ func (l *Layout) ClearStyles() {
 	l.flexOrder = 0
 	l.alignSelf = FlexAlignAuto
 	l.positioning = PositioningStatic
-	if ps.X() > 0 && ps.Y() > 0 {
-		l.Scale(ps.X(), ps.Y())
-	}
 }
 
 func (l *Layout) PixelSize() matrix.Vec2 {

--- a/src/engine/ui/panel.go
+++ b/src/engine/ui/panel.go
@@ -903,9 +903,7 @@ func (p *Panel) ClearLayoutStyles() {
 	pd.aspectRatio = 0
 	pd.usesBorderBox = false
 	pd.fitContent = ContentFitBoth
-	// TODO:  This is commented out for now to fix a click-glitch bug
-	// in the editor content browser.
-	// p.layout.ClearStyles()
+	p.layout.ClearStyles()
 	p.Base().SetDirty(DirtyTypeLayout)
 }
 


### PR DESCRIPTION
Hello, 
This fixes #756 

Deleted code shouldn't be necessary, after debugging I figured that scaling is using the same pixel size for calculations and should always return `false` but sometimes concurrency in UI sometimes pass through zeros in PixelSize(). 

Here is the code:

```golang
func (l *Layout) ClearStyles() {
	ps := l.PixelSize()
...
	if ps.X() > 0 && ps.Y() > 0 {
		l.Scale(ps.X(), ps.Y())
	}
...
}

...

func (l *Layout) Scale(width, height float32) bool {
	ps := l.PixelSize()
	if matrix.Vec2ApproxTo(ps, matrix.Vec2{width, height}, fractionOfPixel) {
		return false
	}
...
	return true
}

```

Thanks to conversation with @BrentFarris I was able to pinpoint what code causes the issue at the moment.  

This fixes even an issue with clicking glitch in _Content_ workspace mentioned in [Discord](https://discord.com/channels/1203214266275074087/1203231666294751323/1508118379876192327) by **CuriousExplorer**. I wasn't able to reproduce it after this change.

Hopefully I didn't forgot something to check. :crossed_fingers: 