### PR TITLE
fix: address cpu hotpath and css rendering issue

### DIFF
--- a/src/engine/ui/input.go
+++ b/src/engine/ui/input.go
@@ -977,7 +977,15 @@ func (input *Input) keyPressed(keyId int, keyState hid.KeyState) {
 	if input.IsDisabled() {
 		return
 	}
-	host := input.man.Value().Host
+	// doKeyCallbacks invokes this for EVERY registered input on every keypress,
+	// regardless of focus. A destroyed/recycled input (pooled UI) can still have
+	// a live callback for a frame; its manager weak-ref is then dead. Guard it so
+	// a stray keypress no-ops instead of nil-derefing host below.
+	man := input.man.Value()
+	if man == nil || input.entity.IsDestroyed() {
+		return
+	}
+	host := man.Host
 	data := input.InputData()
 	if input.entity.IsActive() && data.isActive {
 		if keyState == hid.KeyStateDown {

--- a/src/engine/ui/label.go
+++ b/src/engine/ui/label.go
@@ -63,7 +63,11 @@ func (label *Label) Init(text string) {
 		text:            text,
 		textLength:      utf8.RuneCountInString(text),
 		fgColor:         matrix.ColorWhite(),
-		bgColor:         matrix.ColorBlack(),
+		// Transparent (alpha 0) by default so the font renderer blends glyph
+		// edges against the label's calculated surface (the real opaque color
+		// behind the text) instead of a fixed color, avoiding halos. An opaque
+		// bgColor (alpha >= 1) is treated as an intentional text-highlight box.
+		bgColor:         matrix.ColorTransparent(),
 		fontSize:        LabelFontSize,
 		baseline:        rendering.FontBaselineTop,
 		justify:         rendering.FontJustifyLeft,
@@ -128,9 +132,10 @@ func (label *Label) FontFace() rendering.FontFace { return label.LabelData().fon
 func (label *Label) colorRange(section colorRange) {
 	ld := label.LabelData()
 	end := len(ld.runeShaderData)
+	fg, bg := label.resolveFontColors(section.hue, section.bgHue)
 	for i := section.start; i < section.end && end > section.end; i++ {
-		ld.runeShaderData[i].FgColor = section.hue
-		ld.runeShaderData[i].BgColor = section.bgHue
+		ld.runeShaderData[i].FgColor = fg
+		ld.runeShaderData[i].BgColor = bg
 	}
 }
 
@@ -182,7 +187,17 @@ func (label *Label) renderText() {
 				pl.padding.Horizontal() - pl.border.Horizontal()
 			if contentWidth > 0 {
 				if ld.overrideMaxWidth <= 0 {
-					label.layout.ScaleWidth(contentWidth)
+					// Re-anchor after growing: a transform's position is its
+					// CENTER (layoutFloating -> al() = -parentW/2 + selfW/2),
+					// so changing the width without re-running layoutFloating
+					// leaves the center where the narrow label sat. The glyphs
+					// (built below from WorldScale, origin -es.X()/2) would then
+					// be emitted ~(newW-oldW)/2 px left of the box and the
+					// parent scissor would clip the start of the text. Re-anchor
+					// for the new width before the meshes are generated.
+					if label.layout.ScaleWidth(contentWidth) {
+						layoutFloating(&label.layout)
+					}
 				}
 				if ld.overrideMaxWidth <= 0 || maxWidth > contentWidth {
 					maxWidth = contentWidth
@@ -193,9 +208,13 @@ func (label *Label) renderText() {
 			label.layout.ScaleHeight(label.measure(maxWidth).Height())
 		}
 		host := label.man.Value().Host
+		// Resolve against the calculated surface so the font cache picks the
+		// crisp non-OIT material (both colors opaque) instead of fringing the
+		// edges over solid backgrounds.
+		fg, bg := label.resolveFontColors(ld.fgColor, ld.bgColor)
 		ld.runeDrawings = host.FontCache().RenderMeshesWithLetterSpacing(
 			host, ld.text, 0, 0, 0, ld.fontSize,
-			maxWidth, ld.fgColor, ld.bgColor, ld.justify,
+			maxWidth, fg, bg, ld.justify,
 			ld.baseline, label.entity.Transform.WorldScale(),
 			true, false, ld.fontFace, ld.lineHeight, ld.letterSpacing, &host.Cameras.UI)
 		ld.runeShaderData = make([]*rendering.TextShaderData, len(ld.runeDrawings))
@@ -204,7 +223,7 @@ func (label *Label) renderText() {
 			rd.Transform = &label.entity.Transform
 			rd.Layer = rendering.RenderLayerUI
 			ld.runeShaderData[i] = rd.ShaderData.(*rendering.TextShaderData)
-			if ld.bgColor.A() < 1.0 {
+			if bg.A() < 1.0 {
 				transparent := ld.runeDrawings[i]
 				transparent.Material = host.FontCache().TransparentMaterial(
 					ld.runeDrawings[i].Material)
@@ -243,11 +262,51 @@ func (label *Label) labelRender() {
 	ld.renderRequired = false
 }
 
+// calculatedSurface returns the opaque "used" color this text visually sits on:
+// the parent panel's calculated background, or the manager's root backdrop when
+// the label has no parent panel. Used as the glyph-edge blend target so
+// anti-aliasing produces no halo.
+func (label *Label) calculatedSurface() matrix.Color {
+	if label.entity.Parent != nil {
+		if p := FirstPanelOnEntity(label.entity.Parent); p != nil {
+			return p.CalculatedBGColor()
+		}
+	}
+	if m := label.man.Value(); m != nil {
+		return m.RootBackgroundColor()
+	}
+	return matrix.ColorBlack()
+}
+
+// resolveFontColors maps an intended (fg, bg) pair to the colors handed to the
+// font shader. When bg is already opaque (alpha >= 1) it is an intentional
+// highlight box and the pair is used as-is. Otherwise the glyph blends against
+// the label's calculated surface: the foreground is composited over that surface
+// to a fully opaque RGB (partial fg transparency folded into the color, so muted
+// text stays halo-free) and the background becomes the opaque surface itself.
+//
+// Both returned colors are opaque, which selects the cheap non-OIT text material
+// (see rendering/font.go: opaque iff fg.A==1 && bg.A==1). That matters for
+// crispness: the order-independent-transparency material darkens glyph edges
+// (a visible fringe over bright solid backgrounds like accent buttons). The
+// shader does mix(bg, fg, coverage), so the per-glyph quad is filled with the
+// surface color outside the glyph — but since the surface IS the real backdrop,
+// that fill is invisible and the anti-aliased edges blend toward the correct
+// color with no halo.
+func (label *Label) resolveFontColors(fg, bg matrix.Color) (matrix.Color, matrix.Color) {
+	if bg.A() >= 1.0 {
+		return fg, bg
+	}
+	surface := label.calculatedSurface()
+	return matrix.ColorOver(fg, surface), surface
+}
+
 func (label *Label) updateColors() {
 	ld := label.LabelData()
+	fg, bg := label.resolveFontColors(ld.fgColor, ld.bgColor)
 	for i := range ld.runeShaderData {
-		ld.runeShaderData[i].FgColor = ld.fgColor
-		ld.runeShaderData[i].BgColor = ld.bgColor
+		ld.runeShaderData[i].FgColor = fg
+		ld.runeShaderData[i].BgColor = bg
 	}
 }
 

--- a/src/engine/ui/markup/css/helpers/numbers.go
+++ b/src/engine/ui/markup/css/helpers/numbers.go
@@ -68,12 +68,22 @@ func ArithmeticString(args []string) (int, error) {
 func NumFromLengthWithFont(str string, window WindowDimensions, fontSize float32) float32 {
 	dpmm := window.DotsPerMillimeter()
 	parse := func(raw string, cut int) float32 {
-		var v float32
-		fmt.Sscanf(raw[:len(raw)-cut], "%f", &v)
-		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
-			return 0
+		// strconv.ParseFloat is orders of magnitude faster than fmt.Sscanf("%f"),
+		// which dominated CPU: this runs for every CSS length on every layout
+		// pass. Preserve fmt's leniency (take the longest leading numeric prefix,
+		// tolerating trailing garbage) by trimming trailing chars until it parses;
+		// valid input parses on the first try so the common path stays fast.
+		s := strings.TrimSpace(raw[:len(raw)-cut])
+		for len(s) > 0 {
+			if f, err := strconv.ParseFloat(s, 32); err == nil {
+				if math.IsNaN(f) || math.IsInf(f, 0) {
+					return 0
+				}
+				return float32(f)
+			}
+			s = s[:len(s)-1]
 		}
-		return v
+		return 0
 	}
 	switch {
 	case strings.HasSuffix(str, "vmin"):

--- a/src/engine/ui/markup/css/properties/css_background_color.go
+++ b/src/engine/ui/markup/css/properties/css_background_color.go
@@ -19,16 +19,6 @@ import (
 	"kaijuengine.com/matrix"
 )
 
-func setChildTextBackgroundColor(elm *document.Element, color matrix.Color) {
-	for _, c := range elm.Children {
-		if c.IsText() {
-			c.UI.ToLabel().SetBGColor(color)
-		} else if !c.UI.IsType(ui.ElementTypeLabel) && c.UI.ToPanel().Background() == nil { // Only continue if transparent
-			setChildTextBackgroundColor(c, color)
-		}
-	}
-}
-
 func (p BackgroundColor) Process(panel *ui.Panel, elm *document.Element, values []rules.PropertyValue, host *engine.Host) error {
 	if len(values) != 1 {
 		return fmt.Errorf("Expected exactly 1 value but got %d", len(values))
@@ -45,13 +35,10 @@ func (p BackgroundColor) Process(panel *ui.Panel, elm *document.Element, values 
 	hex := values[0].Str
 	if hex == "inherit" {
 		if isLabel {
-			pBase := panel.Base()
-			elm.UI.AddEvent(ui.EventTypeRender, func() {
-				if pBase.Entity().Parent != nil {
-					p := ui.FirstPanelOnEntity(pBase.Entity().Parent)
-					elm.UI.ToLabel().SetBGColor(p.Base().ShaderData().FgColor)
-				}
-			})
+			// A label's font now blends against its calculated surface (the
+			// real opaque color behind it, resolved by walking up the panel
+			// tree), so "inherit" needs no work: leaving the label background
+			// transparent makes the text track whatever the parent renders.
 			return nil
 		}
 		if applyPanelColor {
@@ -93,8 +80,9 @@ func (p BackgroundColor) Process(panel *ui.Panel, elm *document.Element, values 
 		panel.Base().ToInput().SetBGColor(color)
 	} else if panel.Base().IsType(ui.ElementTypeTextArea) {
 		panel.Base().ToTextArea().SetBGColor(color)
-	} else if !panel.HasEnforcedColor() {
-		setChildTextBackgroundColor(elm, color)
 	}
+	// Child text no longer needs its background pushed down: each label resolves
+	// its own opaque surface by walking up the panel tree (CalculatedBGColor),
+	// which composites partial transparency correctly at every level.
 	return nil
 }

--- a/src/engine/ui/markup/css/properties/css_height.go
+++ b/src/engine/ui/markup/css/properties/css_height.go
@@ -23,6 +23,15 @@ func (p Height) Process(panel *ui.Panel, elm *document.Element, values []rules.P
 		return fmt.Errorf("expected exactly 1 value but got %d", len(values))
 	}
 
+	if values[0].Str == "initial" {
+		return nil
+	}
+
+	if values[0].Str == "fit-content" {
+		panel.FitContentHeight()
+		return nil
+	}
+
 	height := helpers.NumFromLength(values[0].Str, host.Window)
 
 	panel.DontFitContentHeight()

--- a/src/engine/ui/markup/css/rules/parser.go
+++ b/src/engine/ui/markup/css/rules/parser.go
@@ -24,6 +24,24 @@ type StyleSheet struct {
 	stateFuncDepth int
 }
 
+// varRefSentinel prefixes a deferred custom-property reference that is stored
+// inside a PropertyValue's Str field or a function value's Args slice (e.g.
+// var() inside calc()). The NUL byte cannot appear in real CSS source, so this
+// marker can never collide with a genuine token.
+const varRefSentinel = "\x00var:"
+
+// makeVarRef encodes a deferred reference to the given custom property name.
+func makeVarRef(name string) string { return varRefSentinel + name }
+
+// parseVarRef returns the custom property name and true when s is a deferred
+// var reference produced by makeVarRef.
+func parseVarRef(s string) (string, bool) {
+	if strings.HasPrefix(s, varRefSentinel) {
+		return s[len(varRefSentinel):], true
+	}
+	return "", false
+}
+
 func (s *StyleSheet) addGroup() {
 	g := SelectorGroup{
 		Selectors: make([]Selector, 0),
@@ -182,7 +200,7 @@ func (s *StyleSheet) readSelector(cssParser *css.Parser) {
 	s.Groups[idx].Selectors = append(s.Groups[idx].Selectors, sel)
 }
 
-func (s *StyleSheet) readProperty(prop string, cssParser *css.Parser, window helpers.WindowDimensions) {
+func (s *StyleSheet) readProperty(prop string, cssParser *css.Parser, _ helpers.WindowDimensions) {
 	r := Rule{
 		Property: prop,
 		Values:   make([]PropertyValue, 0),
@@ -208,20 +226,24 @@ func (s *StyleSheet) readProperty(prop string, cssParser *css.Parser, window hel
 				last := &r.Values[len(r.Values)-1]
 				str := string(val.Data)
 				if last.Str == "var" {
+					// Drop the placeholder "var" function value and record a
+					// deferred reference to the custom property. Resolution is
+					// performed after the whole sheet is parsed so the final
+					// (last-:root-wins) value of every custom property is used,
+					// matching CSS computed-value semantics.
 					r.Values = r.Values[0 : len(r.Values)-1]
-					if len(r.Values) > 0 {
+					if s.stateFuncDepth > 1 && len(r.Values) > 0 {
+						// var() nested inside another function (e.g. calc()):
+						// record the deferred reference in the enclosing
+						// function's argument list, preserving argument order.
 						last = &r.Values[len(r.Values)-1]
-					}
-					if v, ok := s.CustomVars[str]; ok {
-						for i := range v {
-							if s.stateFuncDepth > 1 {
-								last.Args = append(last.Args, v[i])
-							} else {
-								r.Values = append(r.Values, PropertyValue{
-									Str: v[i],
-								})
-							}
-						}
+						last.Args = append(last.Args, makeVarRef(str))
+					} else {
+						// Top-level var(): record a deferred placeholder value
+						// that will expand into zero or more values later.
+						r.Values = append(r.Values, PropertyValue{
+							Str: makeVarRef(str),
+						})
 					}
 				} else {
 					last.Args = append(last.Args, str)
@@ -233,18 +255,67 @@ func (s *StyleSheet) readProperty(prop string, cssParser *css.Parser, window hel
 			}
 		}
 	}
+	// Numeric resolution is intentionally deferred to resolveRuleVars (called
+	// post-parse) because deferred var references are not yet substituted here.
+	s.currentGroup().AddRule(r)
+}
+
+// resolveVars walks every parsed rule in the sheet and substitutes the final
+// value of each deferred custom-property reference, then computes numeric forms.
+// It must be called once after the entire sheet has been parsed, when
+// s.CustomVars holds the last-wins value for every custom property.
+func (s *StyleSheet) resolveVars(window helpers.WindowDimensions) {
+	for gi := range s.Groups {
+		g := &s.Groups[gi]
+		for ri := range g.Rules {
+			s.resolveRuleVars(&g.Rules[ri], window)
+		}
+	}
+}
+
+// resolveRuleVars substitutes deferred var references in a single rule and then
+// computes the numeric forms of every value. An unknown custom property resolves
+// to nothing, preserving the previous eager behavior.
+func (s *StyleSheet) resolveRuleVars(r *Rule, window helpers.WindowDimensions) {
+	// Expand top-level deferred var placeholders. A custom property can expand
+	// to multiple tokens, so the value slice is rebuilt.
+	resolved := make([]PropertyValue, 0, len(r.Values))
+	for i := range r.Values {
+		v := r.Values[i]
+		if name, ok := parseVarRef(v.Str); ok {
+			for _, sub := range s.CustomVars[name] {
+				resolved = append(resolved, PropertyValue{Str: sub})
+			}
+			continue
+		}
+		// Expand deferred var references stored inside function arguments
+		// (e.g. var() nested in calc()), preserving argument order.
+		if len(v.Args) > 0 {
+			args := make([]string, 0, len(v.Args))
+			for _, a := range v.Args {
+				if name, ok := parseVarRef(a); ok {
+					args = append(args, s.CustomVars[name]...)
+					continue
+				}
+				args = append(args, a)
+			}
+			v.Args = args
+		}
+		resolved = append(resolved, v)
+	}
+	r.Values = resolved
+
 	for i := range r.Values {
 		v := &r.Values[i]
 		if len(v.Args) > 0 {
 			v.ArgNums = make([]float32, len(v.Args))
-			for i := range v.Args {
-				v.ArgNums[i] = helpers.NumFromLength(v.Args[i], window)
+			for j := range v.Args {
+				v.ArgNums[j] = helpers.NumFromLength(v.Args[j], window)
 			}
 		} else {
 			v.Num = helpers.NumFromLength(v.Str, window)
 		}
 	}
-	s.currentGroup().AddRule(r)
 }
 
 func NewStyleSheet() StyleSheet {
@@ -326,6 +397,9 @@ func (s *StyleSheet) Parse(cssStr string, window helpers.WindowDimensions) {
 			s.CustomVars[name] = vals
 		}
 	}
+	// All custom properties are now known with their final (last :root wins)
+	// values; substitute deferred var references and compute numeric forms.
+	s.resolveVars(window)
 	s.removeLastGroup()
 }
 
@@ -344,7 +418,13 @@ func (s *StyleSheet) ParseInline(cssStr string, window helpers.WindowDimensions)
 			s.readProperty(string(propData), cssParser, window)
 		}
 	}
+	// Resolve any deferred var references using whatever custom properties are
+	// known on this style sheet (e.g. those declared by an already-parsed
+	// :root block) and compute numeric forms.
 	group := s.currentGroup()
+	for ri := range group.Rules {
+		s.resolveRuleVars(&group.Rules[ri], window)
+	}
 	s.removeLastGroup()
 	return group
 }

--- a/src/engine/ui/markup/css/rules/parser_test.go
+++ b/src/engine/ui/markup/css/rules/parser_test.go
@@ -20,6 +20,25 @@ const testCSSVarDeclare = `:root { --ed-menu-bar-height: 24px; }
 const testCSSVarInCalc = `:root { --ed-menu-bar-height: 24px; }
 .test { height: calc(100% - var(--ed-menu-bar-height)); }`
 
+// rule appears BEFORE its :root declaration (was broken with eager resolution).
+const testCSSVarRuleBeforeRoot = `.test { height: var(--ed-menu-bar-height); }
+:root { --ed-menu-bar-height: 24px; }`
+
+// a later :root overriding a token must win for an earlier rule.
+const testCSSVarLaterRootWins = `:root { --c: #aaaaaa; }
+.x { color: var(--c); }
+:root { --c: #111111; }`
+
+// custom property expanding to multiple tokens. Note the CSS lexer keeps the
+// custom-property value's internal whitespace, so it is stored as a single
+// token; var() expansion must emit exactly that token.
+const testCSSVarMultiToken = `:root { --pad: 1px 2px 3px 4px; }
+.test { padding: var(--pad); }`
+
+// var inside calc where the override comes after the rule.
+const testCSSVarInCalcLaterRoot = `.test { height: calc(100% - var(--h)); }
+:root { --h: 24px; }`
+
 type dummyWindow struct{}
 
 func (dummyWindow) DotsPerMillimeter() float64 { return 1 }
@@ -284,6 +303,98 @@ func TestParseCalcAndVariable(t *testing.T) {
 	for i := range expectedArgs {
 		if s.Groups[1].Rules[0].Values[0].Args[i] != expectedArgs[i] {
 			t.FailNow()
+		}
+	}
+}
+
+func TestParseVariableRuleBeforeRoot(t *testing.T) {
+	s := NewStyleSheet()
+	s.Parse(testCSSVarRuleBeforeRoot, dummyWindow{})
+	if len(s.Groups) == 0 {
+		t.Fatalf("expected at least one group, got %d", len(s.Groups))
+	}
+	// .test is declared before :root, so it lives in group 0.
+	g := s.Groups[0]
+	if len(g.Rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(g.Rules))
+	}
+	if g.Rules[0].Property != "height" {
+		t.Fatalf("expected height property, got %q", g.Rules[0].Property)
+	}
+	if len(g.Rules[0].Values) != 1 {
+		t.Fatalf("expected 1 value, got %d: %#v", len(g.Rules[0].Values), g.Rules[0].Values)
+	}
+	if g.Rules[0].Values[0].Str != "24px" {
+		t.Fatalf("expected 24px (var resolved despite later :root), got %q", g.Rules[0].Values[0].Str)
+	}
+}
+
+func TestParseVariableLaterRootWins(t *testing.T) {
+	s := NewStyleSheet()
+	s.Parse(testCSSVarLaterRootWins, dummyWindow{})
+	if v := s.CustomVars["--c"]; len(v) != 1 || v[0] != "#111111" {
+		t.Fatalf("expected --c to be #111111, got %#v", v)
+	}
+	// .x is declared in group 1 (group 0 is the :root pseudo group).
+	g := s.Groups[1]
+	if len(g.Rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(g.Rules))
+	}
+	if g.Rules[0].Property != "color" {
+		t.Fatalf("expected color property, got %q", g.Rules[0].Property)
+	}
+	if len(g.Rules[0].Values) != 1 {
+		t.Fatalf("expected 1 value, got %d: %#v", len(g.Rules[0].Values), g.Rules[0].Values)
+	}
+	if g.Rules[0].Values[0].Str != "#111111" {
+		t.Fatalf("expected later :root to win (#111111), got %q", g.Rules[0].Values[0].Str)
+	}
+}
+
+func TestParseVariableMultiToken(t *testing.T) {
+	s := NewStyleSheet()
+	s.Parse(testCSSVarMultiToken, dummyWindow{})
+	g := s.Groups[1]
+	if len(g.Rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(g.Rules))
+	}
+	if g.Rules[0].Property != "padding" {
+		t.Fatalf("expected padding property, got %q", g.Rules[0].Property)
+	}
+	// The lexer stores the multi-token value as a single CustomVars entry, so
+	// it expands back to one PropertyValue holding the whole string.
+	if n := len(s.CustomVars["--pad"]); n != 1 {
+		t.Fatalf("expected --pad to hold 1 token, got %d: %#v", n, s.CustomVars["--pad"])
+	}
+	if len(g.Rules[0].Values) != 1 {
+		t.Fatalf("expected 1 value, got %d: %#v", len(g.Rules[0].Values), g.Rules[0].Values)
+	}
+	if g.Rules[0].Values[0].Str != "1px 2px 3px 4px" {
+		t.Fatalf("expected expanded multi-token value, got %q", g.Rules[0].Values[0].Str)
+	}
+}
+
+func TestParseVariableInCalcLaterRoot(t *testing.T) {
+	s := NewStyleSheet()
+	s.Parse(testCSSVarInCalcLaterRoot, dummyWindow{})
+	// .test is declared before :root, so it lives in group 0.
+	g := s.Groups[0]
+	if len(g.Rules) != 1 {
+		t.Fatalf("expected 1 rule, got %d", len(g.Rules))
+	}
+	if len(g.Rules[0].Values) != 1 {
+		t.Fatalf("expected 1 value, got %d: %#v", len(g.Rules[0].Values), g.Rules[0].Values)
+	}
+	if g.Rules[0].Values[0].Str != "calc" {
+		t.Fatalf("expected calc value, got %q", g.Rules[0].Values[0].Str)
+	}
+	expectedArgs := []string{"100%", "-", "24px"}
+	if len(g.Rules[0].Values[0].Args) != len(expectedArgs) {
+		t.Fatalf("expected %d args, got %d: %#v", len(expectedArgs), len(g.Rules[0].Values[0].Args), g.Rules[0].Values[0].Args)
+	}
+	for i := range expectedArgs {
+		if g.Rules[0].Values[0].Args[i] != expectedArgs[i] {
+			t.Fatalf("arg %d expected %q, got %q", i, expectedArgs[i], g.Rules[0].Values[0].Args[i])
 		}
 	}
 }

--- a/src/engine/ui/markup/document/html_element.go
+++ b/src/engine/ui/markup/document/html_element.go
@@ -157,7 +157,12 @@ func (e *Element) IsSelect() bool {
 }
 
 func (e *Element) IsSelectOption() bool {
-	return e.Data == "option"
+	// Must be an <option> ELEMENT, not a text node whose content happens to be
+	// the word "option" (html.Node stores tag name and text in the same .Data
+	// field). Misclassifying such text skipped its Label UI — leaving the label
+	// blank and nil-dereferencing when the subtree is cloned (e.g. a popover row
+	// proto whose label text is "option").
+	return e.Type == html.ElementNode && e.Data == "option"
 }
 
 func NewHTML(htmlStr string) *Element {
@@ -302,18 +307,27 @@ func (e *Element) Clone(parent *Element) *Element {
 		elm.Parent = weak.Make(parent)
 	}
 	var eParent *engine.Entity
-	if parent != nil {
+	if parent != nil && parent.UI != nil {
 		eParent = parent.UI.Entity()
 	}
-	elm.UI = e.UI.Clone(eParent)
-	if !elm.UI.IsType(ui.ElementTypeLabel) {
-		elm.UIPanel = elm.UI.ToPanel()
+	// Some elements intentionally have no UI (createUIElement returns early for
+	// select options), so mirror that here instead of nil-dereferencing e.UI /
+	// elm.UI when cloning a subtree that contains one (e.g. the MultiSelect
+	// popover rows). Children are still cloned so any UI-bearing descendants are
+	// reproduced.
+	if e.UI != nil {
+		elm.UI = e.UI.Clone(eParent)
+		if !elm.UI.IsType(ui.ElementTypeLabel) {
+			elm.UIPanel = elm.UI.ToPanel()
+		}
 	}
 	elm.Children = make([]*Element, 0, len(e.Children))
 	for i := range e.Children {
 		e.Children[i].Clone(elm)
 	}
 	elm.Stylizer = e.Stylizer.clone(elm)
-	elm.UI.Layout().Stylizer = &elm.Stylizer
+	if elm.UI != nil {
+		elm.UI.Layout().Stylizer = &elm.Stylizer
+	}
 	return elm
 }

--- a/src/engine/ui/markup/document/html_parser.go
+++ b/src/engine/ui/markup/document/html_parser.go
@@ -93,7 +93,17 @@ func classifyHTMLInputType(rawType string) htmlInputType {
 }
 
 type Document struct {
-	host              weak.Pointer[engine.Host]
+	host weak.Pointer[engine.Host]
+	// uiMan is a STRONG reference to the manager that owns this document's UI
+	// elements. The manager's update is registered with only a weak self-ref and
+	// is torn down by runtime.AddCleanup when the manager is GC'd, and elements
+	// hold the manager weakly too. A dedicated manager (e.g. a floating overlay's
+	// NewContext manager) therefore has no strong owner once its builder returns
+	// and would be collected mid-use — its update stops (the overlay never
+	// renders) and element.man goes nil (nil-deref on input). Keeping it alive as
+	// long as the document lives ties the manager's lifetime to the widget; it is
+	// released on Destroy (doc cleared) so the manager is then cleaned up.
+	uiMan             *ui.Manager
 	Elements          []*Element
 	TopElements       []*Element
 	HeadElements      []*Element
@@ -527,6 +537,7 @@ func (d *Document) setupBody(h *Element, uiMan *ui.Manager) *Element {
 
 func DocumentFromHTMLString(uiMan *ui.Manager, htmlStr string, withData any, funcMap map[string]func(*Element)) *Document {
 	parsed := &Document{
+		uiMan:         uiMan,
 		Elements:      make([]*Element, 0),
 		groups:        map[string][]*Element{},
 		ids:           map[string]*Element{},

--- a/src/engine/ui/markup/html.go
+++ b/src/engine/ui/markup/html.go
@@ -53,6 +53,25 @@ func DocumentFromHTMLAssetRooted(uiMan *ui.Manager, htmlPath string, withData an
 	return doc, nil
 }
 
+// DocumentFromHTMLAssetWithCSS loads an HTML document from the asset database
+// like DocumentFromHTMLAsset (including kaiju-include expansion) but forwards an
+// explicit cssStr into the style cascade. DocumentFromHTMLAsset hardcodes an
+// empty cssStr, which prevents callers from theming asset-sourced templates;
+// this variant closes that gap. The cssStr is parsed after css.DefaultCSS/OverrideCSS
+// and before any document <style>/<link>, so later rules win (there is no specificity weighting).
+func DocumentFromHTMLAssetWithCSS(uiMan *ui.Manager, htmlPath, cssStr string, withData any, funcMap map[string]func(*document.Element), root *document.Element) (*document.Document, error) {
+	host := uiMan.Host
+	m, err := host.AssetDatabase().ReadText(htmlPath)
+	if err != nil {
+		return nil, err
+	}
+	m, err = expandHTMLIncludes(host.AssetDatabase(), htmlPath, m, map[string]bool{})
+	if err != nil {
+		return nil, err
+	}
+	return DocumentFromHTMLString(uiMan, m, cssStr, withData, funcMap, root), nil
+}
+
 func expandHTMLIncludes(db assets.Database, ownerPath, html string, stack map[string]bool) (string, error) {
 	var firstErr error
 	expanded := htmlIncludeTagRE.ReplaceAllStringFunc(html, func(includeTag string) string {

--- a/src/engine/ui/panel.go
+++ b/src/engine/ui/panel.go
@@ -284,11 +284,19 @@ func (p *Panel) FittingContentHeight() bool {
 
 func (p *Panel) FitContentWidth() {
 	pd := p.PanelData()
+	old := pd.fitContent
 	switch pd.fitContent {
 	case ContentFitNone:
 		pd.fitContent = ContentFitWidth
 	case ContentFitHeight:
 		pd.fitContent = ContentFitBoth
+	}
+	// Idempotent: this is an enable-setter that CSS re-applies on every layout
+	// pass (height/width: fit-content). Dirtying unconditionally re-triggered
+	// relayout every pass so Clean() never converged. Only dirty on a real
+	// state change.
+	if pd.fitContent == old {
+		return
 	}
 	if p.dirtyType == DirtyTypeNone {
 		p.Base().SetDirty(DirtyTypeLayout)
@@ -299,11 +307,15 @@ func (p *Panel) FitContentWidth() {
 
 func (p *Panel) FitContentHeight() {
 	pd := p.PanelData()
+	old := pd.fitContent
 	switch pd.fitContent {
 	case ContentFitNone:
 		pd.fitContent = ContentFitHeight
 	case ContentFitWidth:
 		pd.fitContent = ContentFitBoth
+	}
+	if pd.fitContent == old {
+		return
 	}
 	if p.dirtyType == DirtyTypeNone {
 		p.Base().SetDirty(DirtyTypeLayout)
@@ -313,7 +325,11 @@ func (p *Panel) FitContentHeight() {
 }
 
 func (p *Panel) FitContent() {
-	p.PanelData().fitContent = ContentFitBoth
+	pd := p.PanelData()
+	if pd.fitContent == ContentFitBoth {
+		return
+	}
+	pd.fitContent = ContentFitBoth
 	if p.dirtyType == DirtyTypeNone {
 		p.Base().SetDirty(DirtyTypeLayout)
 	} else {
@@ -587,6 +603,46 @@ func (p *Panel) panelPostLayoutUpdate() {
 		if pd.HasMaxHeight() && h > pd.maxSize.Y() {
 			h = pd.maxSize.Y()
 		}
+		// Clamp fit-content to the parent's content box. A fit-content element
+		// must not grow past its container (the container scrolls, or the window
+		// resizes) — this is also what CSS fit-content means: min(max-content,
+		// available). Critically, it breaks the runaway where a fit-content flex
+		// container sums a width/height:100% child that resolves back to the
+		// container's own (growing) size, so flex widths could explode and the
+		// layout never converged. An explicit min-size still wins (the author has
+		// opted into overflow).
+		if !p.entity.IsRoot() {
+			if pu := FirstOnEntity(p.entity.Parent); pu != nil && !pu.IsType(ElementTypeLabel) {
+				pl := pu.Layout()
+				ps := pl.PixelSize()
+				availW := ps.X() - pl.Padding().Horizontal() - pl.Border().Horizontal()
+				availH := ps.Y() - pl.Padding().Vertical() - pl.Border().Vertical()
+				// A flex container with align-items:stretch fills its parent on the
+				// CROSS axis (column -> width, row -> height). When it is ALSO
+				// fit-content on that axis, make the cross size DEFINITE (= parent
+				// available) rather than content-derived. Otherwise it fits to
+				// children that are themselves stretched / width|height:100% to
+				// fill it -> a circular dependency that drifts on sub-pixel float
+				// error so Clean() never converges. Making it definite propagates a
+				// concrete cross size down through nested stretch-flex containers
+				// (and matches CSS: an auto-size block/flex box fills its container
+				// on the block axis). An explicit min-size still wins.
+				stretch := p.IsFlex() && pd.flexAlignItems == FlexAlignStretch
+				colCross := pd.flexDirection == FlexDirectionColumn || pd.flexDirection == FlexDirectionColumnReverse
+				switch {
+				case stretch && colCross && availW > 0 && !(pd.HasMinWidth() && pd.minSize.X() > availW):
+					w = availW // cross = width: fill definitely
+				case availW > 0 && w > availW && !(pd.HasMinWidth() && pd.minSize.X() > availW):
+					w = availW // clamp to container
+				}
+				switch {
+				case stretch && !colCross && availH > 0 && !(pd.HasMinHeight() && pd.minSize.Y() > availH):
+					h = availH // cross = height: fill definitely
+				case availH > 0 && h > availH && !(pd.HasMinHeight() && pd.minSize.Y() > availH):
+					h = availH // clamp to container
+				}
+			}
+		}
 		switch pd.fitContent {
 		case ContentFitWidth:
 			p.layout.ScaleWidth(max(1, w))
@@ -605,7 +661,15 @@ func (p *Panel) panelPostLayoutUpdate() {
 		yScroll += scrollBarWidth
 	}
 	pd.maxScroll = matrix.NewVec2(max(0, bounds.X()-ws.X()), max(0.0, yScroll))
-	if !matrix.Vec2Roughly(last, pd.maxScroll) {
+	// Re-dirty/reveal scrollbars only when maxScroll moves by at least the
+	// same fraction-of-a-pixel that Scale/ScaleWidth/ScaleHeight require to
+	// actually apply a resize. Using a tighter tolerance here (the old
+	// Vec2Roughly == 0.001) created a dead zone: a sub-0.2px content drift
+	// re-dirtied this panel every layout pass, but Scale refused to resolve a
+	// sub-0.2px change, so Clean() never converged and burned all 100
+	// iterations every frame (frame-rate collapse). maxScroll is still stored
+	// precisely above, so scrolling stays exact.
+	if !matrix.Vec2ApproxTo(last, pd.maxScroll, fractionOfPixel) {
 		if pd.scrollBarX != nil {
 			pd.scrollBarX.Base().Show()
 		}
@@ -685,6 +749,50 @@ func (p *Panel) UnEnforceColor() {
 }
 
 func (p *Panel) Color() matrix.Color { return p.shaderData.FgColor }
+
+// CalculatedBGColor returns this panel's opaque "used" background color: its own
+// fill (which may be partially or fully transparent) alpha-composited over its
+// parent's calculated background, recursively up to the manager's opaque root
+// backdrop. This is the actual color a child element or its text visually sits
+// on. The font renderer uses it as the glyph-edge blend target so anti-aliasing
+// produces no halo, regardless of how transparent the intervening panels are.
+//
+// It is computed live by walking ancestors (cheap: tree depth is small and this
+// only runs while the UI is dirty/cleaning). The result is opaque whenever the
+// root backdrop is opaque (the default), which is why text composited onto it
+// can be rendered fully opaque and halo-free.
+func (p *Panel) CalculatedBGColor() matrix.Color {
+	return matrix.ColorOver(p.ownCalculatedFill(), p.parentCalculatedBG())
+}
+
+// ownCalculatedFill is this panel's contribution to the calculated color chain:
+// its fill color when it actually paints a background, otherwise fully
+// transparent so the parent's background shows through. A plain container that
+// paints nothing still carries a default opaque-white shaderData.FgColor; using
+// that directly would make text on transparent containers blend toward (and box
+// itself in) white. Background()==nil (no valid drawing) means "paints nothing".
+func (p *Panel) ownCalculatedFill() matrix.Color {
+	c := p.shaderData.FgColor
+	if !p.PanelData().drawing.IsValid() {
+		c.SetA(0)
+	}
+	return c
+}
+
+// parentCalculatedBG returns the opaque calculated background that this panel is
+// painted on top of: the nearest ancestor panel's CalculatedBGColor, or the
+// manager's root backdrop when there is no ancestor panel.
+func (p *Panel) parentCalculatedBG() matrix.Color {
+	if pe := p.entity.Parent; pe != nil {
+		if pp := FirstPanelOnEntity(pe); pp != nil {
+			return pp.CalculatedBGColor()
+		}
+	}
+	if m := p.man.Value(); m != nil {
+		return m.RootBackgroundColor()
+	}
+	return matrix.ColorBlack()
+}
 
 func (p *Panel) SetColor(bgColor matrix.Color) {
 	if p.HasEnforcedColor() {
@@ -1991,6 +2099,10 @@ func (p *Panel) setColorInternal(bgColor matrix.Color) {
 		}
 	}
 	p.shaderData.FgColor = bgColor
+	// A fill change shifts the calculated ("used") background that descendant
+	// text composites against, so re-render the subtree to refresh glyph colors
+	// (labels recompute their surface from this panel each render pass).
+	p.Base().SetDirty(DirtyTypeColorChange)
 }
 
 func (p *Panel) AllowClickThrough() {

--- a/src/engine/ui/textarea.go
+++ b/src/engine/ui/textarea.go
@@ -1071,6 +1071,18 @@ func (textarea *TextArea) delete(kb *hid.Keyboard) {
 	data.hasPreferredCursorX = false
 }
 
+// ApplyColorRange colors a [start,end) rune range of the text area's content in
+// place (no glyph re-mesh), the same mechanism Label uses. SetText clears color ranges, 
+// so re-apply after the text changes.
+func (textarea *TextArea) ApplyColorRange(start, end int, fg, bg matrix.Color) {
+	textarea.Data().label.ColorRange(start, end, fg, bg)
+}
+
+// ClearColorRanges removes all applied color ranges.
+func (textarea *TextArea) ClearColorRanges() {
+	textarea.Data().label.ClearColorRanges()
+}
+
 func (textarea *TextArea) SetFontFace(face rendering.FontFace) {
 	data := textarea.Data()
 	data.label.SetFontFace(face)

--- a/src/engine/ui/ui.go
+++ b/src/engine/ui/ui.go
@@ -8,8 +8,16 @@ package ui
 
 import (
 	"log/slog"
+	"os"
+	"runtime"
+	"sort"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
 	"weak"
 
+	"kaijuengine.com/build"
 	"kaijuengine.com/engine"
 	"kaijuengine.com/engine/pooling"
 	"kaijuengine.com/engine/systems/events"
@@ -19,6 +27,71 @@ import (
 	"kaijuengine.com/platform/windowing"
 	"kaijuengine.com/rendering"
 )
+
+// uiDiagEnabled gates the temporary layout-convergence diagnostics. Enable with
+// KAIJU_UI_DIAG=1 to log slow / non-converging UI.Clean passes and the elements
+// that stay dirty. TEMP: remove once the layout perf issue is resolved.
+var uiDiagEnabled = os.Getenv("KAIJU_UI_DIAG") != "" && build.Debug
+var uiDiagCount atomic.Int64
+
+// diagCapturing/diagDirtyCounts capture WHICH call site re-dirties each element
+// during the one instrumented settle-pass in uiCleanDiag. Single-root use only
+// (the gallery has one UI root) so the plain map needs no synchronization.
+var diagCapturing atomic.Bool
+var diagDirtyCounts map[string]int
+
+// diagDirtySource walks the stack past the dirty plumbing (SetDirty/
+// layoutChanged/setDirtyInternal) to the real setter that requested the dirty,
+// returning "shortFunc:line". TEMP diagnostic (uiDiagEnabled).
+func diagDirtySource() string {
+	var pcs [16]uintptr
+	n := runtime.Callers(3, pcs[:])
+	frames := runtime.CallersFrames(pcs[:n])
+	for {
+		f, more := frames.Next()
+		nm := f.Function
+		if strings.Contains(nm, "layoutChanged") || strings.HasSuffix(nm, ".SetDirty") ||
+			strings.Contains(nm, "setDirtyInternal") || strings.Contains(nm, "diagDirtySource") {
+			if !more {
+				break
+			}
+			continue
+		}
+		if idx := strings.LastIndexByte(nm, '/'); idx >= 0 {
+			nm = nm[idx+1:]
+		}
+		return nm + ":" + strconv.Itoa(f.Line)
+	}
+	return "?"
+}
+
+func diagRecord(ui *UI, dirtyType DirtyType) {
+	if diagDirtyCounts == nil {
+		return
+	}
+	diagDirtyCounts[diagAncestry(ui)+" elm="+strconv.Itoa(int(ui.elmType))+
+		" dirty="+strconv.Itoa(dirtyType)+" <- "+diagDirtySource()]++
+}
+
+// diagAncestry returns the chain of up to 6 ancestor entity names (· for an
+// unnamed entity), nearest first, to locate otherwise-unnamed elements in the
+// tree. TEMP diagnostic (uiDiagEnabled).
+func diagAncestry(t *UI) string {
+	var b strings.Builder
+	e := &t.entity
+	for i := 0; i < 6 && e != nil; i++ {
+		if i > 0 {
+			b.WriteByte('<')
+		}
+		if nm := e.Name(); nm != "" {
+			b.WriteString(nm)
+		} else {
+			b.WriteByte('*') // unnamed entity
+		}
+		e = e.Parent
+	}
+	return b.String()
+}
 
 type DirtyType = int
 type ElementType = uint8
@@ -314,6 +387,9 @@ func (ui *UI) setDirtyInternal(dirtyType DirtyType) {
 
 func (ui *UI) SetDirty(dirtyType DirtyType) {
 	defer tracing.NewRegion("UI.SetDirty").End()
+	if uiDiagEnabled && diagCapturing.Load() {
+		diagRecord(ui, dirtyType)
+	}
 	ui.setDirtyInternal(dirtyType)
 }
 
@@ -337,6 +413,10 @@ func (ui *UI) Clean() {
 	if ui.flags.dontClean() {
 		return
 	}
+	var diagStart time.Time
+	if uiDiagEnabled {
+		diagStart = time.Now()
+	}
 	root := ui.rootUI()
 	tree := []*UI{root}
 	var createTree func(target *engine.Entity)
@@ -352,18 +432,69 @@ func (ui *UI) Clean() {
 	createTree(root.Entity())
 	stabilized := false
 	maxIterations := 100
+	iterations := 0
+	// Convergence guard. Most layouts settle in 1-4 iterations. A few flex
+	// subtrees never fully settle: they oscillate by a tiny amount forever
+	// (the flex main-axis fit-content interaction plus the world<->local matrix
+	// round-trip accumulating sub-pixel error across deep nesting). Without a
+	// guard that burns all 100 iterations every frame. The rendered result is
+	// already pixel-accurate, so after a minimum number of passes we stop once
+	// the layout is only jittering below settleEpsilon, or once it is clearly
+	// oscillating (the largest per-pass size change has stopped decreasing)
+	// rather than converging.
+	const settleEpsilon = 1.0
+	const minGuardIterations = 10 // 10% of maxIterations
+	prevMaxDelta := float32(-1)
+	stalls := 0
 	for !stabilized && maxIterations > 0 {
 		stabilized = true
+		maxDelta := float32(0)
 		for i := range tree {
 			if !tree[i].IsActive() {
 				continue
 			}
+			before := tree[i].Layout().PixelSize()
 			tree[i].cleanDirty()
 			tree[i].Layout().update()
 			tree[i].postLayoutUpdate()
+			after := tree[i].Layout().PixelSize()
+			if d := after.X() - before.X(); d > maxDelta {
+				maxDelta = d
+			} else if -d > maxDelta {
+				maxDelta = -d
+			}
+			if d := after.Y() - before.Y(); d > maxDelta {
+				maxDelta = d
+			} else if -d > maxDelta {
+				maxDelta = -d
+			}
 			stabilized = stabilized && tree[i].dirty() == DirtyTypeNone
 		}
 		maxIterations--
+		iterations++
+		if stabilized {
+			break
+		}
+		if iterations >= minGuardIterations {
+			if maxDelta < settleEpsilon {
+				break // only sub-pixel jitter remains; accept it
+			}
+			if prevMaxDelta >= 0 && maxDelta >= prevMaxDelta*0.95 {
+				// Not shrinking pass-over-pass -> oscillating, not converging.
+				stalls++
+				if stalls >= 2 {
+					break
+				}
+			} else {
+				stalls = 0
+			}
+		}
+		prevMaxDelta = maxDelta
+	}
+	if uiDiagEnabled {
+		if elapsed := time.Since(diagStart); !stabilized || elapsed > 30*time.Millisecond {
+			uiCleanDiag(root, tree, iterations, elapsed, stabilized)
+		}
 	}
 	for i := range tree {
 		if !tree[i].IsActive() {
@@ -372,6 +503,84 @@ func (ui *UI) Clean() {
 		tree[i].GenerateScissor()
 		tree[i].render()
 	}
+}
+
+// uiCleanDiag logs why a Clean() pass was slow or failed to converge, naming the
+// elements still dirty after the iteration cap so the oscillating subtree can be
+// identified (dirty type, own size, parent size). TEMP diagnostic (uiDiagEnabled).
+func uiCleanDiag(root *UI, tree []*UI, iterations int, elapsed time.Duration, stabilized bool) {
+	n := uiDiagCount.Add(1)
+	if n > 3 && n%60 != 0 {
+		return // a few immediate samples, then throttle to limit log spam
+	}
+	// layoutMode: 0=Flow(block), 1=Grid, 2=Flex; -1=label/none.
+	layoutModeOf := func(u *UI) int {
+		if u == nil || u.IsType(ElementTypeLabel) {
+			return -1
+		}
+		return u.ToPanel().PanelData().layoutMode
+	}
+	parentOf := func(t *UI) (string, int) {
+		if p := t.entity.Parent; p != nil {
+			pname := p.Name()
+			if pu := FirstOnEntity(p); pu != nil {
+				return pname, layoutModeOf(pu)
+			}
+			return pname, -1
+		}
+		return "<root>", -1
+	}
+	// 1) End-state stuck nodes (dirty != None after the 100-iteration cap) with
+	// their own and their parent's layout mode (confirms flow vs flex).
+	logged := 0
+	for i := range tree {
+		t := tree[i]
+		if !t.IsActive() || t.dirty() == DirtyTypeNone || logged >= 12 {
+			continue
+		}
+		logged++
+		ps := t.Layout().PixelSize()
+		pname, pmode := parentOf(t)
+		slog.Warn("  ui-diag stuck",
+			"name", t.entity.Name(), "elmType", int(t.elmType), "dirty", int(t.dirty()),
+			"mode", layoutModeOf(t), "w", ps.X(), "h", ps.Y(),
+			"parent", pname, "parentMode", pmode)
+	}
+	// 2) One extra instrumented settle-pass that captures WHICH call site
+	// re-dirties each element (the actual non-convergence source). Since sizes
+	// are stable, the culprit is a layout setter firing without a real change
+	// (e.g. an exact-Approx guard tripping on a float artifact).
+	diagDirtyCounts = make(map[string]int, 32)
+	diagCapturing.Store(true)
+	for i := range tree {
+		t := tree[i]
+		if !t.IsActive() {
+			continue
+		}
+		t.cleanDirty()
+		t.Layout().update()
+		t.postLayoutUpdate()
+	}
+	diagCapturing.Store(false)
+	type srcCount struct {
+		what  string
+		count int
+	}
+	srcs := make([]srcCount, 0, len(diagDirtyCounts))
+	for k, c := range diagDirtyCounts {
+		srcs = append(srcs, srcCount{k, c})
+	}
+	sort.Slice(srcs, func(i, j int) bool { return srcs[i].count > srcs[j].count })
+	for i := range srcs {
+		if i >= 12 {
+			break
+		}
+		slog.Warn("  ui-diag dirty-source", "count", srcs[i].count, "what", srcs[i].what)
+	}
+	diagDirtyCounts = nil
+	slog.Warn("UI.Clean slow/non-converged",
+		"root", root.entity.Name(), "converged", stabilized, "iterations", iterations,
+		"elapsedMs", elapsed.Milliseconds(), "treeSize", len(tree), "dirtyEvents", len(srcs))
 }
 
 func (ui *UI) GenerateScissor() {

--- a/src/engine/ui/ui_manager.go
+++ b/src/engine/ui/ui_manager.go
@@ -15,6 +15,7 @@ import (
 	"kaijuengine.com/engine/pooling"
 	"kaijuengine.com/engine/systems/events"
 	"kaijuengine.com/klib"
+	"kaijuengine.com/matrix"
 	"kaijuengine.com/platform/profiler/tracing"
 	"kaijuengine.com/platform/windowing"
 )
@@ -30,8 +31,36 @@ type Manager struct {
 	updateId        engine.UpdateId
 	skipUpdate      int
 	resizeEvtId     events.Id
+	rootBGColor     matrix.Color
 	windowResized   bool
 	windowMinimized bool
+}
+
+// RootBackgroundColor is the opaque backdrop that the top of the UI tree
+// composites against when computing calculated ("used") colors for halo-free
+// font rendering. It is the color a root-level transparent element resolves to.
+// Defaults to opaque black; a zero (fully transparent) value is treated as
+// opaque black so the calculated-color chain is always grounded on an opaque
+// backdrop.
+func (man *Manager) RootBackgroundColor() matrix.Color {
+	if man.rootBGColor.A() <= 0 {
+		return matrix.ColorBlack()
+	}
+	return man.rootBGColor
+}
+
+// SetRootBackgroundColor overrides the backdrop used for calculated colors and
+// re-renders the root elements so the new value propagates down the tree.
+func (man *Manager) SetRootBackgroundColor(c matrix.Color) {
+	if man.rootBGColor.Equals(c) {
+		return
+	}
+	man.rootBGColor = c
+	man.pools.Each(func(elm *UI) {
+		if elm.IsValid() && elm.entity.IsRoot() {
+			elm.SetDirty(DirtyTypeColorChange)
+		}
+	})
 }
 
 func (man *Manager) update(deltaTime float64) {

--- a/src/matrix/color.go
+++ b/src/matrix/color.go
@@ -144,6 +144,32 @@ func ColorMix(lhs, rhs Color, amount Float) Color {
 	}
 }
 
+// ColorOver alpha-composites src "over" dst using straight (non-premultiplied)
+// alpha and returns the result as a straight-alpha color. This is the standard
+// Porter-Duff "over" operator:
+//
+//	A_out   = src.A + dst.A*(1-src.A)
+//	RGB_out = (src.RGB*src.A + dst.RGB*dst.A*(1-src.A)) / A_out
+//
+// When dst is opaque (the common case for calculated/"used" UI colors) the
+// result is opaque and is exactly what src looks like painted on top of dst.
+// If both src and dst are effectively transparent the result is transparent
+// (RGB carried from src so a sensible hue remains for later compositing).
+func ColorOver(src, dst Color) Color {
+	sa := src[A]
+	outA := sa + dst[A]*(1-sa)
+	if outA <= 0.00001 {
+		return Color{src[R], src[G], src[B], 0}
+	}
+	dContrib := dst[A] * (1 - sa)
+	return Color{
+		(src[R]*sa + dst[R]*dContrib) / outA,
+		(src[G]*sa + dst[G]*dContrib) / outA,
+		(src[B]*sa + dst[B]*dContrib) / outA,
+		outA,
+	}
+}
+
 func ColorFromHexString(str string) (Color, error) {
 	c8, err := Color8FromHexString(str)
 	return ColorFromColor8(c8), err

--- a/src/platform/windowing/window.go
+++ b/src/platform/windowing/window.go
@@ -59,6 +59,7 @@ type Window struct {
 	cursorChangeCount        int
 	cachedScreenSizeWidthMM  int
 	cacheScreenSizeHeightMM  int
+	dpmmCache                atomic.Uint64 // cached DotsPerMillimeter (float bits); 0 = recompute
 	windowSync               chan struct{}
 	titleBarMode             TitleBarMode
 	syncRequest              bool
@@ -256,8 +257,20 @@ func (w *Window) SwapBuffersWithContainer(container rendering.RenderingContainer
 	}
 }
 
+// DotsPerMillimeter returns the window's DPI scaled to dots/mm. The underlying
+// platform query is a cgo call (e.g. cocoa_get_backing_scale_factor on macOS)
+// and was being invoked for every CSS length resolution during layout, which
+// dominated CPU. The value only changes on resize / display change, so it is
+// cached here and invalidated by the resize/move handlers. Cache is lock-free
 func (w *Window) DotsPerMillimeter() float64 {
-	return w.dotsPerMillimeter()
+	if bits := w.dpmmCache.Load(); bits != 0 {
+		return math.Float64frombits(bits)
+	}
+	v := w.dotsPerMillimeter()
+	if v > 0 {
+		w.dpmmCache.Store(math.Float64bits(v))
+	}
+	return v
 }
 
 // NOTE: currently only implemented on windows
@@ -503,6 +516,7 @@ func (w *Window) processWindowResizeEvent(evt *WindowResizeEvent) {
 	w.right = int(evt.right)
 	w.bottom = int(evt.bottom)
 	w.cachedScreenSizeWidthMM, w.cacheScreenSizeHeightMM = 0, 0
+	w.dpmmCache.Store(0)
 }
 
 func (w *Window) processWindowMoveEvent(evt *WindowMoveEvent) {
@@ -515,6 +529,7 @@ func (w *Window) processWindowMoveEvent(evt *WindowMoveEvent) {
 	w.right = w.x + ww
 	w.bottom = w.y + wh
 	w.cachedScreenSizeWidthMM, w.cacheScreenSizeHeightMM = 0, 0
+	w.dpmmCache.Store(0)
 	w.invalidateMonitorCache()
 	w.OnMove.Execute()
 }

--- a/src/rendering/draw_instance.go
+++ b/src/rendering/draw_instance.go
@@ -7,14 +7,23 @@
 package rendering
 
 import (
+	"log/slog"
 	"reflect"
+	"sync/atomic"
 	"unsafe"
 
+	"kaijuengine.com/build"
 	"kaijuengine.com/engine/graviton"
 	"kaijuengine.com/klib"
 	"kaijuengine.com/matrix"
 	"kaijuengine.com/platform/profiler/tracing"
 )
+
+// drawDiag gates logging of the instance-buffer write guard. The guard itself
+// (skip a write that would run past the mapped buffer) is always on so a sizing
+// bug degrades to a missed draw instead of a SIGBUS/SIGSEGV. TEMP diagnostic.
+var drawDiag = build.Debug
+var drawDiagCount atomic.Int64
 
 type ViewCuller interface {
 	IsInView(box graviton.AABB) bool
@@ -281,6 +290,7 @@ type DrawInstanceViewState struct {
 	boundInstanceData []InstanceCopyData
 	visibleCount      int
 	frameData         DrawInstanceFrameData
+	lastInstanceCount uintptr
 }
 
 type DrawInstanceFrameData struct {
@@ -477,6 +487,35 @@ func (d *DrawInstanceGroup) UpdateDataForView(device *GPUDevice, frame int, ligh
 			if state.generatedSets && len(state.boundInstanceData) > 0 {
 				for j := range state.boundInstanceData {
 					d.updateBoundData(state, instanceIndex, j, instance, frame)
+				}
+			}
+			if drawDiag {
+				// Guard against writing past the mapped instance buffer. The buffer
+				// was allocated for state.lastInstanceCount instances of
+				// state.instanceBuffer.size bytes each; base is its frame mapping. A
+				// nil base or an offset past capacity means the buffer geometry
+				// disagrees with what we're about to write (e.g. a shader whose
+				// reflected instance stride is smaller than the instance data) — skip
+				// this write rather than fault. Use continue (NOT break) so the loop
+				// keeps scanning and the destroyed-instance compaction above still
+				// runs for the remaining instances; breaking here orphaned destroyed
+				// instances, leaking them into the group every frame.
+				// capBytes is only known when the buffer was sized via resizeBuffers
+				// (size>0); guard the overrun check on it so manually-mapped buffers
+				// (e.g. tests) aren't falsely skipped. A nil base always skips.
+				capBytes := state.instanceBuffer.size * uintptr(state.lastInstanceCount)
+				if base == nil || (capBytes > 0 && offset+uintptr(d.instanceSize) > capBytes) {
+					if drawDiagCount.Add(1)%120 == 1 {
+						slog.Warn("DrawInstanceGroup.UpdateDataForView: skipping out-of-bounds instance write (shader/instance stride mismatch?)",
+							"frame", frame, "baseNil", base == nil,
+							"offset", uint64(offset), "instanceSize", d.instanceSize,
+							"padding", state.rawData.padding, "stride", d.instanceSize+state.rawData.padding,
+							"capBytes", uint64(capBytes), "iSize", uint64(state.instanceBuffer.size),
+							"lastInstanceCount", state.lastInstanceCount,
+							"writtenSoFar", instanceIndex, "instances", len(d.Instances),
+							"layer", int(d.EffectiveLayer()), "hasView", view != nil)
+					}
+					continue
 				}
 			}
 			to := unsafe.Pointer(uintptr(base) + offset)

--- a/src/rendering/font.go
+++ b/src/rendering/font.go
@@ -281,13 +281,15 @@ func (cache *FontCache) initFont(face FontFace, adb assets.Database) bool {
 	defer tracing.NewRegion("FontCache.initFont").End()
 	bin := fontBin{}
 	bin.texture, _ = cache.renderCaches.TextureCache().Texture(face.string()+".png", TextureFilterLinear)
-	bin.texture.MipLevels = 1
 	bin.cachedLetters = make(map[rune]*cachedLetterMesh)
 	bin.cachedOrthoLetters = make(map[rune]*cachedLetterMesh)
 	out, _ := adb.Read(face.string() + ".bin")
 	if bin.texture == nil || out == nil || len(out) == 0 {
 		return false
 	}
+	// Set MipLevels only after confirming the texture loaded; a missing font
+	// (nil texture) must fail gracefully here, not nil-deref.
+	bin.texture.MipLevels = 1
 	read := bytes.NewReader(out)
 	// Create an int32 variable named count that is read from read
 	var count int32


### PR DESCRIPTION
* enhance font support for transparent label and panel
* ensure text gets centered in its own panel
* switch to `strconv.ParseFloat` instead of `fmt.Scanf("%f", ...)`
* Allow having switchable themes in css with vars, they were statically resolved at parse before
* cache dpm instead of calling out to c every frame