### PR TITLE
feat: add a virtualized panel, text doc, and refactor textarea

### DIFF
--- a/src/engine/entity_test.go
+++ b/src/engine/entity_test.go
@@ -746,9 +746,6 @@ func TestEntity_Init(t *testing.T) {
 	if e.HasChildren() {
 		t.Fatal("Init should initialize empty children")
 	}
-	if e.namedData == nil {
-		t.Fatal("Init should initialize namedData map")
-	}
 }
 
 // ---------------------------------------------------------------------------

--- a/src/engine/ui/layout.go
+++ b/src/engine/ui/layout.go
@@ -65,6 +65,10 @@ func (l *Layout) ClearStyles() {
 		l.border.Horizontal() != 0 || l.border.Vertical() != 0 {
 		ps.SetX(ps.X() - l.padding.Horizontal() - l.border.Horizontal())
 		ps.SetY(ps.Y() - l.padding.Vertical() - l.border.Vertical())
+		// Write the box-model-stripped size back to the transform, mirroring how
+		// SetPadding/SetBorder apply it. Without this the inflated scale persists
+		// and re-applying padding after ClearStyles accumulates.
+		l.Scale(ps.Width(), ps.Height())
 	}
 	l.offset = matrix.Vec2{}
 	l.rowLayoutOffset = matrix.Vec2{}
@@ -499,6 +503,14 @@ func (l *Layout) prepare() {
 		} else {
 			l.runningStylizer = true
 			l.ui.ToSlider().onLayoutUpdating()
+			l.runningStylizer = false
+		}
+	case ElementTypeVirtualList:
+		if l.runningStylizer {
+			l.ui.ToVirtualList().onLayoutUpdating()
+		} else {
+			l.runningStylizer = true
+			l.ui.ToVirtualList().onLayoutUpdating()
 			l.runningStylizer = false
 		}
 	}

--- a/src/engine/ui/panel.go
+++ b/src/engine/ui/panel.go
@@ -121,6 +121,7 @@ type requestScroll struct {
 
 type panelData struct {
 	scrollBarX, scrollBarY    *Panel
+	scrollBarsHidden          bool
 	scrollBarStart            float32
 	scrollBarDrag             matrix.Vec2
 	scroll, offset, maxScroll matrix.Vec2
@@ -1902,6 +1903,15 @@ func (p *Panel) updateScrollBars() {
 	if pd.scrollBarX == nil && pd.scrollBarY == nil {
 		return
 	}
+	if pd.scrollBarsHidden {
+		if pd.scrollBarX != nil {
+			pd.scrollBarX.Base().Hide()
+		}
+		if pd.scrollBarY != nil {
+			pd.scrollBarY.Base().Hide()
+		}
+		return
+	}
 	if !p.flags.hovering() {
 		if pd.scrollBarX != nil {
 			pd.scrollBarX.Base().Hide()
@@ -1979,6 +1989,16 @@ func (p *Panel) updateScrollBars() {
 
 func (p *Panel) ScrollDirection() PanelScrollDirection {
 	return p.PanelData().scrollDirection
+}
+
+// SetScrollbarsVisible toggles whether this panel's scroll bars are ever shown.
+// Scrolling (wheel, drag, programmatic SetScrollY/SetScrollX) still works when
+// hidden; only the visual bars are suppressed. Used by views that drive their
+// scroll externally (e.g. a line-number gutter slaved to a sibling's scroll).
+func (p *Panel) SetScrollbarsVisible(visible bool) {
+	pd := p.PanelData()
+	pd.scrollBarsHidden = !visible
+	p.Base().SetDirty(DirtyTypeLayout)
 }
 
 func (p *Panel) BorderSize() matrix.Vec4     { return p.layout.Border() }

--- a/src/engine/ui/text_document.go
+++ b/src/engine/ui/text_document.go
@@ -1,0 +1,492 @@
+/******************************************************************************/
+/* text_document.go                                                           */
+/******************************************************************************/
+/* MIT License, Copyright (c) 2026-present Dj Gilcrease                       */
+/******************************************************************************/
+
+package ui
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+// documentModel is the line-based text buffer behind the rewritten TextArea. It
+// stores text as a slice of logical lines (no trailing newline per line) so that
+// editing a single line and mapping a (line,col) cursor to a row index are both
+// cheap and independent of total document size — the key to handling 100k lines.
+//
+// The empty document is a single empty line ([]string{""}) so the caret always
+// has a valid line to sit on, and a trailing newline in the input yields a final
+// empty line (matching how editors behave). Line endings are detected on setText
+// and normalized to '\n' internally, then re-emitted in the original style by
+// text().
+//
+// Every mutation goes through the single apply() "replace range" primitive
+// (insert is an empty range, delete is an empty replacement, replace is both),
+// which keeps undo/redo trivial: a command records the removed text, the
+// inserted text, and where it happened, and undo/redo just run apply() in the
+// other direction.
+//
+// The model holds the cursor and selection so undo can restore them and edits
+// keep them coherent; cursor *movement* (word boundaries, vertical motion) lives
+// in TextArea because it needs glyph metrics the model does not have.
+type documentModel struct {
+	lines     []string
+	eol       eolStyle
+	cursor    textPos
+	sel       textSelection
+	undoStack []docCommand
+	redoStack []docCommand
+	maxUndo   int
+}
+
+// textPos is a caret location: a line index and a rune column within that line.
+type textPos struct {
+	line int
+	col  int
+}
+
+// textSelection is a directed selection from anchor to active. It is empty (no
+// selection) when anchor == active.
+type textSelection struct {
+	anchor textPos
+	active textPos
+}
+
+type eolStyle int
+
+const (
+	eolLF eolStyle = iota
+	eolCRLF
+	eolCR
+)
+
+// docCommand is one undoable edit: the range starting at start that held removed
+// was replaced with inserted. Undo replaces inserted with removed; redo does the
+// reverse. cursorBefore/selBefore restore the caret/selection on undo.
+type docCommand struct {
+	start        textPos
+	removed      string
+	inserted     string
+	cursorBefore textPos
+	selBefore    textSelection
+	cursorAfter  textPos
+}
+
+const documentDefaultMaxUndo = 1000
+
+func newDocumentModel() *documentModel {
+	return &documentModel{
+		lines:   []string{""},
+		eol:     eolLF,
+		maxUndo: documentDefaultMaxUndo,
+	}
+}
+
+// --- content ----------------------------------------------------------------
+
+func (m *documentModel) setText(s string) {
+	m.eol = detectEOL(s)
+	normalized := normalizeEOL(s)
+	m.lines = strings.Split(normalized, "\n")
+	if len(m.lines) == 0 {
+		m.lines = []string{""}
+	}
+	m.cursor = textPos{}
+	m.clearSelection()
+	m.undoStack = m.undoStack[:0]
+	m.redoStack = m.redoStack[:0]
+}
+
+func (m *documentModel) text() string {
+	return strings.Join(m.lines, eolString(m.eol))
+}
+
+func (m *documentModel) lineCount() int { return len(m.lines) }
+
+func (m *documentModel) line(i int) string {
+	if i < 0 || i >= len(m.lines) {
+		return ""
+	}
+	return m.lines[i]
+}
+
+// --- cursor / selection ------------------------------------------------------
+
+func (m *documentModel) cursorPos() textPos { return m.cursor }
+
+func (m *documentModel) setCursor(p textPos) {
+	m.cursor = m.clampPos(p)
+	m.clearSelection()
+}
+
+func (m *documentModel) hasSelection() bool { return m.sel.anchor != m.sel.active }
+
+func (m *documentModel) setSelection(anchor, active textPos) {
+	m.sel.anchor = m.clampPos(anchor)
+	m.sel.active = m.clampPos(active)
+	m.cursor = m.sel.active
+}
+
+func (m *documentModel) clearSelection() {
+	m.sel.anchor = m.cursor
+	m.sel.active = m.cursor
+}
+
+// selection returns the normalized [start,end) range and whether a selection
+// exists.
+func (m *documentModel) selection() (start, end textPos, ok bool) {
+	if !m.hasSelection() {
+		return m.cursor, m.cursor, false
+	}
+	a, b := m.sel.anchor, m.sel.active
+	if m.posLess(b, a) {
+		a, b = b, a
+	}
+	return a, b, true
+}
+
+func (m *documentModel) selectedText() string {
+	start, end, ok := m.selection()
+	if !ok {
+		return ""
+	}
+	return m.textInRange(start, end)
+}
+
+func (m *documentModel) selectAll() {
+	last := len(m.lines) - 1
+	m.sel.anchor = textPos{0, 0}
+	m.sel.active = textPos{last, editableTextRuneCount(m.lines[last])}
+	m.cursor = m.sel.active
+}
+
+// --- edits (undoable) --------------------------------------------------------
+
+// insert replaces the active selection (if any) with s, otherwise inserts s at
+// the cursor. Newlines in s split lines as expected.
+func (m *documentModel) insert(s string) bool {
+	if s == "" {
+		return false
+	}
+	cb, sb := m.cursor, m.sel
+	start, end, _ := m.selection()
+	removed, after := m.apply(start, end, s)
+	m.cursor = after
+	m.clearSelection()
+	m.record(docCommand{
+		start: start, removed: removed, inserted: s,
+		cursorBefore: cb, selBefore: sb, cursorAfter: after,
+	})
+	return true
+}
+
+func (m *documentModel) deleteSelection() bool {
+	start, end, ok := m.selection()
+	if !ok {
+		return false
+	}
+	cb, sb := m.cursor, m.sel
+	removed, after := m.apply(start, end, "")
+	m.cursor = after
+	m.clearSelection()
+	m.record(docCommand{
+		start: start, removed: removed, inserted: "",
+		cursorBefore: cb, selBefore: sb, cursorAfter: after,
+	})
+	return true
+}
+
+// backspace deletes the selection if present, otherwise the single position
+// before the cursor (joining lines when at column 0).
+func (m *documentModel) backspace() bool {
+	if m.hasSelection() {
+		return m.deleteSelection()
+	}
+	prev := m.posBefore(m.cursor)
+	if prev == m.cursor {
+		return false
+	}
+	return m.deleteRangeRecorded(prev, m.cursor)
+}
+
+// deleteForward deletes the selection if present, otherwise the single position
+// after the cursor (joining lines when at end of line).
+func (m *documentModel) deleteForward() bool {
+	if m.hasSelection() {
+		return m.deleteSelection()
+	}
+	next := m.posAfter(m.cursor)
+	if next == m.cursor {
+		return false
+	}
+	return m.deleteRangeRecorded(m.cursor, next)
+}
+
+// deleteRange deletes [start,end) as one undoable command (used by TextArea for
+// word/line deletes after it computes the range).
+func (m *documentModel) deleteRange(start, end textPos) bool {
+	start = m.clampPos(start)
+	end = m.clampPos(end)
+	if start == end {
+		return false
+	}
+	if m.posLess(end, start) {
+		start, end = end, start
+	}
+	return m.deleteRangeRecorded(start, end)
+}
+
+func (m *documentModel) deleteRangeRecorded(start, end textPos) bool {
+	cb, sb := m.cursor, m.sel
+	removed, after := m.apply(start, end, "")
+	m.cursor = after
+	m.clearSelection()
+	m.record(docCommand{
+		start: start, removed: removed, inserted: "",
+		cursorBefore: cb, selBefore: sb, cursorAfter: after,
+	})
+	return true
+}
+
+func (m *documentModel) undo() bool {
+	if len(m.undoStack) == 0 {
+		return false
+	}
+	cmd := m.undoStack[len(m.undoStack)-1]
+	m.undoStack = m.undoStack[:len(m.undoStack)-1]
+	m.apply(cmd.start, m.advance(cmd.start, cmd.inserted), cmd.removed)
+	m.cursor = m.clampPos(cmd.cursorBefore)
+	m.sel = textSelection{m.clampPos(cmd.selBefore.anchor), m.clampPos(cmd.selBefore.active)}
+	m.redoStack = append(m.redoStack, cmd)
+	return true
+}
+
+func (m *documentModel) redoLast() bool {
+	if len(m.redoStack) == 0 {
+		return false
+	}
+	cmd := m.redoStack[len(m.redoStack)-1]
+	m.redoStack = m.redoStack[:len(m.redoStack)-1]
+	m.apply(cmd.start, m.advance(cmd.start, cmd.removed), cmd.inserted)
+	m.cursor = m.clampPos(cmd.cursorAfter)
+	m.clearSelection()
+	m.undoStack = append(m.undoStack, cmd)
+	return true
+}
+
+// record pushes cmd onto the undo stack (coalescing per-keystroke typing and
+// backspacing into the previous command) and clears the redo stack.
+func (m *documentModel) record(cmd docCommand) {
+	m.redoStack = m.redoStack[:0]
+	if m.coalesce(cmd) {
+		return
+	}
+	m.undoStack = append(m.undoStack, cmd)
+	if m.maxUndo > 0 && len(m.undoStack) > m.maxUndo {
+		m.undoStack = m.undoStack[len(m.undoStack)-m.maxUndo:]
+	}
+}
+
+// coalesce merges a single-rune insert or backspace into the top command so a
+// run of typing (or backspacing) is one undo step. Returns true if merged.
+func (m *documentModel) coalesce(cmd docCommand) bool {
+	if len(m.undoStack) == 0 {
+		return false
+	}
+	top := &m.undoStack[len(m.undoStack)-1]
+	// Typing: contiguous single-rune insertions, no newline.
+	if top.removed == "" && cmd.removed == "" &&
+		utf8.RuneCountInString(cmd.inserted) == 1 && cmd.inserted != "\n" &&
+		!strings.HasSuffix(top.inserted, "\n") &&
+		cmd.start == m.advance(top.start, top.inserted) {
+		top.inserted += cmd.inserted
+		top.cursorAfter = cmd.cursorAfter
+		return true
+	}
+	// Backspacing: contiguous single-rune deletions, no newline.
+	if top.inserted == "" && cmd.inserted == "" &&
+		utf8.RuneCountInString(cmd.removed) == 1 && cmd.removed != "\n" &&
+		!strings.Contains(top.removed, "\n") &&
+		m.advance(cmd.start, cmd.removed) == top.start {
+		top.start = cmd.start
+		top.removed = cmd.removed + top.removed
+		top.cursorAfter = cmd.cursorAfter
+		return true
+	}
+	return false
+}
+
+// --- core splice + helpers ---------------------------------------------------
+
+// apply replaces the (already-orderable) range [start,end) with newText and
+// returns the removed text and the position just past the inserted text. It does
+// NOT record undo — callers do that (or are undo/redo themselves).
+func (m *documentModel) apply(start, end textPos, newText string) (string, textPos) {
+	start = m.clampPos(start)
+	end = m.clampPos(end)
+	if m.posLess(end, start) {
+		start, end = end, start
+	}
+	removed := m.textInRange(start, end)
+	startLine := m.lines[start.line]
+	endLine := m.lines[end.line]
+	prefix := editableTextSlice(startLine, 0, start.col)
+	suffix := editableTextSlice(endLine, end.col, editableTextRuneCount(endLine))
+	merged := prefix + newText + suffix
+	newLines := strings.Split(merged, "\n")
+
+	tail := make([]string, len(m.lines)-(end.line+1))
+	copy(tail, m.lines[end.line+1:])
+	m.lines = append(m.lines[:start.line], newLines...)
+	m.lines = append(m.lines, tail...)
+	if len(m.lines) == 0 {
+		m.lines = []string{""}
+	}
+	return removed, m.advance(start, newText)
+}
+
+// textInRange returns the text spanning the normalized range [start,end).
+func (m *documentModel) textInRange(start, end textPos) string {
+	if start.line == end.line {
+		return editableTextSlice(m.lines[start.line], start.col, end.col)
+	}
+	var b strings.Builder
+	first := m.lines[start.line]
+	b.WriteString(editableTextSlice(first, start.col, editableTextRuneCount(first)))
+	b.WriteByte('\n')
+	for i := start.line + 1; i < end.line; i++ {
+		b.WriteString(m.lines[i])
+		b.WriteByte('\n')
+	}
+	b.WriteString(editableTextSlice(m.lines[end.line], 0, end.col))
+	return b.String()
+}
+
+// advance returns the position reached by writing s starting at start.
+func (m *documentModel) advance(start textPos, s string) textPos {
+	if s == "" {
+		return start
+	}
+	nl := strings.Count(s, "\n")
+	if nl == 0 {
+		return textPos{start.line, start.col + editableTextRuneCount(s)}
+	}
+	last := s[strings.LastIndexByte(s, '\n')+1:]
+	return textPos{start.line + nl, editableTextRuneCount(last)}
+}
+
+func (m *documentModel) clampPos(p textPos) textPos {
+	if p.line < 0 {
+		p.line = 0
+	}
+	if p.line >= len(m.lines) {
+		p.line = len(m.lines) - 1
+	}
+	cnt := editableTextRuneCount(m.lines[p.line])
+	if p.col < 0 {
+		p.col = 0
+	}
+	if p.col > cnt {
+		p.col = cnt
+	}
+	return p
+}
+
+func (m *documentModel) posLess(a, b textPos) bool {
+	if a.line != b.line {
+		return a.line < b.line
+	}
+	return a.col < b.col
+}
+
+func (m *documentModel) posBefore(p textPos) textPos {
+	p = m.clampPos(p)
+	if p.col > 0 {
+		return textPos{p.line, p.col - 1}
+	}
+	if p.line > 0 {
+		return textPos{p.line - 1, editableTextRuneCount(m.lines[p.line-1])}
+	}
+	return p
+}
+
+func (m *documentModel) posAfter(p textPos) textPos {
+	p = m.clampPos(p)
+	if p.col < editableTextRuneCount(m.lines[p.line]) {
+		return textPos{p.line, p.col + 1}
+	}
+	if p.line < len(m.lines)-1 {
+		return textPos{p.line + 1, 0}
+	}
+	return p
+}
+
+// --- flat-offset conversions (compat for SetCursorOffset etc.) ---------------
+
+func (m *documentModel) runeCountTotal() int {
+	total := 0
+	for i := range m.lines {
+		total += editableTextRuneCount(m.lines[i])
+	}
+	return total + (len(m.lines) - 1) // newlines between lines
+}
+
+func (m *documentModel) offsetToPos(offset int) textPos {
+	if offset <= 0 {
+		return textPos{}
+	}
+	remaining := offset
+	for i := range m.lines {
+		cnt := editableTextRuneCount(m.lines[i])
+		if remaining <= cnt {
+			return textPos{i, remaining}
+		}
+		remaining -= cnt + 1 // +1 for the newline
+		if remaining < 0 {
+			// offset landed on the newline boundary -> end of this line
+			return textPos{i, cnt}
+		}
+	}
+	last := len(m.lines) - 1
+	return textPos{last, editableTextRuneCount(m.lines[last])}
+}
+
+func (m *documentModel) posToOffset(p textPos) int {
+	p = m.clampPos(p)
+	offset := 0
+	for i := 0; i < p.line; i++ {
+		offset += editableTextRuneCount(m.lines[i]) + 1
+	}
+	return offset + p.col
+}
+
+// --- end-of-line handling ----------------------------------------------------
+
+func detectEOL(s string) eolStyle {
+	if strings.Contains(s, "\r\n") {
+		return eolCRLF
+	}
+	if strings.Contains(s, "\r") {
+		return eolCR
+	}
+	return eolLF
+}
+
+func normalizeEOL(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return s
+}
+
+func eolString(style eolStyle) string {
+	switch style {
+	case eolCRLF:
+		return "\r\n"
+	case eolCR:
+		return "\r"
+	default:
+		return "\n"
+	}
+}

--- a/src/engine/ui/text_document_test.go
+++ b/src/engine/ui/text_document_test.go
@@ -1,0 +1,243 @@
+/******************************************************************************/
+/* text_document_test.go                                                      */
+/******************************************************************************/
+/* MIT License, Copyright (c) 2015-present Brent Farris, (John 4:13-14)       */
+/******************************************************************************/
+
+package ui
+
+import "testing"
+
+func TestDocumentEmptyInvariant(t *testing.T) {
+	m := newDocumentModel()
+	assertEqualI(t, m.lineCount(), 1, "lineCount")
+	assertEqualStr(t, m.line(0), "", "line(0)")
+	assertEqualPos(t, m.cursorPos(), textPos{0, 0}, "cursor")
+	assertTrue(t, !m.hasSelection(), "no selection")
+}
+
+func TestDocumentSetTextSplitsLines(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("ab\ncd\nef")
+	assertEqualI(t, m.lineCount(), 3, "lineCount")
+	assertEqualStr(t, m.line(1), "cd", "line(1)")
+	assertEqualStr(t, m.text(), "ab\ncd\nef", "text")
+}
+
+func TestDocumentTrailingNewlineYieldsFinalEmptyLine(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("a\n")
+	assertEqualI(t, m.lineCount(), 2, "lineCount")
+	assertEqualStr(t, m.line(1), "", "final empty line")
+	assertEqualStr(t, m.text(), "a\n", "text")
+}
+
+func TestDocumentEOLNormalizationRoundTrip(t *testing.T) {
+	crlf := newDocumentModel()
+	crlf.setText("a\r\nb")
+	assertEqualI(t, crlf.lineCount(), 2, "crlf lineCount")
+	assertEqualStr(t, crlf.text(), "a\r\nb", "CRLF re-emitted")
+
+	cr := newDocumentModel()
+	cr.setText("a\rb")
+	assertEqualI(t, cr.lineCount(), 2, "cr lineCount")
+	assertEqualStr(t, cr.text(), "a\rb", "CR re-emitted")
+}
+
+func TestDocumentInsertSameLine(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("ac")
+	m.setCursor(textPos{0, 1})
+	m.insert("b")
+	assertEqualStr(t, m.text(), "abc", "text")
+	assertEqualPos(t, m.cursorPos(), textPos{0, 2}, "cursor")
+}
+
+func TestDocumentInsertNewlineSplits(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("abcd")
+	m.setCursor(textPos{0, 2})
+	m.insert("\n")
+	assertEqualI(t, m.lineCount(), 2, "lineCount")
+	assertEqualStr(t, m.line(0), "ab", "line(0)")
+	assertEqualStr(t, m.line(1), "cd", "line(1)")
+	assertEqualPos(t, m.cursorPos(), textPos{1, 0}, "cursor")
+}
+
+func TestDocumentInsertMultiLine(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("XY")
+	m.setCursor(textPos{0, 1})
+	m.insert("1\n2\n3")
+	assertEqualStr(t, m.text(), "X1\n2\n3Y", "text")
+	assertEqualPos(t, m.cursorPos(), textPos{2, 1}, "cursor")
+}
+
+func TestDocumentBackspaceWithinLine(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("abc")
+	m.setCursor(textPos{0, 2})
+	assertTrue(t, m.backspace(), "backspace ok")
+	assertEqualStr(t, m.text(), "ac", "text")
+	assertEqualPos(t, m.cursorPos(), textPos{0, 1}, "cursor")
+}
+
+func TestDocumentBackspaceJoinsLines(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("ab\ncd")
+	m.setCursor(textPos{1, 0})
+	assertTrue(t, m.backspace(), "backspace ok")
+	assertEqualStr(t, m.text(), "abcd", "text")
+	assertEqualPos(t, m.cursorPos(), textPos{0, 2}, "cursor")
+}
+
+func TestDocumentBackspaceAtStartNoOp(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("abc")
+	m.setCursor(textPos{0, 0})
+	assertTrue(t, !m.backspace(), "backspace at start is a no-op")
+	assertEqualStr(t, m.text(), "abc", "text unchanged")
+}
+
+func TestDocumentDeleteForwardJoinsLines(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("ab\ncd")
+	m.setCursor(textPos{0, 2})
+	assertTrue(t, m.deleteForward(), "deleteForward ok")
+	assertEqualStr(t, m.text(), "abcd", "text")
+	assertEqualPos(t, m.cursorPos(), textPos{0, 2}, "cursor")
+}
+
+func TestDocumentSelectionDeleteAndReplace(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("hello world")
+	m.setSelection(textPos{0, 0}, textPos{0, 5})
+	assertTrue(t, m.hasSelection(), "has selection")
+	assertEqualStr(t, m.selectedText(), "hello", "selectedText")
+
+	// Insert over selection replaces it.
+	m.insert("hi")
+	assertEqualStr(t, m.text(), "hi world", "text")
+	assertEqualPos(t, m.cursorPos(), textPos{0, 2}, "cursor")
+	assertTrue(t, !m.hasSelection(), "selection cleared")
+}
+
+func TestDocumentDeleteRangeMultiLine(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("one\ntwo\nthree")
+	assertTrue(t, m.deleteRange(textPos{0, 1}, textPos{2, 2}), "deleteRange ok")
+	assertEqualStr(t, m.text(), "oree", "text")
+	assertEqualPos(t, m.cursorPos(), textPos{0, 1}, "cursor")
+}
+
+func TestDocumentSelectAll(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("ab\ncd")
+	m.selectAll()
+	start, end, ok := m.selection()
+	assertTrue(t, ok, "has selection")
+	assertEqualPos(t, start, textPos{0, 0}, "start")
+	assertEqualPos(t, end, textPos{1, 2}, "end")
+	assertEqualStr(t, m.selectedText(), "ab\ncd", "selectedText")
+}
+
+func TestDocumentOffsetConversions(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("ab\ncd")
+	assertEqualI(t, m.runeCountTotal(), 5, "runeCountTotal")
+	cases := []struct {
+		off int
+		pos textPos
+	}{
+		{0, textPos{0, 0}},
+		{2, textPos{0, 2}},
+		{3, textPos{1, 0}},
+		{5, textPos{1, 2}},
+	}
+	for _, c := range cases {
+		assertEqualPos(t, m.offsetToPos(c.off), c.pos, "offsetToPos")
+		assertEqualI(t, m.posToOffset(c.pos), c.off, "posToOffset")
+	}
+}
+
+func TestDocumentMultiByteRunes(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("a界b")
+	m.setCursor(textPos{0, 2})
+	assertTrue(t, m.backspace(), "backspace ok")
+	assertEqualStr(t, m.text(), "ab", "text")
+	assertEqualPos(t, m.cursorPos(), textPos{0, 1}, "cursor")
+}
+
+func TestDocumentUndoRedoSingleEdit(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("ac")
+	m.setCursor(textPos{0, 1})
+	m.insert("\n") // split into "a" / "c"
+	assertEqualStr(t, m.text(), "a\nc", "after insert")
+
+	assertTrue(t, m.undo(), "undo ok")
+	assertEqualStr(t, m.text(), "ac", "after undo")
+	assertEqualPos(t, m.cursorPos(), textPos{0, 1}, "undo restores cursor")
+
+	assertTrue(t, m.redoLast(), "redo ok")
+	assertEqualStr(t, m.text(), "a\nc", "after redo")
+	assertEqualPos(t, m.cursorPos(), textPos{1, 0}, "redo restores post-edit cursor")
+}
+
+func TestDocumentTypingCoalescesToSingleUndo(t *testing.T) {
+	m := newDocumentModel()
+	m.insert("a")
+	m.insert("b")
+	m.insert("c")
+	assertEqualStr(t, m.text(), "abc", "after typing")
+
+	assertTrue(t, m.undo(), "undo ok")
+	assertEqualStr(t, m.text(), "", "a run of typing undoes in one step")
+	assertEqualPos(t, m.cursorPos(), textPos{0, 0}, "cursor")
+
+	assertTrue(t, m.redoLast(), "redo ok")
+	assertEqualStr(t, m.text(), "abc", "after redo")
+	assertEqualPos(t, m.cursorPos(), textPos{0, 3}, "cursor")
+}
+
+func TestDocumentBackspaceCoalescesToSingleUndo(t *testing.T) {
+	m := newDocumentModel()
+	m.setText("abc")
+	m.setCursor(textPos{0, 3})
+	m.backspace()
+	m.backspace()
+	m.backspace()
+	assertEqualStr(t, m.text(), "", "after backspaces")
+
+	assertTrue(t, m.undo(), "undo ok")
+	assertEqualStr(t, m.text(), "abc", "a run of backspaces undoes in one step")
+	assertEqualPos(t, m.cursorPos(), textPos{0, 3}, "cursor")
+}
+
+func TestDocumentNewEditClearsRedo(t *testing.T) {
+	m := newDocumentModel()
+	m.insert("a")
+	m.insert("b")
+	assertTrue(t, m.undo(), "undo ok")
+	assertEqualStr(t, m.text(), "", "after undo")
+	// A fresh edit after undo discards the redo stack.
+	m.insert("z")
+	assertTrue(t, !m.redoLast(), "redo discarded after new edit")
+	assertEqualStr(t, m.text(), "z", "text")
+}
+
+func TestDocumentNewlineIsOwnUndoStep(t *testing.T) {
+	m := newDocumentModel()
+	m.insert("a")
+	m.insert("\n")
+	m.insert("b")
+	assertEqualStr(t, m.text(), "a\nb", "after edits")
+	// "b" undo, then the newline undo, then "a" undo — newline is not coalesced.
+	assertTrue(t, m.undo(), "undo 1")
+	assertEqualStr(t, m.text(), "a\n", "after undo 1")
+	assertTrue(t, m.undo(), "undo 2")
+	assertEqualStr(t, m.text(), "a", "after undo 2")
+	assertTrue(t, m.undo(), "undo 3")
+	assertEqualStr(t, m.text(), "", "after undo 3")
+}

--- a/src/engine/ui/textarea.go
+++ b/src/engine/ui/textarea.go
@@ -14,7 +14,6 @@ import (
 	"weak"
 
 	"kaijuengine.com/engine/assets"
-	"kaijuengine.com/engine/systems/events"
 	"kaijuengine.com/matrix"
 	"kaijuengine.com/platform/hid"
 	"kaijuengine.com/platform/profiler/tracing"
@@ -27,34 +26,79 @@ const (
 	textareaDefaultHeight float32 = 96.0
 )
 
+// TextColorSpan colors a [Start,End) rune range WITHIN a single line. It is a
+// pure data carrier used by the widget layer (syntax highlighting, markers).
+type TextColorSpan struct {
+	Start, End int
+	FG, BG     matrix.Color
+}
+
+// textareaData is the runtime state of a TextArea. The text itself lives in a
+// line-based documentModel; the visible lines are rendered by a child
+// VirtualList (one recycled Label per visible line) so the widget handles very
+// large documents at constant rendering cost. Cursor, selection, and the
+// current-line highlight are overlay panels parented to the list's scrolling
+// content so they track the rows.
 type textareaData struct {
 	panelData
-	label               *Label
-	placeholder         *Label
-	cursor              *Panel
-	content             *Panel
-	selectionContainer  *Panel
-	selectionPanels     []*Panel
-	selectionColor      matrix.Color
-	text                string
-	onUpDown            events.Event
-	cursorOffset        int
+	doc                *documentModel
+	list               *VirtualList
+	lineDelegate       *textareaLineDelegate
+	placeholder        *Label
+	cursor             *Panel
+	selectionContainer *Panel
+	selectionPanels    []*Panel
+	currentLinePanel   *Panel
+
+	selectionColor   matrix.Color
+	fgColor          matrix.Color
+	bgColor          matrix.Color
+	currentLineColor matrix.Color
+	fontFace         rendering.FontFace
+	fontSize         float32
+	fontWeight       string
+	fontStyle        string
+	lineHeight       float32
+	letterSpacing    float32
+	wrap             bool
+
+	lineSpans map[int][]TextColorSpan
+
 	cursorBlink         float32
-	selectStart         int
-	selectEnd           int
-	selectAnchor        int
 	preferredCursorX    float32
 	hasPreferredCursorX bool
 	ensureVisibleNext   bool
-	required            bool
-	isActive            bool
-	prevFocusElement    weak.Pointer[UI]
-	nextFocusElement    weak.Pointer[UI]
-	textOnFocus         string
+	maxLineWidth        float32
+	dragAnchor          textPos
+
+	required             bool
+	isActive             bool
+	readOnly             bool
+	highlightCurrentLine bool
+
+	prevFocusElement weak.Pointer[UI]
+	nextFocusElement weak.Pointer[UI]
+	textOnFocus      string
+
+	onVisibleRangeChanged func(first, last int)
+	lastVisFirst          int
+	lastVisLast           int
+
+	onScroll           func()
+	lastScrollNotified float32
 }
 
 func (t *textareaData) innerPanelData() *panelData { return &t.panelData }
 
+func (t *textareaData) effectiveFontSize() float32 {
+	if t.fontSize > 0 {
+		return t.fontSize
+	}
+	return LabelFontSize
+}
+
+// textareaCaretGeometry / textareaLineRange are used by the pure caret/selection
+// helpers below (which are exercised directly by the tests).
 type textareaCaretGeometry struct {
 	line   int
 	x      float32
@@ -79,7 +123,12 @@ func (textarea *TextArea) TextAreaData() *textareaData {
 }
 
 func (textarea *TextArea) Init(placeholderText string) {
-	data := &textareaData{}
+	data := &textareaData{
+		doc:         newDocumentModel(),
+		wrap:        true,
+		lineSpans:   map[int][]TextColorSpan{},
+		lastVisLast: -1,
+	}
 	textarea.elmData = data
 	p := textarea.Base().ToPanel()
 	man := p.man.Value()
@@ -88,49 +137,69 @@ func (textarea *TextArea) Init(placeholderText string) {
 	p.Init(tex, ElementTypeTextArea)
 	p.layout.Scale(textareaDefaultWidth, textareaDefaultHeight)
 	p.DontFitContent()
-	p.SetOverflow(OverflowScroll)
-	p.SetScrollDirection(PanelScrollDirectionVertical)
+	p.SetOverflow(OverflowHidden)
 
-	data.content = man.Add().ToPanel()
-	data.content.Init(nil, ElementTypePanel)
-	data.content.DontFitContent()
-	data.content.AllowClickThrough()
-	p.AddChild(data.content.Base())
+	// The scrolling list of text rows.
+	data.list = man.Add().ToVirtualList()
+	data.list.Init()
+	data.lineDelegate = &textareaLineDelegate{ta: textarea}
+	data.list.Base().layout.SetPositioning(PositioningAbsolute)
+	p.AddChild(data.list.Base())
+	content := data.list.Content()
 
+	// Selection rectangles (behind the glyphs).
 	data.selectionContainer = man.Add().ToPanel()
 	data.selectionContainer.Init(nil, ElementTypePanel)
 	data.selectionContainer.DontFitContent()
 	data.selectionContainer.layout.SetPositioning(PositioningAbsolute)
 	data.selectionContainer.AllowClickThrough()
-	data.content.AddChild(data.selectionContainer.Base())
+	content.AddChild(data.selectionContainer.Base())
 
-	data.label = man.Add().ToLabel()
-	data.label.Init("")
-	data.label.layout.SetPositioning(PositioningAbsolute)
-	data.label.SetBaseline(rendering.FontBaselineTop)
-	data.label.SetWrap(true)
-	data.content.AddChild(data.label.Base())
+	// Current-line highlight (furthest back).
+	data.currentLinePanel = man.Add().ToPanel()
+	data.currentLinePanel.Init(tex, ElementTypePanel)
+	data.currentLinePanel.DontFitContent()
+	data.currentLinePanel.layout.SetPositioning(PositioningAbsolute)
+	data.currentLinePanel.layout.SetZ(0)
+	data.currentLinePanel.AllowClickThrough()
+	content.AddChild(data.currentLinePanel.Base())
+	data.currentLinePanel.entity.SetActive(false)
 
+	// Placeholder shown when empty.
 	data.placeholder = man.Add().ToLabel()
 	data.placeholder.Init(placeholderText)
 	data.placeholder.layout.SetPositioning(PositioningAbsolute)
+	data.placeholder.layout.SetZ(5)
 	data.placeholder.SetBaseline(rendering.FontBaselineTop)
 	data.placeholder.SetWrap(true)
-	data.content.AddChild(data.placeholder.Base())
+	content.AddChild(data.placeholder.Base())
 
+	// Cursor (in front of glyphs).
 	data.cursor = man.Add().ToPanel()
 	data.cursor.Init(tex, ElementTypePanel)
 	data.cursor.DontFitContent()
-	data.cursor.SetColor(matrix.ColorBlack())
 	data.cursor.layout.SetPositioning(PositioningAbsolute)
-	data.content.AddChild(data.cursor.Base())
+	data.cursor.layout.SetZ(10)
+	data.cursor.AllowClickThrough()
+	content.AddChild(data.cursor.Base())
+
+	data.fontFace = data.placeholder.FontFace()
+	data.fontSize = data.placeholder.FontSize()
+	data.selectionContainer.layout.SetZ(1)
 
 	textarea.ensureSelectionPanel()
 	textarea.SetFGColor(matrix.ColorBlack())
 	textarea.SetBGColor(matrix.ColorWhite())
 	textarea.SetSelectColor(matrix.Color{1, 1, 0, 0.5})
+	data.currentLineColor = matrix.Color{0, 0, 0, 0.06}
+	data.cursor.SetColor(matrix.ColorBlack())
+
+	data.list.SetDelegate(data.lineDelegate)
+	textarea.applyHeightMode()
+
 	textarea.hideCursor()
 	textarea.hideSelection()
+	textarea.updatePlaceholderVisibility()
 
 	base := textarea.Base()
 	base.AddEvent(EventTypeEnter, textarea.onEnter)
@@ -161,173 +230,149 @@ func (textarea *TextArea) SetNextFocusedElement(next *UI) {
 	}
 }
 
-func (textarea *TextArea) ensureSelectionPanel() *Panel {
-	return textarea.ensureSelectionPanelIndex(0)
+// --- row delegate ------------------------------------------------------------
+
+type textareaLineDelegate struct{ ta *TextArea }
+
+func (d *textareaLineDelegate) RowCount() int { return d.ta.Data().doc.lineCount() }
+
+func (d *textareaLineDelegate) CreateRow(man *Manager) *UI {
+	lbl := man.Add().ToLabel()
+	lbl.Init("")
+	lbl.SetBaseline(rendering.FontBaselineTop)
+	lbl.layout.SetPositioning(PositioningAbsolute)
+	lbl.layout.SetZ(2)
+	return lbl.Base()
 }
 
-func (textarea *TextArea) ensureSelectionPanelIndex(index int) *Panel {
-	data := textarea.Data()
-	if len(data.selectionPanels) > index {
-		return data.selectionPanels[index]
-	}
-	tex, _ := textarea.man.Value().Host.TextureCache().Texture(
-		assets.TextureSquare, rendering.TextureFilterLinear)
-	panel := textarea.man.Value().Add().ToPanel()
-	panel.Init(tex, ElementTypePanel)
-	panel.DontFitContent()
-	panel.SetColor(data.selectionColor)
-	panel.layout.SetPositioning(PositioningAbsolute)
-	panel.layout.SetZ(1)
-	panel.AllowClickThrough()
-	data.selectionContainer.AddChild(panel.Base())
-	data.selectionPanels = append(data.selectionPanels, panel)
-	return panel
-}
-
-func (textarea *TextArea) onLayoutUpdating() {
-	data := textarea.Data()
-	width := textarea.contentWidth()
-	scrollHeight := textarea.scrollContentHeight()
-
-	data.content.layout.Scale(width+textareaPadding*2, scrollHeight)
-	for _, label := range []*Label{data.label, data.placeholder} {
-		label.layout.SetOffset(textareaPadding, textareaPadding)
-		label.SetMaxWidth(width)
-		label.SetWidthAutoHeight(width)
-	}
-	data.selectionContainer.layout.SetOffset(textareaPadding, textareaPadding)
-	data.selectionContainer.layout.Scale(width, scrollHeight-textareaPadding*2)
-	if data.selectStart != data.selectEnd {
-		textarea.updateSelectionPanels()
-	}
-	textarea.updateCursorPosition()
-}
-
-func (textarea *TextArea) update(deltaTime float64) {
-	defer tracing.NewRegion("TextArea.update").End()
-	textarea.Base().ToPanel().update(deltaTime)
-	data := textarea.Data()
-	if !data.isActive {
-		return
-	}
-	if !textarea.entity.IsActive() {
-		data.isActive = false
-		return
-	}
-	data.cursorBlink -= float32(deltaTime)
-	if data.cursorBlink <= 0 {
-		if data.cursor.entity.IsActive() {
-			textarea.hideCursor()
-		} else {
-			textarea.showCursor()
+func (d *textareaLineDelegate) BindRow(index int, row *UI) {
+	data := d.ta.Data()
+	lbl := row.ToLabel()
+	d.ta.applyLabelStyle(lbl)
+	lbl.SetWrap(data.wrap)
+	lbl.SetText(data.doc.line(index))
+	if spans, ok := data.lineSpans[index]; ok {
+		for _, s := range spans {
+			lbl.ColorRange(s.Start, s.End, s.FG, s.BG)
 		}
-		data.cursorBlink = cursorBlinkRate
 	}
-	if textarea.flags.drag() {
-		offset := textarea.pointerPosWithin()
-		data.cursorOffset = editableTextClampOffset(data.text, offset)
-		data.hasPreferredCursorX = false
-		textarea.setSelect(data.selectAnchor, data.cursorOffset)
-		textarea.showCursor()
-		textarea.requestEnsureCursorVisible()
+	// A recycled row was deactivated (its glyph drawings turned off); SetText
+	// no-ops when the text is unchanged, so force a re-render to be sure the
+	// glyphs are rebuilt and reactivated (otherwise the row can render blank).
+	lbl.LabelData().renderRequired = true
+}
+
+func (d *textareaLineDelegate) UnbindRow(index int, row *UI) {}
+
+// --- styling helpers ---------------------------------------------------------
+
+func (textarea *TextArea) applyLabelStyle(lbl *Label) {
+	d := textarea.Data()
+	lbl.SetColor(d.fgColor)
+	lbl.SetBGColor(d.bgColor)
+	if d.fontFace != "" {
+		lbl.SetFontFace(d.fontFace)
 	}
-	if data.ensureVisibleNext {
-		data.ensureVisibleNext = false
-		textarea.ensureCursorVisible(textarea.updateCursorPosition())
+	if d.fontWeight != "" {
+		lbl.SetFontWeight(d.fontWeight)
+	}
+	if d.fontStyle != "" {
+		lbl.SetFontStyle(d.fontStyle)
+	}
+	lbl.SetFontSize(d.effectiveFontSize())
+	if d.lineHeight > 0 {
+		lbl.SetLineHeight(d.lineHeight)
 	}
 }
 
-func (textarea *TextArea) showCursor() {
+func (textarea *TextArea) resolvedLineHeight() float32 {
+	d := textarea.Data()
+	if d.lineHeight > 0 {
+		return d.lineHeight
+	}
+	return d.effectiveFontSize()
+}
+
+// applyHeightMode points the list at the fixed or variable height model to match
+// the current wrap setting. The fixed (no-wrap) height is the font's actual
+// single-line height so rows abut without overlap or gaps.
+func (textarea *TextArea) applyHeightMode() {
 	data := textarea.Data()
-	if data.isActive && !data.cursor.entity.IsActive() {
-		data.cursor.entity.SetActive(true)
+	if data.wrap {
+		data.list.SetRowHeightFunc(textarea.measureLineHeight)
+	} else {
+		data.list.SetFixedRowHeight(textarea.singleLineHeight())
 	}
-	data.cursorBlink = cursorBlinkRate
-	textarea.updateCursorPosition()
+	data.list.SetContentWidth(0)
 }
 
-func (textarea *TextArea) hideCursor() {
+// singleLineHeight is the rendered height of one line of text in the current
+// font, used as the fixed row height in no-wrap mode (and for the gutter).
+func (textarea *TextArea) singleLineHeight() float32 {
 	data := textarea.Data()
-	if data.cursor.entity.IsActive() {
-		data.cursor.entity.SetActive(false)
+	host := textarea.man.Value().Host
+	sz := host.FontCache().MeasureStringWithinWithLetterSpacing(
+		data.fontFace, "Xg", data.effectiveFontSize(), 0, data.lineHeight, data.letterSpacing)
+	if sz.Y() > 0 {
+		return sz.Y()
 	}
-	data.cursorBlink = cursorBlinkRate
+	return textarea.resolvedLineHeight()
 }
 
-func (textarea *TextArea) updateCursorPosition() textareaCaretGeometry {
+func (textarea *TextArea) measureLineHeight(index int) float32 {
 	data := textarea.Data()
-	caret := textarea.caretGeometry(data.cursorOffset)
-	data.cursor.layout.Scale(cursorWidth, max(float32(0.001), caret.height))
-	data.cursor.layout.SetOffset(textareaPadding+caret.x, textareaPadding+caret.y)
-	return caret
-}
-
-func (textarea *TextArea) ensureCursorVisible(caret textareaCaretGeometry) {
-	viewportHeight := textarea.contentHeight()
-	if viewportHeight <= 0 {
-		return
+	lh := textarea.singleLineHeight()
+	if !data.wrap {
+		return lh
 	}
-	panel := (*Panel)(textarea)
-	scrollY := panel.ScrollY()
-	top := caret.y
-	bottom := caret.y + caret.height
-	if top < scrollY {
-		panel.SetScrollY(top)
-	} else if bottom > scrollY+viewportHeight {
-		panel.SetScrollY(bottom - viewportHeight)
+	host := textarea.man.Value().Host
+	text := data.doc.line(index)
+	if text == "" {
+		return lh
 	}
+	sz := host.FontCache().MeasureStringWithinWithLetterSpacing(
+		data.fontFace, text, data.effectiveFontSize(),
+		textarea.textContentWidth(), data.lineHeight, data.letterSpacing)
+	return max(sz.Y(), lh)
 }
 
-func (textarea *TextArea) requestEnsureCursorVisible() {
-	textarea.Data().ensureVisibleNext = true
-	textarea.updateCursorPosition()
-}
+// --- geometry ---------------------------------------------------------------
 
-func (textarea *TextArea) contentWidth() float32 {
+func (textarea *TextArea) textContentWidth() float32 {
 	ps := textarea.layout.PixelSize()
-	return max(float32(0.001), ps.Width()-textareaPadding*2)
+	return max(ps.Width()-textareaPadding*2, 1)
 }
 
-func (textarea *TextArea) contentHeight() float32 {
-	ps := textarea.layout.PixelSize()
-	return max(float32(0.001), ps.Height()-textareaPadding*2)
-}
-
-func (textarea *TextArea) scrollContentHeight() float32 {
-	data := textarea.Data()
-	ld := data.label.LabelData()
-	lineHeight := textareaLineHeight(ld)
-	height := textarea.contentHeight()
-	rects := textarea.runeRects()
-	ranges := textareaLineRanges(data.text, rects, lineHeight)
-	if len(ranges) > 0 {
-		last := ranges[len(ranges)-1]
-		height = max(height, last.y+last.height)
+func (textarea *TextArea) lineRects(line int) []matrix.Vec4 {
+	d := textarea.Data()
+	maxW := float32(0)
+	if d.wrap {
+		maxW = textarea.textContentWidth()
 	}
-	return height + textareaPadding*2
-}
-
-func (textarea *TextArea) runeRects() []matrix.Vec4 {
-	data := textarea.Data()
-	ld := data.label.LabelData()
 	return textarea.man.Value().Host.FontCache().StringRectsWithinWithLetterSpacing(
-		ld.fontFace, data.text, ld.fontSize, textarea.contentWidth(),
-		ld.lineHeight, ld.letterSpacing)
+		d.fontFace, d.doc.line(line), d.effectiveFontSize(), maxW, d.lineHeight, d.letterSpacing)
 }
 
-func (textarea *TextArea) caretGeometry(offset int) textareaCaretGeometry {
+func (textarea *TextArea) caretPixel(pos textPos) textareaCaretGeometry {
 	data := textarea.Data()
-	ld := data.label.LabelData()
-	return textareaCaretFromRuneRects(data.text, textarea.runeRects(),
-		offset, textareaLineHeight(ld))
+	rects := textarea.lineRects(pos.line)
+	c := textareaCaretFromRuneRects(data.doc.line(pos.line), rects, pos.col, textarea.resolvedLineHeight())
+	c.y += data.list.RowOffset(pos.line)
+	c.line = pos.line
+	return c
 }
 
-func textareaLineHeight(ld *labelData) float32 {
-	if ld.lineHeight > 0 {
-		return ld.lineHeight
-	}
-	return ld.fontSize
+// colAtX returns the rune column on line nearest content-space x, on the first
+// visual row (sufficient for no-wrap; an approximation for wrapped lines).
+func (textarea *TextArea) colAtX(line int, x float32) int {
+	rects := textarea.lineRects(line)
+	ranges := textareaLineRanges(textarea.Data().doc.line(line), rects, textarea.resolvedLineHeight())
+	return textareaLineOffsetForX(ranges, rects, 0, x)
 }
+
+// --- pure caret / line / selection helpers (string + rune-rect based) --------
+// These are storage-agnostic and exercised directly by the tests; the rewritten
+// TextArea applies them per line.
 
 func textareaCaretFromRuneRects(text string, rects []matrix.Vec4, offset int, fallbackHeight float32) textareaCaretGeometry {
 	offset = editableTextClampOffset(text, offset)
@@ -596,20 +641,159 @@ func textareaRuneOffsetFromPoint(text string, rects []matrix.Vec4, point matrix.
 	return editableTextClamp(lastInLine, 0, editableTextRuneCount(text))
 }
 
-func (textarea *TextArea) pointerOffsetAtPosition(point matrix.Vec2) int {
-	point.SetX(point.X() - textareaPadding)
-	point.SetY(point.Y() - textareaPadding + (*Panel)(textarea).ScrollY())
-	return textareaRuneOffsetFromPoint(textarea.Data().text, textarea.runeRects(), point)
+// --- selection panel pool ----------------------------------------------------
+
+func (textarea *TextArea) ensureSelectionPanel() *Panel {
+	return textarea.ensureSelectionPanelIndex(0)
 }
 
-func (textarea *TextArea) pointerPosWithin() int {
-	host := textarea.man.Value().Host
-	pos := textarea.Base().cursorPos(&host.Window.Cursor)
-	wp := textarea.entity.Transform.WorldPosition()
-	ws := textarea.entity.Transform.WorldScale()
-	pos.SetX(pos.X() - (wp.X() - ws.X()*0.5))
-	pos.SetY(pos.Y() - (wp.Y() - ws.Y()*0.5))
-	return textarea.pointerOffsetAtPosition(pos)
+func (textarea *TextArea) ensureSelectionPanelIndex(index int) *Panel {
+	data := textarea.Data()
+	if len(data.selectionPanels) > index {
+		return data.selectionPanels[index]
+	}
+	tex, _ := textarea.man.Value().Host.TextureCache().Texture(
+		assets.TextureSquare, rendering.TextureFilterLinear)
+	panel := textarea.man.Value().Add().ToPanel()
+	panel.Init(tex, ElementTypePanel)
+	panel.DontFitContent()
+	panel.SetColor(data.selectionColor)
+	panel.layout.SetPositioning(PositioningAbsolute)
+	panel.layout.SetZ(1)
+	panel.AllowClickThrough()
+	data.selectionContainer.AddChild(panel.Base())
+	data.selectionPanels = append(data.selectionPanels, panel)
+	return panel
+}
+
+// --- layout / update ---------------------------------------------------------
+
+func (textarea *TextArea) onLayoutUpdating() {
+	data := textarea.Data()
+	ps := textarea.layout.PixelSize()
+	innerH := max(ps.Height()-textareaPadding*2, 1)
+	data.list.Base().layout.SetOffset(textareaPadding, textareaPadding)
+	data.list.Base().layout.Scale(max(ps.Width()-textareaPadding*2, 1), innerH)
+	// Anchor the placeholder at the content top-left; let the label size itself
+	// to the content width (see BindRow — no override width).
+	data.placeholder.layout.SetOffset(0, 0)
+	// Size the selection container to the scrolling content so its child
+	// selection rectangles anchor in the same content-space coordinates the
+	// cursor uses (otherwise they sit against a zero-size box and don't show).
+	csz := data.list.Content().layout.PixelSize()
+	data.selectionContainer.layout.SetOffset(0, 0)
+	data.selectionContainer.layout.Scale(max(csz.X(), 1), max(csz.Y(), 1))
+	textarea.updateCurrentLine()
+	textarea.updateSelectionPanels()
+	textarea.updateCursorPosition()
+	textarea.maybeNotifyVisibleRange()
+	textarea.notifyScrollIfChanged()
+}
+
+// notifyScrollIfChanged fires the OnScroll observer when the vertical scroll
+// position changes, so a consumer (e.g. the widget-layer code editor) can keep a
+// companion gutter scrolled in lockstep without its own per-frame hook.
+func (textarea *TextArea) notifyScrollIfChanged() {
+	data := textarea.Data()
+	if data.onScroll == nil {
+		return
+	}
+	y := (*Panel)(data.list).ScrollY()
+	if y == data.lastScrollNotified {
+		return
+	}
+	data.lastScrollNotified = y
+	data.onScroll()
+}
+
+func (textarea *TextArea) update(deltaTime float64) {
+	defer tracing.NewRegion("TextArea.update").End()
+	textarea.Base().ToPanel().update(deltaTime)
+	data := textarea.Data()
+	if !data.isActive {
+		return
+	}
+	if !textarea.entity.IsActive() {
+		data.isActive = false
+		return
+	}
+	data.cursorBlink -= float32(deltaTime)
+	if data.cursorBlink <= 0 {
+		if data.cursor.entity.IsActive() {
+			textarea.hideCursor()
+		} else {
+			textarea.showCursor()
+		}
+		data.cursorBlink = cursorBlinkRate
+	}
+	// The scrolling list (not the TextArea panel) is the pointer hit target, so
+	// the drag flag lands on it; watch both so click-drag extends the selection.
+	if textarea.flags.drag() || data.list.Base().flags.drag() {
+		pos := textarea.pointerPosWithin()
+		data.doc.setSelection(data.dragAnchor, pos)
+		data.hasPreferredCursorX = false
+		textarea.showCursor()
+		textarea.requestEnsureCursorVisible()
+	}
+	if data.ensureVisibleNext {
+		data.ensureVisibleNext = false
+		textarea.ensureCursorVisible()
+	}
+}
+
+func (textarea *TextArea) maybeNotifyVisibleRange() {
+	data := textarea.Data()
+	if data.onVisibleRangeChanged == nil {
+		return
+	}
+	first, last := data.list.VisibleRange()
+	if first == data.lastVisFirst && last == data.lastVisLast {
+		return
+	}
+	data.lastVisFirst, data.lastVisLast = first, last
+	data.onVisibleRangeChanged(first, last)
+}
+
+// --- cursor / selection rendering -------------------------------------------
+
+func (textarea *TextArea) showCursor() {
+	data := textarea.Data()
+	if data.isActive && !data.cursor.entity.IsActive() {
+		data.cursor.entity.SetActive(true)
+	}
+	data.cursorBlink = cursorBlinkRate
+	textarea.updateCursorPosition()
+}
+
+func (textarea *TextArea) hideCursor() {
+	data := textarea.Data()
+	if data.cursor.entity.IsActive() {
+		data.cursor.entity.SetActive(false)
+	}
+	data.cursorBlink = cursorBlinkRate
+}
+
+func (textarea *TextArea) updateCursorPosition() {
+	data := textarea.Data()
+	caret := textarea.caretPixel(data.doc.cursorPos())
+	data.cursor.layout.Scale(cursorWidth, max(float32(0.001), caret.height))
+	data.cursor.layout.SetOffset(caret.x, caret.y)
+}
+
+func (textarea *TextArea) updateCurrentLine() {
+	data := textarea.Data()
+	if !data.highlightCurrentLine || data.doc.hasSelection() {
+		data.currentLinePanel.entity.SetActive(false)
+		return
+	}
+	line := data.doc.cursorPos().line
+	y := data.list.RowOffset(line)
+	h := data.list.RowHeight(line)
+	w := max(textarea.textContentWidth(), data.maxLineWidth)
+	data.currentLinePanel.SetColor(data.currentLineColor)
+	data.currentLinePanel.layout.SetOffset(0, y)
+	data.currentLinePanel.layout.Scale(max(w, 1), max(h, 1))
+	data.currentLinePanel.entity.SetActive(true)
 }
 
 func (textarea *TextArea) showSelection() {
@@ -631,68 +815,142 @@ func (textarea *TextArea) hideSelection() {
 
 func (textarea *TextArea) updateSelectionPanels() {
 	data := textarea.Data()
-	if data.selectStart == data.selectEnd {
+	start, end, ok := data.doc.selection()
+	if !ok {
 		textarea.hideSelection()
 		return
 	}
-	rects := textarea.runeRects()
-	ld := data.label.LabelData()
-	start, end := editableTextNormalizeSelection(data.text, data.selectStart, data.selectEnd)
-	panelRects := textareaSelectionPanelRects(data.text, rects, start, end,
-		textarea.contentWidth(), textareaLineHeight(ld))
-	for panelIndex, rect := range panelRects {
-		panel := textarea.ensureSelectionPanelIndex(panelIndex)
-		panel.layout.SetOffset(rect.X(), rect.Y())
-		panel.layout.Scale(rect.Z(), rect.W())
-		panel.entity.SetActive(true)
+	first, last := data.list.VisibleRange()
+	lo := max(start.line, first)
+	hi := min(end.line, last)
+	lh := textarea.resolvedLineHeight()
+	contentW := max(textarea.textContentWidth(), data.maxLineWidth)
+	pi := 0
+	for line := lo; line <= hi; line++ {
+		lineText := data.doc.line(line)
+		sCol := 0
+		if line == start.line {
+			sCol = start.col
+		}
+		eCol := editableTextRuneCount(lineText)
+		fullLine := true
+		if line == end.line {
+			eCol = end.col
+			fullLine = false
+		}
+		rects := textarea.lineRects(line)
+		rowY := data.list.RowOffset(line)
+		prs := textareaSelectionPanelRects(lineText, rects, sCol, eCol, contentW, lh)
+		if len(prs) == 0 && fullLine {
+			// Fully-selected empty line: show a thin marker the line height tall.
+			prs = []matrix.Vec4{{0, 0, lh * 0.5, lh}}
+		}
+		for _, r := range prs {
+			w := r.Z()
+			if fullLine && r.X()+r.Z() >= contentW-1 {
+				w = max(w, contentW-r.X())
+			}
+			panel := textarea.ensureSelectionPanelIndex(pi)
+			pi++
+			panel.layout.SetOffset(r.X(), rowY+r.Y())
+			panel.layout.Scale(max(0.001, w), r.W())
+			panel.entity.SetActive(true)
+		}
 	}
-	for i := len(panelRects); i < len(data.selectionPanels); i++ {
+	for i := pi; i < len(data.selectionPanels); i++ {
 		data.selectionPanels[i].entity.SetActive(false)
 	}
-	textarea.showSelection()
+	if pi > 0 {
+		textarea.showSelection()
+	} else {
+		textarea.hideSelection()
+	}
 }
 
 func (textarea *TextArea) updatePlaceholderVisibility() {
 	data := textarea.Data()
-	if len(data.text) == 0 {
+	empty := data.doc.lineCount() == 1 && data.doc.line(0) == ""
+	if empty {
 		data.placeholder.Show()
 	} else {
 		data.placeholder.Hide()
 	}
 }
 
-func (textarea *TextArea) setSelect(start, end int) {
-	data := textarea.Data()
-	start, end = editableTextNormalizeSelection(data.text, start, end)
-	if data.selectStart == start && data.selectEnd == end {
-		return
-	}
-	data.selectStart = start
-	data.selectEnd = end
-	if start == end {
-		textarea.hideSelection()
-	} else {
-		textarea.showSelection()
-		textarea.updateSelectionPanels()
-	}
+// --- scrolling ---------------------------------------------------------------
+
+func (textarea *TextArea) requestEnsureCursorVisible() {
+	textarea.Data().ensureVisibleNext = true
+	textarea.updateCursorPosition()
 }
 
-func (textarea *TextArea) resetSelect() {
-	textarea.setSelect(0, 0)
-}
-
-func (textarea *TextArea) moveCursor(offset int, extendSelection, keepPreferredX bool) {
+func (textarea *TextArea) ensureCursorVisible() {
 	data := textarea.Data()
-	oldOffset := data.cursorOffset
-	data.cursorOffset = editableTextClampOffset(data.text, offset)
-	if extendSelection {
-		if data.selectStart == data.selectEnd {
-			data.selectAnchor = oldOffset
+	caret := textarea.caretPixel(data.doc.cursorPos())
+	list := data.list
+	p := (*Panel)(list)
+	vh := list.ViewportHeight()
+	if vh > 0 {
+		scrollY := p.ScrollY()
+		if caret.y < scrollY {
+			p.SetScrollY(caret.y)
+		} else if caret.y+caret.height > scrollY+vh {
+			p.SetScrollY(caret.y + caret.height - vh)
 		}
-		textarea.setSelect(data.selectAnchor, data.cursorOffset)
+	}
+	if !data.wrap {
+		vw := list.layout.PixelSize().Width()
+		if vw > 0 {
+			scrollX := p.ScrollX()
+			if caret.x < scrollX {
+				p.SetScrollX(caret.x)
+			} else if caret.x+cursorWidth > scrollX+vw {
+				p.SetScrollX(caret.x + cursorWidth - vw)
+			}
+		}
+	}
+}
+
+// --- pointer hit testing -----------------------------------------------------
+
+// pointerPosWithin maps the current cursor position to a document (line,col).
+// It works in the scrolling content panel's own world frame: the UI world is
+// +Y up (window-centered), so the content's top edge is center+halfHeight and a
+// point's vertical distance BELOW that top is the (Y-down) document offset. The
+// content panel's world position already includes the scroll, so no separate
+// scroll term is needed.
+func (textarea *TextArea) pointerPosWithin() textPos {
+	data := textarea.Data()
+	host := textarea.man.Value().Host
+	cur := textarea.Base().cursorPos(&host.Window.Cursor)
+	content := data.list.Content()
+	cwp := content.entity.Transform.WorldPosition()
+	cws := content.entity.Transform.WorldScale()
+	docY := (cwp.Y() + cws.Y()*0.5) - cur.Y()
+	docX := cur.X() - (cwp.X() - cws.X()*0.5)
+	if docY < 0 {
+		docY = 0
+	}
+	line := data.list.RowAt(docY)
+	rects := textarea.lineRects(line)
+	localY := docY - data.list.RowOffset(line)
+	col := textareaRuneOffsetFromPoint(data.doc.line(line), rects, matrix.Vec2{docX, localY})
+	return data.doc.clampPos(textPos{line, col})
+}
+
+// --- cursor movement ---------------------------------------------------------
+
+func (textarea *TextArea) moveCursorTo(pos textPos, extend, keepPreferredX bool) {
+	data := textarea.Data()
+	pos = data.doc.clampPos(pos)
+	if extend {
+		anchor := data.doc.sel.anchor
+		if !data.doc.hasSelection() {
+			anchor = data.doc.cursorPos()
+		}
+		data.doc.setSelection(anchor, pos)
 	} else {
-		textarea.resetSelect()
-		data.selectAnchor = data.cursorOffset
+		data.doc.setCursor(pos)
 	}
 	if !keepPreferredX {
 		data.hasPreferredCursorX = false
@@ -701,51 +959,200 @@ func (textarea *TextArea) moveCursor(offset int, extendSelection, keepPreferredX
 	textarea.requestEnsureCursorVisible()
 }
 
-func (textarea *TextArea) deleteSelection(skipEvent bool) bool {
+func (textarea *TextArea) wordBoundaryPos(pos textPos, dir int) textPos {
 	data := textarea.Data()
-	if data.selectStart == data.selectEnd {
-		return false
+	line := data.doc.line(pos.line)
+	if dir < 0 {
+		if pos.col == 0 {
+			return data.doc.posBefore(pos)
+		}
+		return textPos{pos.line, editableTextWordBoundary(line, pos.col-1, -1)}
 	}
-	str, cursorOffset, deleted := editableTextDeleteRange(data.text,
-		data.selectStart, data.selectEnd)
-	if !deleted {
-		return false
+	if pos.col >= editableTextRuneCount(line) {
+		return data.doc.posAfter(pos)
 	}
-	textarea.setText(str, skipEvent)
-	data.cursorOffset = cursorOffset
-	data.selectAnchor = cursorOffset
-	data.hasPreferredCursorX = false
-	textarea.resetSelect()
-	textarea.requestEnsureCursorVisible()
-	return true
+	return textPos{pos.line, editableTextWordBoundary(line, pos.col+1, 1)}
 }
 
-func (textarea *TextArea) InsertText(text string) {
+func (textarea *TextArea) moveHorizontal(kb *hid.Keyboard, dir int) {
 	data := textarea.Data()
-	str, cursorOffset, changed := textareaInsertTextAt(data.text,
-		data.cursorOffset, data.selectStart, data.selectEnd, text)
-	if !changed {
+	pos := data.doc.cursorPos()
+	var newPos textPos
+	if kb.HasMeta() {
+		if dir < 0 {
+			newPos = textPos{pos.line, 0}
+		} else {
+			newPos = textPos{pos.line, editableTextRuneCount(data.doc.line(pos.line))}
+		}
+	} else if kb.HasCtrl() || kb.HasAlt() {
+		newPos = textarea.wordBoundaryPos(pos, dir)
+	} else if dir < 0 {
+		newPos = data.doc.posBefore(pos)
+	} else {
+		newPos = data.doc.posAfter(pos)
+	}
+	textarea.moveCursorTo(newPos, kb.HasShift(), false)
+}
+
+func (textarea *TextArea) moveVertical(kb *hid.Keyboard, dir int) {
+	data := textarea.Data()
+	if kb.HasCtrl() || kb.HasMeta() {
+		if dir < 0 {
+			textarea.moveCursorTo(textPos{0, 0}, kb.HasShift(), false)
+		} else {
+			last := data.doc.lineCount() - 1
+			textarea.moveCursorTo(textPos{last, editableTextRuneCount(data.doc.line(last))}, kb.HasShift(), false)
+		}
 		return
 	}
-	textarea.setText(str, false)
-	data.cursorOffset = cursorOffset
-	data.selectAnchor = cursorOffset
+	pos := data.doc.cursorPos()
+	if !data.hasPreferredCursorX {
+		data.preferredCursorX = textarea.caretPixel(pos).x
+		data.hasPreferredCursorX = true
+	}
+	target := editableTextClamp(pos.line+dir, 0, data.doc.lineCount()-1)
+	if target == pos.line {
+		// Already at first/last line: jump to start/end of the line.
+		if dir < 0 {
+			textarea.moveCursorTo(textPos{pos.line, 0}, kb.HasShift(), false)
+		} else {
+			textarea.moveCursorTo(textPos{pos.line, editableTextRuneCount(data.doc.line(pos.line))}, kb.HasShift(), false)
+		}
+		return
+	}
+	col := textarea.colAtX(target, data.preferredCursorX)
+	textarea.moveCursorTo(textPos{target, col}, kb.HasShift(), true)
+}
+
+func (textarea *TextArea) moveLineBoundary(kb *hid.Keyboard, end bool) {
+	data := textarea.Data()
+	pos := data.doc.cursorPos()
+	var newPos textPos
+	if kb.HasCtrl() || kb.HasMeta() {
+		if end {
+			last := data.doc.lineCount() - 1
+			newPos = textPos{last, editableTextRuneCount(data.doc.line(last))}
+		} else {
+			newPos = textPos{0, 0}
+		}
+	} else if end {
+		newPos = textPos{pos.line, editableTextRuneCount(data.doc.line(pos.line))}
+	} else {
+		newPos = textPos{pos.line, 0}
+	}
+	textarea.moveCursorTo(newPos, kb.HasShift(), false)
+}
+
+// --- editing -----------------------------------------------------------------
+
+func (textarea *TextArea) afterEdit(skipEvent bool) {
+	data := textarea.Data()
+	wasValid := textarea.IsValid()
+	if !data.wrap {
+		data.maxLineWidth = 0
+		data.list.SetContentWidth(0)
+	}
+	data.list.ReloadData()
+	textarea.updatePlaceholderVisibility()
 	data.hasPreferredCursorX = false
-	textarea.resetSelect()
+	if !skipEvent {
+		textarea.change()
+	}
+	if wasValid != textarea.IsValid() {
+		textarea.Base().SetDirty(DirtyTypeGenerated)
+	}
 	textarea.showCursor()
 	textarea.requestEnsureCursorVisible()
 }
 
+func (textarea *TextArea) InsertText(text string) {
+	if textarea.IsReadOnly() {
+		return
+	}
+	if textarea.Data().doc.insert(text) {
+		textarea.afterEdit(false)
+	}
+}
+
+func (textarea *TextArea) backspace(kb *hid.Keyboard) {
+	if textarea.IsReadOnly() {
+		return
+	}
+	data := textarea.Data()
+	if data.doc.hasSelection() {
+		data.doc.deleteSelection()
+	} else if kb.HasMeta() {
+		pos := data.doc.cursorPos()
+		data.doc.deleteRange(textPos{pos.line, 0}, pos)
+	} else if kb.HasCtrl() || kb.HasAlt() {
+		pos := data.doc.cursorPos()
+		data.doc.deleteRange(textarea.wordBoundaryPos(pos, -1), pos)
+	} else if !data.doc.backspace() {
+		return
+	}
+	textarea.afterEdit(false)
+}
+
+func (textarea *TextArea) delete(kb *hid.Keyboard) {
+	if textarea.IsReadOnly() {
+		return
+	}
+	data := textarea.Data()
+	if data.doc.hasSelection() {
+		data.doc.deleteSelection()
+	} else if kb.HasMeta() {
+		pos := data.doc.cursorPos()
+		data.doc.deleteRange(pos, textPos{pos.line, editableTextRuneCount(data.doc.line(pos.line))})
+	} else if kb.HasCtrl() || kb.HasAlt() {
+		pos := data.doc.cursorPos()
+		data.doc.deleteRange(pos, textarea.wordBoundaryPos(pos, 1))
+	} else if !data.doc.deleteForward() {
+		return
+	}
+	textarea.afterEdit(false)
+}
+
+func (textarea *TextArea) Undo() {
+	if textarea.IsReadOnly() {
+		return
+	}
+	if textarea.Data().doc.undo() {
+		textarea.afterEdit(false)
+	}
+}
+
+func (textarea *TextArea) Redo() {
+	if textarea.IsReadOnly() {
+		return
+	}
+	if textarea.Data().doc.redoLast() {
+		textarea.afterEdit(false)
+	}
+}
+
+// --- text get/set ------------------------------------------------------------
+
+func (textarea *TextArea) Text() string { return textarea.Data().doc.text() }
+
+// LineCount is the number of logical lines in the document.
+func (textarea *TextArea) LineCount() int { return textarea.Data().doc.lineCount() }
+
+// Line returns the text of logical line i (without its newline).
+func (textarea *TextArea) Line(i int) string { return textarea.Data().doc.line(i) }
+
+// SelectedText returns the currently selected text (empty if no selection).
+func (textarea *TextArea) SelectedText() string { return textarea.Data().doc.selectedText() }
+
 func (textarea *TextArea) setText(text string, skipEvent bool) {
 	data := textarea.Data()
 	wasValid := textarea.IsValid()
-	data.text = text
-	data.label.SetText(text)
-	data.cursorOffset = editableTextClampOffset(data.text, data.cursorOffset)
-	data.selectAnchor = data.cursorOffset
-	data.hasPreferredCursorX = false
-	data.selectStart = 0
-	data.selectEnd = 0
+	data.doc.setText(text)
+	clear(data.lineSpans)
+	data.maxLineWidth = 0
+	if !data.wrap {
+		data.list.SetContentWidth(0)
+	}
+	data.list.ReloadData()
 	textarea.updatePlaceholderVisibility()
 	textarea.hideSelection()
 	if !skipEvent {
@@ -755,6 +1162,17 @@ func (textarea *TextArea) setText(text string, skipEvent bool) {
 		textarea.Base().SetDirty(DirtyTypeGenerated)
 	}
 }
+
+func (textarea *TextArea) SetText(text string)             { textarea.setText(text, false) }
+func (textarea *TextArea) SetTextWithoutEvent(text string) { textarea.setText(text, true) }
+
+func (textarea *TextArea) SetPlaceholder(text string) {
+	data := textarea.Data()
+	data.placeholder.SetText(text)
+	textarea.updatePlaceholderVisibility()
+}
+
+// --- events ------------------------------------------------------------------
 
 func (textarea *TextArea) focus()  { textarea.Base().requestEvent(EventTypeFocus) }
 func (textarea *TextArea) blur()   { textarea.Base().requestEvent(EventTypeBlur) }
@@ -777,11 +1195,13 @@ func (textarea *TextArea) onDown() {
 		return
 	}
 	textarea.Focus()
-	textarea.resetSelect()
-	offset := textarea.pointerPosWithin()
-	textarea.SetCursorOffset(offset)
-	textarea.Data().selectAnchor = offset
+	pos := textarea.pointerPosWithin()
+	data := textarea.Data()
+	data.doc.setCursor(pos)
+	data.dragAnchor = pos
+	data.hasPreferredCursorX = false
 	textarea.showCursor()
+	textarea.requestEnsureCursorVisible()
 }
 
 func (textarea *TextArea) onDoubleClick() {
@@ -792,58 +1212,13 @@ func (textarea *TextArea) onDoubleClick() {
 	textarea.SelectAll()
 }
 
-func (textarea *TextArea) onMiss() {
-	textarea.RemoveFocus()
-}
+func (textarea *TextArea) onMiss()    { textarea.RemoveFocus() }
+func (textarea *TextArea) onRebuild() { textarea.forceLabelAndPlaceholderRerender() }
 
-func (textarea *TextArea) onRebuild() {
-	textarea.forceLabelAndPlaceholderRerender()
-	textarea.updateSelectionPanels()
-	textarea.updateCursorPosition()
-}
+func (textarea *TextArea) deactivated() { textarea.RemoveFocus() }
+func (textarea *TextArea) activated()   { textarea.updatePlaceholderVisibility() }
 
-func (textarea *TextArea) deactivated() {
-	textarea.RemoveFocus()
-}
-
-func (textarea *TextArea) activated() {
-	textarea.updatePlaceholderVisibility()
-}
-
-func (textarea *TextArea) Text() string {
-	return textarea.Data().text
-}
-
-func (textarea *TextArea) SetText(text string) {
-	textarea.setText(text, false)
-}
-
-func (textarea *TextArea) SetTextWithoutEvent(text string) {
-	textarea.setText(text, true)
-}
-
-func (textarea *TextArea) SetPlaceholder(text string) {
-	data := textarea.Data()
-	data.placeholder.SetText(text)
-	textarea.updatePlaceholderVisibility()
-}
-
-func (textarea *TextArea) IsRequired() bool {
-	return textarea.Data().required
-}
-
-func (textarea *TextArea) SetRequired(required bool) {
-	data := textarea.Data()
-	if data.required == required {
-		return
-	}
-	data.required = required
-	textarea.Base().SetDirty(DirtyTypeGenerated)
-}
-
-func (textarea *TextArea) IsValid() bool {
-	return !textarea.IsRequired() || textarea.Text() != ""
-}
+// --- focus -------------------------------------------------------------------
 
 func (textarea *TextArea) Focus() {
 	if textarea.IsDisabled() {
@@ -855,7 +1230,7 @@ func (textarea *TextArea) Focus() {
 	}
 	data.isActive = true
 	textarea.resetSelect()
-	data.textOnFocus = data.text
+	data.textOnFocus = textarea.Text()
 	textarea.showCursor()
 	man := textarea.man.Value()
 	if man != nil {
@@ -863,6 +1238,8 @@ func (textarea *TextArea) Focus() {
 	}
 	textarea.focus()
 }
+
+func (textarea *TextArea) resetSelect() { textarea.Data().doc.clearSelection() }
 
 func (textarea *TextArea) removeFocusWithoutEvents() {
 	data := textarea.Data()
@@ -932,224 +1309,287 @@ func (textarea *TextArea) focusPrevious() {
 	}
 }
 
+// --- selection / clipboard ---------------------------------------------------
+
 func (textarea *TextArea) SelectAll() {
-	data := textarea.Data()
-	data.selectAnchor = 0
-	textarea.setSelect(0, editableTextRuneCount(data.text))
-	data.cursorOffset = editableTextRuneCount(data.text)
+	textarea.Data().doc.selectAll()
 	textarea.requestEnsureCursorVisible()
 }
 
 func (textarea *TextArea) copyToClipboard() {
 	data := textarea.Data()
-	if data.selectStart != data.selectEnd {
-		str := textareaSelectedText(data.text, data.selectStart, data.selectEnd)
-		textarea.Base().Host().Window.CopyToClipboard(str)
+	if data.doc.hasSelection() {
+		textarea.Base().Host().Window.CopyToClipboard(data.doc.selectedText())
 	}
 }
 
 func (textarea *TextArea) cutToClipboard() {
+	if textarea.IsReadOnly() {
+		textarea.copyToClipboard()
+		return
+	}
 	textarea.copyToClipboard()
-	textarea.deleteSelection(false)
+	if textarea.Data().doc.deleteSelection() {
+		textarea.afterEdit(false)
+	}
 }
 
 func (textarea *TextArea) pasteFromClipboard() {
-	text := textarea.man.Value().Host.Window.ClipboardContents()
-	textarea.InsertText(text)
-}
-
-func (textarea *TextArea) lineHeight() float32 {
-	return textareaLineHeight(textarea.Data().label.LabelData())
-}
-
-func (textarea *TextArea) movementRects() ([]matrix.Vec4, float32) {
-	return textarea.runeRects(), textarea.lineHeight()
-}
-
-func (textarea *TextArea) moveHorizontal(kb *hid.Keyboard, dir int) {
-	data := textarea.Data()
-	newPos := data.cursorOffset + dir
-	if kb.HasMeta() {
-		rects, height := textarea.movementRects()
-		if dir < 0 {
-			newPos = textareaLineStartOffset(data.text, rects, data.cursorOffset, height)
-		} else {
-			newPos = textareaLineEndOffset(data.text, rects, data.cursorOffset, height)
-		}
-	} else if kb.HasCtrl() || kb.HasAlt() {
-		newPos = editableTextWordBoundary(data.text, newPos, dir)
-	}
-	textarea.moveCursor(newPos, kb.HasShift(), false)
-}
-
-func (textarea *TextArea) moveVertical(kb *hid.Keyboard, dir int) {
-	data := textarea.Data()
-	count := editableTextRuneCount(data.text)
-	if kb.HasCtrl() || kb.HasMeta() {
-		if dir < 0 {
-			textarea.moveCursor(0, kb.HasShift(), false)
-		} else {
-			textarea.moveCursor(count, kb.HasShift(), false)
-		}
+	if textarea.IsReadOnly() {
 		return
 	}
-	rects, height := textarea.movementRects()
-	if !data.hasPreferredCursorX {
-		data.preferredCursorX = textareaCaretFromRuneRects(data.text, rects,
-			data.cursorOffset, height).x
-		data.hasPreferredCursorX = true
-	}
-	newPos := textareaMoveVerticalOffset(data.text, rects, data.cursorOffset,
-		dir, data.preferredCursorX, height)
-	textarea.moveCursor(newPos, kb.HasShift(), true)
+	textarea.InsertText(textarea.man.Value().Host.Window.ClipboardContents())
 }
 
-func (textarea *TextArea) moveLineBoundary(kb *hid.Keyboard, end bool) {
+// --- validation / disabled / readonly ---------------------------------------
+
+func (textarea *TextArea) IsRequired() bool { return textarea.Data().required }
+
+func (textarea *TextArea) SetRequired(required bool) {
 	data := textarea.Data()
-	count := editableTextRuneCount(data.text)
-	newPos := 0
-	if kb.HasCtrl() || kb.HasMeta() {
-		if end {
-			newPos = count
-		}
-	} else {
-		rects, height := textarea.movementRects()
-		if end {
-			newPos = textareaLineEndOffset(data.text, rects, data.cursorOffset, height)
-		} else {
-			newPos = textareaLineStartOffset(data.text, rects, data.cursorOffset, height)
-		}
+	if data.required == required {
+		return
 	}
-	textarea.moveCursor(newPos, kb.HasShift(), false)
+	data.required = required
+	textarea.Base().SetDirty(DirtyTypeGenerated)
 }
 
-func (textarea *TextArea) backspace(kb *hid.Keyboard) {
+func (textarea *TextArea) IsValid() bool {
+	return !textarea.IsRequired() || textarea.Text() != ""
+}
+
+func (textarea *TextArea) IsFocused() bool  { return textarea.Data().isActive }
+func (textarea *TextArea) IsDisabled() bool { return textarea.Base().IsDisabled() }
+
+func (textarea *TextArea) SetDisabled(disabled bool) { textarea.Base().SetDisabled(disabled) }
+
+func (textarea *TextArea) IsReadOnly() bool { return textarea.Data().readOnly }
+
+func (textarea *TextArea) SetReadOnly(readOnly bool) {
+	textarea.Data().readOnly = readOnly
+}
+
+// --- cursor offset (compat + line,col) ---------------------------------------
+
+func (textarea *TextArea) SetCursorOffset(offset int) {
 	data := textarea.Data()
-	if data.selectStart != data.selectEnd {
-		textarea.deleteSelection(false)
-	} else if kb.HasMeta() {
-		textarea.setSelect(0, data.cursorOffset)
-		textarea.deleteSelection(false)
-	} else if kb.HasCtrl() || kb.HasAlt() {
-		from := editableTextWordBoundary(data.text, data.cursorOffset-1, -1)
-		textarea.setSelect(from, data.cursorOffset)
-		textarea.deleteSelection(false)
-	} else {
-		str, cursorOffset, changed := textareaBackspaceText(data.text,
-			data.cursorOffset, data.selectStart, data.selectEnd)
-		if changed {
-			textarea.setText(str, false)
-			data.cursorOffset = cursorOffset
-			data.selectAnchor = cursorOffset
-			textarea.requestEnsureCursorVisible()
-		}
-	}
+	data.doc.setCursor(data.doc.offsetToPos(offset))
 	data.hasPreferredCursorX = false
+	textarea.requestEnsureCursorVisible()
 }
 
-func (textarea *TextArea) delete(kb *hid.Keyboard) {
+func (textarea *TextArea) CursorPosition() (line, col int) {
+	p := textarea.Data().doc.cursorPos()
+	return p.line, p.col
+}
+
+func (textarea *TextArea) SetCursorLineColumn(line, col int) {
 	data := textarea.Data()
-	if data.selectStart != data.selectEnd {
-		textarea.deleteSelection(false)
-	} else if kb.HasMeta() {
-		textarea.setSelect(data.cursorOffset, editableTextRuneCount(data.text))
-		textarea.deleteSelection(false)
-	} else if kb.HasCtrl() || kb.HasAlt() {
-		to := editableTextWordBoundary(data.text, data.cursorOffset+1, 1)
-		textarea.setSelect(data.cursorOffset, to)
-		textarea.deleteSelection(false)
-	} else {
-		str, cursorOffset, changed := textareaDeleteText(data.text,
-			data.cursorOffset, data.selectStart, data.selectEnd)
-		if changed {
-			textarea.setText(str, false)
-			data.cursorOffset = cursorOffset
-			data.selectAnchor = cursorOffset
-			textarea.requestEnsureCursorVisible()
-		}
-	}
+	data.doc.setCursor(textPos{line, col})
 	data.hasPreferredCursorX = false
+	textarea.requestEnsureCursorVisible()
 }
 
-// ApplyColorRange colors a [start,end) rune range of the text area's content in
-// place (no glyph re-mesh), the same mechanism Label uses. SetText clears color ranges, 
-// so re-apply after the text changes.
+func (textarea *TextArea) ScrollToLine(line int, align VirtualAlign) {
+	textarea.Data().list.ScrollToIndex(line, align)
+}
+
+// --- color spans / markers ---------------------------------------------------
+
+// ApplyColorRange colors a [start,end) rune range using flat (whole-document)
+// rune offsets, for backward compatibility with the old single-string API. It
+// maps the flat range onto the affected lines.
 func (textarea *TextArea) ApplyColorRange(start, end int, fg, bg matrix.Color) {
-	textarea.Data().label.ColorRange(start, end, fg, bg)
+	data := textarea.Data()
+	if start > end {
+		start, end = end, start
+	}
+	s := data.doc.offsetToPos(start)
+	e := data.doc.offsetToPos(end)
+	for line := s.line; line <= e.line && line < data.doc.lineCount(); line++ {
+		lineLen := editableTextRuneCount(data.doc.line(line))
+		c0 := 0
+		if line == s.line {
+			c0 = s.col
+		}
+		c1 := lineLen
+		if line == e.line {
+			c1 = e.col
+		}
+		if c1 <= c0 {
+			continue
+		}
+		data.lineSpans[line] = append(data.lineSpans[line], TextColorSpan{Start: c0, End: c1, FG: fg, BG: bg})
+	}
+	data.list.RefreshVisible()
 }
 
-// ClearColorRanges removes all applied color ranges.
-func (textarea *TextArea) ClearColorRanges() {
-	textarea.Data().label.ClearColorRanges()
+// SetLineColorSpans replaces the color spans for a single line (rune columns
+// within the line). This is the per-line API the widget layer's virtualized
+// highlighter uses.
+func (textarea *TextArea) SetLineColorSpans(line int, spans []TextColorSpan) {
+	data := textarea.Data()
+	if len(spans) == 0 {
+		delete(data.lineSpans, line)
+	} else {
+		data.lineSpans[line] = spans
+	}
+	data.list.RefreshVisible()
 }
+
+func (textarea *TextArea) ClearLineColorSpans(line int) {
+	delete(textarea.Data().lineSpans, line)
+	textarea.Data().list.RefreshVisible()
+}
+
+// SetLineSpansBulk replaces ALL per-line color spans in one shot (one refresh).
+// The map is keyed by line index; values are per-line rune-column spans. This is
+// the entry point the widget-layer virtualized highlighter uses so it can push a
+// freshly tokenized document without O(visible^2) per-line refreshes.
+func (textarea *TextArea) SetLineSpansBulk(spans map[int][]TextColorSpan) {
+	data := textarea.Data()
+	data.lineSpans = spans
+	if data.lineSpans == nil {
+		data.lineSpans = map[int][]TextColorSpan{}
+	}
+	data.list.RefreshVisible()
+}
+
+func (textarea *TextArea) ClearColorRanges() {
+	data := textarea.Data()
+	clear(data.lineSpans)
+	data.list.RefreshVisible()
+}
+
+func (textarea *TextArea) SetHighlightCurrentLine(enabled bool, color matrix.Color) {
+	data := textarea.Data()
+	data.highlightCurrentLine = enabled
+	data.currentLineColor = color
+	textarea.updateCurrentLine()
+}
+
+func (textarea *TextArea) SetOnVisibleRangeChanged(fn func(first, last int)) {
+	textarea.Data().onVisibleRangeChanged = fn
+}
+
+// SetOnScroll registers an observer fired whenever the vertical scroll position
+// changes. The widget layer uses it to keep a companion gutter in lockstep.
+func (textarea *TextArea) SetOnScroll(fn func()) { textarea.Data().onScroll = fn }
+
+// ScrollY is the current vertical scroll offset (pixels from the top).
+func (textarea *TextArea) ScrollY() float32 { return (*Panel)(textarea.Data().list).ScrollY() }
+
+// SetScrollY sets the vertical scroll offset (clamped to the content).
+func (textarea *TextArea) SetScrollY(y float32) { (*Panel)(textarea.Data().list).SetScrollY(y) }
+
+// MaxScrollY is the maximum vertical scroll offset.
+func (textarea *TextArea) MaxScrollY() float32 {
+	return (*Panel)(textarea.Data().list).MaxScroll().Y()
+}
+
+// ViewportHeight is the visible height of the scrolling text area (excluding the
+// internal padding), i.e. how much of the document is on screen at once.
+func (textarea *TextArea) ViewportHeight() float32 {
+	return textarea.Data().list.ViewportHeight()
+}
+
+// SetScrollbarsVisible toggles the built-in scroll bars. A code editor that
+// paints its own scroll/marker track hides these and drives scrolling through
+// SetScrollY instead.
+func (textarea *TextArea) SetScrollbarsVisible(visible bool) {
+	(*Panel)(textarea.Data().list).SetScrollbarsVisible(visible)
+}
+
+// LineHeight is the rendered height of a single line (the fixed row height in
+// no-wrap mode), which a companion gutter should match.
+func (textarea *TextArea) LineHeight() float32 { return textarea.singleLineHeight() }
+
+// VisibleLineRange returns the first and last line indices currently realized.
+func (textarea *TextArea) VisibleLineRange() (first, last int) {
+	return textarea.Data().list.VisibleRange()
+}
+
+// --- font / color setters ----------------------------------------------------
 
 func (textarea *TextArea) SetFontFace(face rendering.FontFace) {
 	data := textarea.Data()
-	data.label.SetFontFace(face)
+	data.fontFace = face
 	data.placeholder.SetFontFace(face)
-	textarea.updateSelectionPanels()
+	textarea.refreshRowStyle()
 }
 
 func (textarea *TextArea) SetFontWeight(weight string) {
 	data := textarea.Data()
-	data.label.SetFontWeight(weight)
+	data.fontWeight = weight
 	data.placeholder.SetFontWeight(weight)
-	textarea.updateSelectionPanels()
+	textarea.refreshRowStyle()
 }
 
 func (textarea *TextArea) SetFontStyle(style string) {
 	data := textarea.Data()
-	data.label.SetFontStyle(style)
+	data.fontStyle = style
 	data.placeholder.SetFontStyle(style)
-	textarea.updateSelectionPanels()
+	textarea.refreshRowStyle()
 }
 
 func (textarea *TextArea) SetFontSize(fontSize float32) {
 	data := textarea.Data()
-	data.label.SetFontSize(fontSize)
+	data.fontSize = fontSize
 	data.placeholder.SetFontSize(fontSize)
-	textarea.updateSelectionPanels()
-	textarea.updateCursorPosition()
+	textarea.applyHeightMode()
+	textarea.refreshRowStyle()
 }
 
-func (textarea *TextArea) FontSize() float32 {
-	return textarea.Data().label.FontSize()
-}
-
-func (textarea *TextArea) FontFace() rendering.FontFace {
-	return textarea.Data().label.FontFace()
-}
+func (textarea *TextArea) FontSize() float32            { return textarea.Data().effectiveFontSize() }
+func (textarea *TextArea) FontFace() rendering.FontFace { return textarea.Data().fontFace }
 
 func (textarea *TextArea) SetLineHeight(lineHeight float32) {
 	data := textarea.Data()
-	data.label.SetLineHeight(lineHeight)
+	data.lineHeight = lineHeight
 	data.placeholder.SetLineHeight(lineHeight)
-	textarea.updateSelectionPanels()
-	textarea.updateCursorPosition()
+	textarea.applyHeightMode()
+	textarea.refreshRowStyle()
+}
+
+func (textarea *TextArea) SetLetterSpacing(spacing float32) {
+	textarea.Data().letterSpacing = spacing
+	textarea.refreshRowStyle()
 }
 
 func (textarea *TextArea) SetWrap(wrap bool) {
 	data := textarea.Data()
-	data.label.SetWrap(wrap)
+	if data.wrap == wrap {
+		return
+	}
+	data.wrap = wrap
 	data.placeholder.SetWrap(wrap)
-	textarea.updateSelectionPanels()
+	textarea.applyHeightMode()
+	data.list.ReloadData()
+	textarea.updateCursorPosition()
+}
+
+func (textarea *TextArea) refreshRowStyle() {
+	data := textarea.Data()
+	data.list.ReloadData()
 	textarea.updateCursorPosition()
 }
 
 func (textarea *TextArea) SetFGColor(newColor matrix.Color) {
 	data := textarea.Data()
-	data.label.SetColor(newColor)
+	data.fgColor = newColor
 	data.cursor.SetColor(newColor)
 	data.placeholder.SetColor(matrix.ColorMix(newColor, newColor.Inverted(), 0.5))
+	data.list.RefreshVisible()
 }
 
 func (textarea *TextArea) SetBGColor(newColor matrix.Color) {
 	data := textarea.Data()
+	data.bgColor = newColor
 	(*Panel)(textarea).SetColor(newColor)
-	data.label.SetBGColor(newColor)
 	data.placeholder.SetBGColor(newColor)
 	useBlending := newColor.A() <= (1.0 - math.SmallestNonzeroFloat32)
 	(*Panel)(textarea).SetUseBlending(useBlending)
+	data.list.RefreshVisible()
 }
 
 func (textarea *TextArea) SetCursorColor(newColor matrix.Color) {
@@ -1164,25 +1604,7 @@ func (textarea *TextArea) SetSelectColor(newColor matrix.Color) {
 	}
 }
 
-func (textarea *TextArea) IsFocused() bool {
-	return textarea.Data().isActive
-}
-
-func (textarea *TextArea) IsDisabled() bool {
-	return textarea.Base().IsDisabled()
-}
-
-func (textarea *TextArea) SetDisabled(disabled bool) {
-	textarea.Base().SetDisabled(disabled)
-}
-
-func (textarea *TextArea) SetCursorOffset(offset int) {
-	data := textarea.Data()
-	data.cursorOffset = editableTextClampOffset(data.text, offset)
-	data.selectAnchor = data.cursorOffset
-	data.hasPreferredCursorX = false
-	textarea.requestEnsureCursorVisible()
-}
+// --- keyboard ----------------------------------------------------------------
 
 func (textarea *TextArea) keyPressed(keyId int, keyState hid.KeyState) {
 	if textarea.IsDisabled() {
@@ -1219,6 +1641,14 @@ func (textarea *TextArea) keyPressed(keyId int, keyState hid.KeyState) {
 					textarea.pasteFromClipboard()
 				case 'a':
 					textarea.SelectAll()
+				case 'z':
+					if kb.HasShift() {
+						textarea.Redo()
+					} else {
+						textarea.Undo()
+					}
+				case 'y':
+					textarea.Redo()
 				}
 			}
 			if textarea.events[EventTypeKeyDown].IsEmpty() {
@@ -1260,41 +1690,40 @@ func (textarea *TextArea) keyPressed(keyId int, keyState hid.KeyState) {
 	case hid.KeyStateHeld:
 		switch keyId {
 		case hid.KeyboardKeyBackspace:
-			prev := kb.GetKeyLastClicked(keyId)
-			if time.Since(prev).Milliseconds() > holdKeyPressedDuration {
+			if textarea.heldLongEnough(kb, keyId) {
 				textarea.backspace(kb)
 			}
 		case hid.KeyboardKeyDelete:
-			prev := kb.GetKeyLastClicked(keyId)
-			if time.Since(prev).Milliseconds() > holdKeyPressedDuration {
+			if textarea.heldLongEnough(kb, keyId) {
 				textarea.delete(kb)
 			}
 		case hid.KeyboardKeyLeft:
-			prev := kb.GetKeyLastClicked(keyId)
-			if time.Since(prev).Milliseconds() > holdKeyPressedDuration {
+			if textarea.heldLongEnough(kb, keyId) {
 				textarea.moveHorizontal(kb, -1)
 			}
 		case hid.KeyboardKeyRight:
-			prev := kb.GetKeyLastClicked(keyId)
-			if time.Since(prev).Milliseconds() > holdKeyPressedDuration {
+			if textarea.heldLongEnough(kb, keyId) {
 				textarea.moveHorizontal(kb, 1)
 			}
 		case hid.KeyboardKeyUp:
-			prev := kb.GetKeyLastClicked(keyId)
-			if time.Since(prev).Milliseconds() > holdKeyPressedDuration {
+			if textarea.heldLongEnough(kb, keyId) {
 				textarea.moveVertical(kb, -1)
 			}
 		case hid.KeyboardKeyDown:
-			prev := kb.GetKeyLastClicked(keyId)
-			if time.Since(prev).Milliseconds() > holdKeyPressedDuration {
+			if textarea.heldLongEnough(kb, keyId) {
 				textarea.moveVertical(kb, 1)
 			}
 		}
 	}
 }
 
+func (textarea *TextArea) heldLongEnough(kb *hid.Keyboard, keyId int) bool {
+	prev := kb.GetKeyLastClicked(keyId)
+	return time.Since(prev).Milliseconds() > holdKeyPressedDuration
+}
+
 func (textarea *TextArea) forceLabelAndPlaceholderRerender() {
 	data := textarea.Data()
-	data.label.LabelData().renderRequired = true
 	data.placeholder.LabelData().renderRequired = true
+	data.list.RefreshVisible()
 }

--- a/src/engine/ui/ui.go
+++ b/src/engine/ui/ui.go
@@ -124,6 +124,7 @@ const (
 	ElementTypeSelect
 	ElementTypeSlider
 	ElementTypeTextArea
+	ElementTypeVirtualList
 )
 
 const (
@@ -879,6 +880,8 @@ func (ui *UI) updateFromManager(deltaTime float64) {
 		ui.ToInput().update(deltaTime)
 	case ElementTypeTextArea:
 		ui.ToTextArea().update(deltaTime)
+	case ElementTypeVirtualList:
+		ui.ToVirtualList().update(deltaTime)
 	case ElementTypeLabel:
 		ui.Update(deltaTime)
 	case ElementTypePanel:

--- a/src/engine/ui/virtual_list.go
+++ b/src/engine/ui/virtual_list.go
@@ -1,0 +1,521 @@
+/******************************************************************************/
+/* virtual_list.go                                                            */
+/******************************************************************************/
+/* MIT License, Copyright (c) 2015-present Brent Farris, (John 4:13-14)       */
+/******************************************************************************/
+
+package ui
+
+import (
+	"kaijuengine.com/platform/profiler/tracing"
+)
+
+// VirtualList is a vertically-scrolling list that only materializes the rows
+// currently in view, recycling a small pool of row elements as the user
+// scrolls. That is what lets a list of 100k rows cost the same to render as a
+// list of 30: at any moment only a viewport-worth of row elements are active.
+//
+// It is content-agnostic and not generic: the owner supplies a
+// VirtualListDelegate that knows the row count and how to create/bind/unbind a
+// row element by index, and supplies row heights either as a single fixed value
+// (SetFixedRowHeight, the O(1) no-wrap path) or per-row (SetRowHeightFunc, the
+// variable/wrapped path). The rewritten TextArea is the first consumer (one row
+// per text line); Select's option list is a natural follow-up.
+//
+// All access is on the main thread, in the layout/update loop — no locks.
+type VirtualList Panel
+
+// VirtualAlign selects how ScrollToIndex positions a row within the viewport.
+type VirtualAlign = int
+
+const (
+	// VirtualAlignStart aligns the row's top with the viewport top.
+	VirtualAlignStart VirtualAlign = iota
+	// VirtualAlignCenter centers the row vertically in the viewport.
+	VirtualAlignCenter
+	// VirtualAlignEnd aligns the row's bottom with the viewport bottom.
+	VirtualAlignEnd
+	// VirtualAlignNearest scrolls the minimum amount to make the row visible.
+	VirtualAlignNearest
+)
+
+// VirtualListDelegate is the data source + row lifecycle for a VirtualList.
+// Implementations own the backing data and answer purely by index.
+type VirtualListDelegate interface {
+	// RowCount is the total number of rows in the backing data.
+	RowCount() int
+	// CreateRow builds a fresh, reusable row element. It is called only when
+	// the recycle pool is empty (at most a viewport-worth of times), and the
+	// returned element is reused across many data indices via BindRow.
+	CreateRow(man *Manager) *UI
+	// BindRow populates an existing row element for the given data index.
+	BindRow(index int, row *UI)
+	// UnbindRow is called before a row leaves the viewport and returns to the
+	// pool. Optional cleanup hook (clear text, hide children, etc.).
+	UnbindRow(index int, row *UI)
+}
+
+const virtualListDefaultEstimate float32 = 20
+
+// virtualListParkOffset is where recycled rows are moved (well above any content)
+// so they are scissor-clipped out of view while staying entity-active. We keep
+// pooled rows active rather than SetActive(false): deactivating a row turns off
+// its child glyph drawings, and reactivating + re-binding races the label render
+// (it can mesh-then-deactivate and consume the render flag), leaving a permanent
+// blank row. Parking sidesteps that entirely; the active pool stays bounded to a
+// viewport's worth, so virtualization performance is unchanged.
+const virtualListParkOffset float32 = -1_000_000
+
+// warmingRow is a pooled row that has been created but not yet shown. bornFrame
+// records the frame it was created on; it becomes usable once the list has
+// advanced past that frame (so it has been through a clean/render pass).
+type warmingRow struct {
+	row       *UI
+	bornFrame uint64
+}
+
+type virtualListData struct {
+	panelData
+	content        *Panel
+	delegate       VirtualListDelegate
+	model          virtualHeightModel
+	fixedModel     *fixedHeightModel
+	prefixModel    *prefixHeightModel
+	heightFn       func(index int) float32
+	overscan       int
+	minContentW    float32
+	active         map[int]*UI
+	free           []*UI
+	warming        []warmingRow
+	frame          uint64
+	needsFill      bool
+	lastWindowSize int
+
+	lastFirst     int
+	lastLast      int
+	lastScrollY   float32
+	lastViewportH float32
+	lastTotal     float32
+	haveLast      bool
+}
+
+func (d *virtualListData) innerPanelData() *panelData { return &d.panelData }
+
+func (u *UI) ToVirtualList() *VirtualList      { return (*VirtualList)(u) }
+func (vl *VirtualList) Base() *UI              { return (*UI)(vl) }
+func (vl *VirtualList) Data() *virtualListData { return vl.elmData.(*virtualListData) }
+
+func (vl *VirtualList) Init() {
+	data := &virtualListData{
+		active:     map[int]*UI{},
+		overscan:   4,
+		fixedModel: newFixedHeightModel(virtualListDefaultEstimate),
+		lastLast:   -1,
+	}
+	data.model = data.fixedModel
+	vl.elmData = data
+	p := vl.Base().ToPanel()
+	man := p.man.Value()
+	// No background texture: the list is transparent so the owning element's
+	// themed background shows through (a consumer that wants a panel background
+	// paints it on a container behind the list).
+	p.Init(nil, ElementTypeVirtualList)
+	p.DontFitContent()
+	p.SetOverflow(OverflowScroll)
+	p.SetScrollDirection(PanelScrollDirectionVertical)
+
+	data.content = man.Add().ToPanel()
+	data.content.Init(nil, ElementTypePanel)
+	data.content.DontFitContent()
+	data.content.AllowClickThrough()
+	p.AddChild(data.content.Base())
+}
+
+// Content returns the inner panel that holds the row elements. Consumers may
+// parent overlays (cursors, selection rects) to it so they scroll with the rows.
+func (vl *VirtualList) Content() *Panel { return vl.Data().content }
+
+// RowOffset is the y of the top of row index in content space.
+func (vl *VirtualList) RowOffset(index int) float32 { return vl.Data().model.offsetOf(index) }
+
+// RowHeight is the height of row index.
+func (vl *VirtualList) RowHeight(index int) float32 { return vl.Data().model.heightOf(index) }
+
+// TotalHeight is the full scrollable content height.
+func (vl *VirtualList) TotalHeight() float32 { return vl.Data().model.total() }
+
+// RowAt is the row index whose vertical span contains content-space y.
+func (vl *VirtualList) RowAt(y float32) int { return vl.Data().model.indexAt(y) }
+
+// ViewportHeight is the visible content height of the list.
+func (vl *VirtualList) ViewportHeight() float32 { return vl.viewportHeight() }
+
+// SetContentWidth sets a minimum content width; the content panel is sized to
+// max(viewportWidth, w). Used for horizontal scrolling of long, unwrapped rows.
+// Pass 0 to track the viewport width (no horizontal scroll).
+func (vl *VirtualList) SetContentWidth(w float32) {
+	data := vl.Data()
+	if data.minContentW == w {
+		return
+	}
+	data.minContentW = w
+	vl.invalidateWindow()
+	vl.Base().SetDirty(DirtyTypeLayout)
+}
+
+func (vl *VirtualList) SetDelegate(d VirtualListDelegate) {
+	vl.Data().delegate = d
+	vl.ReloadData()
+}
+
+func (vl *VirtualList) SetOverscan(rows int) {
+	if rows < 0 {
+		rows = 0
+	}
+	vl.Data().overscan = rows
+	vl.invalidateWindow()
+}
+
+// SetFixedRowHeight switches the list to fixed-height rows (every row is h tall).
+// This is the O(1) path used for code (no soft wrap, one line per row).
+func (vl *VirtualList) SetFixedRowHeight(h float32) {
+	data := vl.Data()
+	data.fixedModel.setRowHeight(h)
+	data.model = data.fixedModel
+	data.heightFn = nil
+	vl.invalidateWindow()
+	vl.Base().SetDirty(DirtyTypeLayout)
+}
+
+// SetRowHeightFunc switches the list to variable-height rows, measuring each
+// row's height via fn. Used for wrapped / chat content.
+func (vl *VirtualList) SetRowHeightFunc(fn func(index int) float32) {
+	data := vl.Data()
+	if data.prefixModel == nil {
+		data.prefixModel = newPrefixHeightModel(virtualListDefaultEstimate)
+	}
+	data.model = data.prefixModel
+	data.heightFn = fn
+	vl.remeasureAll()
+	vl.invalidateWindow()
+	vl.Base().SetDirty(DirtyTypeLayout)
+}
+
+// ReloadData re-reads the row count and rebinds the visible rows. Call after the
+// backing data changes (count or content).
+func (vl *VirtualList) ReloadData() {
+	data := vl.Data()
+	n := vl.rowCount()
+	data.model.setCount(n)
+	vl.remeasureAll()
+	vl.recycleAll()
+	vl.clampScroll()
+	vl.invalidateWindow()
+	vl.Base().SetDirty(DirtyTypeLayout)
+}
+
+// InvalidateRow re-measures a single row's height (variable mode) and reflows so
+// the rows below it shift to their new positions.
+func (vl *VirtualList) InvalidateRow(index int) {
+	data := vl.Data()
+	if data.heightFn != nil {
+		data.model.setHeight(index, data.heightFn(index))
+	}
+	vl.invalidateWindow()
+	vl.reflow(true)
+}
+
+// RefreshVisible re-binds the rows currently on screen without changing the
+// window (use when row content/styling changed but heights did not).
+func (vl *VirtualList) RefreshVisible() {
+	data := vl.Data()
+	if data.delegate == nil {
+		return
+	}
+	for idx, row := range data.active {
+		row.layout.SetOffset(0, data.model.offsetOf(idx))
+		data.delegate.BindRow(idx, row)
+	}
+}
+
+// VisibleRange returns the [first,last] data indices currently realized. If the
+// list is empty last < first.
+func (vl *VirtualList) VisibleRange() (first, last int) {
+	return vl.windowFor(vl.viewportHeight(), (*Panel)(vl).ScrollY())
+}
+
+// ScrollToIndex scrolls so row index is visible according to align.
+func (vl *VirtualList) ScrollToIndex(index int, align VirtualAlign) {
+	data := vl.Data()
+	n := vl.rowCount()
+	if n == 0 {
+		return
+	}
+	index = min(max(index, 0), n-1)
+	top := data.model.offsetOf(index)
+	h := data.model.heightOf(index)
+	vh := vl.viewportHeight()
+	target := top
+	switch align {
+	case VirtualAlignStart:
+		target = top
+	case VirtualAlignEnd:
+		target = top + h - vh
+	case VirtualAlignCenter:
+		target = top - (vh-h)*0.5
+	case VirtualAlignNearest:
+		scrollY := (*Panel)(vl).ScrollY()
+		if top < scrollY {
+			target = top
+		} else if top+h > scrollY+vh {
+			target = top + h - vh
+		} else {
+			return
+		}
+	}
+	(*Panel)(vl).SetScrollY(target)
+}
+
+func (vl *VirtualList) onLayoutUpdating() {
+	vl.reflow(false)
+}
+
+func (vl *VirtualList) update(deltaTime float64) {
+	defer tracing.NewRegion("VirtualList.update").End()
+	// NOTE: update() runs on a manager WORKER THREAD (updateFromManager), in
+	// parallel with other elements. It must NOT create rows (man.Add is not
+	// thread-safe) or render (the font cache is not concurrency-safe). All row
+	// creation/binding/rendering is driven from onLayoutUpdating (the single-
+	// threaded clean pass of this element's root). Here we only run the base
+	// panel update (scroll handling) and ensure a reflow happens next clean if
+	// the window is still being filled.
+	vl.Base().ToPanel().update(deltaTime)
+	if vl.Data().needsFill {
+		vl.Base().SetDirty(DirtyTypeLayout)
+	}
+}
+
+// --- internals ---------------------------------------------------------------
+
+func (vl *VirtualList) rowCount() int {
+	if d := vl.Data().delegate; d != nil {
+		return d.RowCount()
+	}
+	return 0
+}
+
+func (vl *VirtualList) viewportHeight() float32 {
+	return max(vl.layout.PixelSize().Y(), 0)
+}
+
+func (vl *VirtualList) invalidateWindow() { vl.Data().haveLast = false }
+
+func (vl *VirtualList) clampScroll() {
+	p := (*Panel)(vl)
+	p.SetScrollY(p.ScrollY())
+}
+
+// remeasureAll fills in every row height for the variable-height model up front.
+// For fixed-height this is a no-op. The huge-list requirement is the fixed path,
+// so paying O(n) here for the variable (chat) path is acceptable.
+func (vl *VirtualList) remeasureAll() {
+	data := vl.Data()
+	if data.model != data.prefixModel || data.heightFn == nil {
+		return
+	}
+	data.prefixModel.reset()
+	n := vl.rowCount()
+	for i := range n {
+		data.prefixModel.setHeight(i, data.heightFn(i))
+	}
+}
+
+func (vl *VirtualList) recycleAll() {
+	data := vl.Data()
+	for idx, row := range data.active {
+		if data.delegate != nil {
+			data.delegate.UnbindRow(idx, row)
+		}
+		row.layout.SetOffset(0, virtualListParkOffset)
+		data.free = append(data.free, row)
+		delete(data.active, idx)
+	}
+}
+
+// parkNewRow creates a new row element parked off-screen and queues it in the
+// "warming" list tagged with the current frame. A row created via man.Add()
+// during a frame is NOT in the manager's iteration list / clean tree for that
+// frame, so it is only laid out/rendered the FOLLOWING frame. Using one before
+// then renders it blank with no recovery, so a warming row is never handed to
+// bind until a later frame (see promoteWarm). Creation only happens in update()
+// (once per frame) so the frame tag is meaningful.
+func (vl *VirtualList) parkNewRow() {
+	data := vl.Data()
+	row := data.delegate.CreateRow(vl.man.Value())
+	row.entity.SetActive(true)
+	data.content.AddChild(row)
+	row.layout.SetPositioning(PositioningAbsolute)
+	row.layout.SetOffset(0, virtualListParkOffset)
+	data.warming = append(data.warming, warmingRow{row: row, bornFrame: data.frame})
+}
+
+// promoteWarm moves rows that have been parked for at least one full frame from
+// the warming queue into the usable free pool (they have now been through a
+// clean/render pass and are safe to show). Called once per frame in update().
+func (vl *VirtualList) promoteWarm() {
+	data := vl.Data()
+	if len(data.warming) == 0 {
+		return
+	}
+	kept := data.warming[:0]
+	for _, w := range data.warming {
+		if w.bornFrame < data.frame {
+			data.free = append(data.free, w.row)
+		} else {
+			kept = append(kept, w)
+		}
+	}
+	data.warming = kept
+}
+
+// replenishPool grows the total pool (active + free + warming) up to target by
+// creating parked rows. New rows go into the warming queue, never directly into
+// free, so they are never shown the same frame they are created.
+func (vl *VirtualList) replenishPool(target int) {
+	data := vl.Data()
+	for len(data.active)+len(data.free)+len(data.warming) < target {
+		vl.parkNewRow()
+	}
+}
+
+// windowFor computes the visible [first,last] index range for a viewport height
+// and scroll offset, expanded by overscan and clamped to the data range.
+func (vl *VirtualList) windowFor(viewportH, scrollY float32) (first, last int) {
+	data := vl.Data()
+	return virtualWindow(data.model, vl.rowCount(), data.overscan, viewportH, scrollY)
+}
+
+// virtualWindow is the pure visible-window computation: the [first,last] rows
+// (inclusive) whose vertical span intersects [scrollY, scrollY+viewportH),
+// expanded by overscan and clamped to [0,n). Returns last < first when empty.
+func virtualWindow(model virtualHeightModel, n, overscan int, viewportH, scrollY float32) (first, last int) {
+	if n == 0 {
+		return 0, -1
+	}
+	first = max(model.indexAt(scrollY)-overscan, 0)
+	last = min(model.indexAt(scrollY+viewportH)+overscan, n-1)
+	return first, last
+}
+
+func (vl *VirtualList) reflow(force bool) {
+	data := vl.Data()
+	if data.delegate == nil {
+		return
+	}
+	// reflow runs in the clean pass (onLayoutUpdating), single-threaded for this
+	// element's root, so creating rows (man.Add) is safe here. Advance the warming
+	// queue once per real frame: rows created during frame F are only promoted to
+	// the usable pool once the host frame has moved past F, guaranteeing they have
+	// been through a clean/render pass (they are not in the frame-F clean tree, so
+	// using one in frame F would render it blank).
+	if host := vl.man.Value().Host; host != nil {
+		if f := host.Frame(); f != data.frame {
+			data.frame = f
+			vl.promoteWarm()
+		}
+	}
+	p := (*Panel)(vl)
+	n := vl.rowCount()
+	data.model.setCount(n)
+	ps := vl.layout.PixelSize()
+	viewportH := max(ps.Y(), 0)
+	width := max(max(ps.X(), 1), data.minContentW)
+	total := data.model.total()
+	scrollY := p.ScrollY()
+	first, last := vl.windowFor(viewportH, scrollY)
+
+	// Only do work when the visible WINDOW (row range), viewport, or content
+	// actually changes — NOT on every scroll pixel — UNLESS a previous pass left
+	// some visible slot unfilled (needsFill), in which case keep running until the
+	// window is complete (so a fast scroll that outran the warm pool self-heals).
+	if !force && !data.needsFill && data.haveLast &&
+		first == data.lastFirst && last == data.lastLast &&
+		approxEqf(viewportH, data.lastViewportH) &&
+		approxEqf(total, data.lastTotal) {
+		return
+	}
+
+	// Size the content panel to the full scroll height so the panel's own
+	// post-layout step computes maxScroll and the scrollbar correctly.
+	data.content.layout.Scale(width, max(total, 1))
+
+	// Recycle rows that fell outside the window: unbind and park them off-screen
+	// (kept entity-active — see virtualListParkOffset). Parked rows go back into
+	// the free pool and, being already laid-out/rendered, are "warm".
+	for idx, row := range data.active {
+		if idx < first || idx > last {
+			data.delegate.UnbindRow(idx, row)
+			row.layout.SetOffset(0, virtualListParkOffset)
+			data.free = append(data.free, row)
+			delete(data.active, idx)
+		}
+	}
+	// Bind every visible slot, but ONLY ever with a "warm" row — one that already
+	// existed (and was laid out/rendered) before this pass. A row created this
+	// frame is NOT in the manager's iteration list or this frame's clean tree, so
+	// if it were shown immediately it would render blank with no way to recover.
+	// All rows in the free pool at this point are warm (parked >= 1 frame ago);
+	// the recycled rows just added are also warm. We consume only that many.
+	warm := len(data.free)
+	data.needsFill = false
+	for i := first; i <= last; i++ {
+		if _, ok := data.active[i]; ok {
+			if force {
+				row := data.active[i]
+				row.layout.SetOffset(0, data.model.offsetOf(i))
+				data.delegate.BindRow(i, row)
+			}
+			continue
+		}
+		if warm <= 0 {
+			// No warm row available for this slot this frame. Leave it empty for
+			// now and flag that the window is incomplete; update() grows the pool
+			// and needsFill keeps reflow running until it can be filled. We never
+			// create-and-show a row here (that renders blank with no recovery).
+			data.needsFill = true
+			continue
+		}
+		row := data.free[0]
+		data.free = data.free[1:]
+		warm--
+		data.active[i] = row
+		row.layout.SetPositioning(PositioningAbsolute)
+		row.layout.SetOffset(0, data.model.offsetOf(i))
+		data.delegate.BindRow(i, row)
+		// Mark the row dirty so this clean pass (we are in onLayoutUpdating) re-runs
+		// its layout + render at the new offset; otherwise a row that was last laid
+		// out while parked stays at the parked position.
+		row.SetDirty(DirtyTypeGenerated)
+	}
+
+	data.lastFirst, data.lastLast = first, last
+	data.lastViewportH, data.lastTotal = viewportH, total
+	data.lastWindowSize = last - first + 1
+	data.haveLast = true
+
+	// Top the pool up to a warm buffer big enough to fill the whole visible window
+	// in one go after rows warm. New rows go into the warming queue (used a later
+	// frame). Done here in the single-threaded clean pass so man.Add is safe.
+	vl.replenishPool(data.lastWindowSize + data.overscan*2 + 8)
+
+	// If the window could not be fully filled this frame (warm pool too small),
+	// make sure another clean pass runs so it gets filled as the pool warms up.
+	if data.needsFill {
+		vl.Base().SetDirty(DirtyTypeLayout)
+	}
+}
+
+func approxEqf(a, b float32) bool {
+	d := a - b
+	return d < 0.01 && d > -0.01
+}

--- a/src/engine/ui/virtual_list_height.go
+++ b/src/engine/ui/virtual_list_height.go
@@ -1,0 +1,203 @@
+/******************************************************************************/
+/* virtual_list_height.go                                                     */
+/******************************************************************************/
+/* MIT License, Copyright (c) 2015-present Brent Farris, (John 4:13-14)       */
+/******************************************************************************/
+
+package ui
+
+import "sort"
+
+// virtualHeightModel maps row indices to vertical offsets and back for a
+// VirtualList. It is the piece that lets the list render only the visible
+// window: given a scroll offset it answers which row sits at that y, and given
+// a row it answers where that row's top is.
+//
+// Two implementations exist. fixedHeightModel is used when every row is the
+// same height (the no-wrap code-editor path) and is pure O(1) arithmetic, which
+// is what keeps 100k lines cheap. prefixHeightModel is used when rows have
+// individual heights (the wrapped / chat path) and keeps cumulative prefix sums
+// so offsetOf stays O(1) and indexAt is a binary search.
+type virtualHeightModel interface {
+	// setCount sets the number of rows; new rows take a default height.
+	setCount(n int)
+	count() int
+	// total is the full content height (sum of all row heights).
+	total() float32
+	// offsetOf is the y of the top edge of row index.
+	offsetOf(index int) float32
+	// heightOf is the height of row index.
+	heightOf(index int) float32
+	// indexAt is the row whose vertical span contains y (clamped to range).
+	indexAt(y float32) int
+	// setHeight records a measured height for a single row. The fixed model
+	// ignores it (all rows share one height).
+	setHeight(index int, h float32)
+	// reset drops any per-row measurements back to defaults.
+	reset()
+}
+
+// fixedHeightModel gives every row the same height. All queries are O(1).
+type fixedHeightModel struct {
+	n         int
+	rowHeight float32
+}
+
+func newFixedHeightModel(rowHeight float32) *fixedHeightModel {
+	return &fixedHeightModel{rowHeight: rowHeight}
+}
+
+func (m *fixedHeightModel) setRowHeight(h float32) { m.rowHeight = h }
+
+func (m *fixedHeightModel) setCount(n int) {
+	if n < 0 {
+		n = 0
+	}
+	m.n = n
+}
+
+func (m *fixedHeightModel) count() int { return m.n }
+
+func (m *fixedHeightModel) total() float32 { return float32(m.n) * m.rowHeight }
+
+func (m *fixedHeightModel) offsetOf(index int) float32 {
+	index = min(max(index, 0), m.n)
+	return float32(index) * m.rowHeight
+}
+
+func (m *fixedHeightModel) heightOf(index int) float32 { return m.rowHeight }
+
+func (m *fixedHeightModel) indexAt(y float32) int {
+	if m.rowHeight <= 0 || m.n == 0 {
+		return 0
+	}
+	if y < 0 {
+		return 0
+	}
+	idx := int(y / m.rowHeight)
+	return min(max(idx, 0), m.n-1)
+}
+
+func (m *fixedHeightModel) setHeight(index int, h float32) {}
+
+func (m *fixedHeightModel) reset() {}
+
+// prefixHeightModel gives each row its own height. Rows that have not been
+// measured yet use estimate, so total height and scrolling work before every
+// row has been realized; measured heights are filled in lazily via setHeight as
+// rows scroll into view. Cumulative prefix sums (cum[i] = sum of heights[0..i-1])
+// are rebuilt lazily from a dirty watermark so a single setHeight does not force
+// a full O(n) recompute on every call.
+type prefixHeightModel struct {
+	estimate  float32
+	heights   []float32
+	cum       []float32 // len == len(heights)+1; cum[i] = sum heights[0..i-1]
+	dirtyFrom int       // first index whose cum entry is stale; len(cum) when clean
+}
+
+func newPrefixHeightModel(estimate float32) *prefixHeightModel {
+	if estimate <= 0 {
+		estimate = 1
+	}
+	return &prefixHeightModel{estimate: estimate, cum: []float32{0}, dirtyFrom: 1}
+}
+
+func (m *prefixHeightModel) setEstimate(h float32) {
+	if h <= 0 {
+		h = 1
+	}
+	m.estimate = h
+}
+
+func (m *prefixHeightModel) setCount(n int) {
+	if n < 0 {
+		n = 0
+	}
+	if n == len(m.heights) {
+		return
+	}
+	if n < len(m.heights) {
+		m.heights = m.heights[:n]
+	} else {
+		for len(m.heights) < n {
+			m.heights = append(m.heights, m.estimate)
+		}
+	}
+	m.cum = make([]float32, n+1)
+	m.dirtyFrom = 0
+}
+
+func (m *prefixHeightModel) count() int { return len(m.heights) }
+
+// ensureCum rebuilds the cumulative sums from dirtyFrom to the end.
+func (m *prefixHeightModel) ensureCum() {
+	if m.dirtyFrom > len(m.heights) {
+		return
+	}
+	if len(m.cum) != len(m.heights)+1 {
+		m.cum = make([]float32, len(m.heights)+1)
+		m.dirtyFrom = 0
+	}
+	start := max(m.dirtyFrom, 0)
+	for i := start; i < len(m.heights); i++ {
+		m.cum[i+1] = m.cum[i] + m.heights[i]
+	}
+	m.dirtyFrom = len(m.cum)
+}
+
+func (m *prefixHeightModel) total() float32 {
+	m.ensureCum()
+	return m.cum[len(m.cum)-1]
+}
+
+func (m *prefixHeightModel) offsetOf(index int) float32 {
+	m.ensureCum()
+	index = min(max(index, 0), len(m.heights))
+	return m.cum[index]
+}
+
+func (m *prefixHeightModel) heightOf(index int) float32 {
+	if index < 0 || index >= len(m.heights) {
+		return 0
+	}
+	return m.heights[index]
+}
+
+func (m *prefixHeightModel) indexAt(y float32) int {
+	if len(m.heights) == 0 {
+		return 0
+	}
+	if y <= 0 {
+		return 0
+	}
+	m.ensureCum()
+	// Largest i such that cum[i] <= y. sort.Search finds the smallest i in
+	// [0,n] with cum[i] > y; the row containing y is that minus one.
+	n := len(m.heights)
+	i := sort.Search(n+1, func(i int) bool { return m.cum[i] > y })
+	i--
+	return min(max(i, 0), n-1)
+}
+
+func (m *prefixHeightModel) setHeight(index int, h float32) {
+	if index < 0 || index >= len(m.heights) {
+		return
+	}
+	if h < 0 {
+		h = 0
+	}
+	if m.heights[index] == h {
+		return
+	}
+	m.heights[index] = h
+	if index < m.dirtyFrom {
+		m.dirtyFrom = index
+	}
+}
+
+func (m *prefixHeightModel) reset() {
+	for i := range m.heights {
+		m.heights[i] = m.estimate
+	}
+	m.dirtyFrom = 0
+}

--- a/src/engine/ui/virtual_list_height_test.go
+++ b/src/engine/ui/virtual_list_height_test.go
@@ -1,0 +1,167 @@
+/******************************************************************************/
+/* virtual_list_height_test.go                                                */
+/******************************************************************************/
+/* MIT License, Copyright (c) 2015-present Brent Farris, (John 4:13-14)       */
+/******************************************************************************/
+
+package ui
+
+import "testing"
+
+// Shared assertion helpers for the virtual-list / document tests. The engine
+// package's tests use the standard library only (no testify).
+
+func assertEqualI(t *testing.T, got, want int, name string) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("%s = %d, want %d", name, got, want)
+	}
+}
+
+func assertEqualF(t *testing.T, got, want float32, name string) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("%s = %v, want %v", name, got, want)
+	}
+}
+
+func assertEqualStr(t *testing.T, got, want string, name string) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("%s = %q, want %q", name, got, want)
+	}
+}
+
+func assertEqualPos(t *testing.T, got, want textPos, name string) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("%s = %+v, want %+v", name, got, want)
+	}
+}
+
+func assertTrue(t *testing.T, cond bool, name string) {
+	t.Helper()
+	if !cond {
+		t.Fatalf("%s: expected true", name)
+	}
+}
+
+func TestFixedHeightModel(t *testing.T) {
+	m := newFixedHeightModel(20)
+	m.setCount(100)
+
+	assertEqualI(t, m.count(), 100, "count")
+	assertEqualF(t, m.total(), 2000, "total")
+	assertEqualF(t, m.offsetOf(0), 0, "offsetOf(0)")
+	assertEqualF(t, m.offsetOf(10), 200, "offsetOf(10)")
+	assertEqualF(t, m.heightOf(0), 20, "heightOf(0)")
+
+	assertEqualI(t, m.indexAt(0), 0, "indexAt(0)")
+	assertEqualI(t, m.indexAt(19), 0, "indexAt(19)")
+	assertEqualI(t, m.indexAt(20), 1, "indexAt(20)")
+	assertEqualI(t, m.indexAt(119), 5, "indexAt(119)")
+	// Past the end clamps to last row.
+	assertEqualI(t, m.indexAt(10_000), 99, "indexAt(past end)")
+	// Negative scroll clamps to first row.
+	assertEqualI(t, m.indexAt(-50), 0, "indexAt(negative)")
+}
+
+func TestFixedHeightModelEmptyAndZero(t *testing.T) {
+	m := newFixedHeightModel(20)
+	assertEqualF(t, m.total(), 0, "empty total")
+	assertEqualI(t, m.indexAt(100), 0, "empty indexAt")
+
+	z := newFixedHeightModel(0)
+	z.setCount(10)
+	assertEqualF(t, z.total(), 0, "zero-height total")
+	assertEqualI(t, z.indexAt(50), 0, "zero-height indexAt")
+
+	m.setCount(-5)
+	assertEqualI(t, m.count(), 0, "negative count clamps to 0")
+}
+
+func TestFixedHeightModelRowHeightChange(t *testing.T) {
+	m := newFixedHeightModel(10)
+	m.setCount(50)
+	assertEqualF(t, m.total(), 500, "total before change")
+	m.setRowHeight(25)
+	assertEqualF(t, m.total(), 1250, "total after change")
+	assertEqualF(t, m.offsetOf(10), 250, "offsetOf after change")
+}
+
+func TestPrefixHeightModelDefaults(t *testing.T) {
+	m := newPrefixHeightModel(15)
+	m.setCount(10)
+
+	assertEqualI(t, m.count(), 10, "count")
+	// Unmeasured rows use the estimate.
+	assertEqualF(t, m.total(), 150, "total")
+	assertEqualF(t, m.offsetOf(0), 0, "offsetOf(0)")
+	assertEqualF(t, m.offsetOf(3), 45, "offsetOf(3)")
+	assertEqualF(t, m.heightOf(0), 15, "heightOf(0)")
+}
+
+func TestPrefixHeightModelMeasuredHeights(t *testing.T) {
+	m := newPrefixHeightModel(10)
+	m.setCount(5)
+	assertEqualF(t, m.total(), 50, "initial total")
+
+	// Measure rows out of order; total + offsets reflect the measurements.
+	m.setHeight(0, 30)
+	m.setHeight(2, 100)
+	// rows: [30, 10, 100, 10, 10] => total 160
+	assertEqualF(t, m.total(), 160, "total after measure")
+	assertEqualF(t, m.offsetOf(0), 0, "offsetOf(0)")
+	assertEqualF(t, m.offsetOf(1), 30, "offsetOf(1)")
+	assertEqualF(t, m.offsetOf(2), 40, "offsetOf(2)")
+	assertEqualF(t, m.offsetOf(3), 140, "offsetOf(3)")
+	assertEqualF(t, m.offsetOf(4), 150, "offsetOf(4)")
+}
+
+func TestPrefixHeightModelIndexAt(t *testing.T) {
+	m := newPrefixHeightModel(10)
+	m.setCount(5)
+	m.setHeight(0, 30) // rows [30,10,100,10,10] offsets 0,30,40,140,150 total 160
+	m.setHeight(2, 100)
+
+	assertEqualI(t, m.indexAt(0), 0, "indexAt(0)")
+	assertEqualI(t, m.indexAt(29), 0, "indexAt(29)")
+	assertEqualI(t, m.indexAt(30), 1, "indexAt(30)")
+	assertEqualI(t, m.indexAt(39), 1, "indexAt(39)")
+	assertEqualI(t, m.indexAt(40), 2, "indexAt(40)")
+	assertEqualI(t, m.indexAt(139), 2, "indexAt(139)")
+	assertEqualI(t, m.indexAt(140), 3, "indexAt(140)")
+	assertEqualI(t, m.indexAt(150), 4, "indexAt(150)")
+	assertEqualI(t, m.indexAt(159), 4, "indexAt(159)")
+	// Past the end clamps to last row.
+	assertEqualI(t, m.indexAt(10_000), 4, "indexAt(past end)")
+	assertEqualI(t, m.indexAt(-5), 0, "indexAt(negative)")
+}
+
+func TestPrefixHeightModelShrinkGrowReset(t *testing.T) {
+	m := newPrefixHeightModel(10)
+	m.setCount(5)
+	m.setHeight(1, 50)
+	assertEqualF(t, m.total(), 90, "total after measure")
+
+	// Shrinking keeps remaining measurements.
+	m.setCount(2)
+	assertEqualI(t, m.count(), 2, "count after shrink")
+	assertEqualF(t, m.total(), 60, "total after shrink") // [10,50]
+
+	// Growing fills with estimate.
+	m.setCount(4)
+	assertEqualF(t, m.total(), 80, "total after grow") // [10,50,10,10]
+
+	// reset drops measurements back to estimate.
+	m.reset()
+	assertEqualF(t, m.total(), 40, "total after reset")
+}
+
+func TestPrefixHeightModelEmpty(t *testing.T) {
+	m := newPrefixHeightModel(10)
+	assertEqualI(t, m.count(), 0, "count")
+	assertEqualF(t, m.total(), 0, "total")
+	assertEqualI(t, m.indexAt(100), 0, "indexAt")
+	assertEqualF(t, m.offsetOf(0), 0, "offsetOf(0)")
+}

--- a/src/engine/ui/virtual_list_test.go
+++ b/src/engine/ui/virtual_list_test.go
@@ -1,0 +1,67 @@
+/******************************************************************************/
+/* virtual_list_test.go                                                       */
+/******************************************************************************/
+/* MIT License, Copyright (c) 2015-present Brent Farris, (John 4:13-14)       */
+/******************************************************************************/
+
+package ui
+
+import "testing"
+
+func TestVirtualWindowFixed(t *testing.T) {
+	m := newFixedHeightModel(20)
+	m.setCount(100_000)
+
+	// Viewport 200px (10 rows) at the top, overscan 0.
+	first, last := virtualWindow(m, m.count(), 0, 200, 0)
+	assertEqualI(t, first, 0, "first")
+	assertEqualI(t, last, 10, "last") // indexAt(200) == 10
+
+	// Overscan expands both ends and clamps at 0.
+	first, last = virtualWindow(m, m.count(), 2, 200, 0)
+	assertEqualI(t, first, 0, "first overscan")
+	assertEqualI(t, last, 12, "last overscan")
+
+	// Scrolled into the middle: window tracks the offset, count stays bounded.
+	first, last = virtualWindow(m, m.count(), 2, 200, 1000) // indexAt(1000)=50
+	assertEqualI(t, first, 48, "first mid")
+	assertEqualI(t, last, 62, "last mid") // indexAt(1200)=60 +2
+	if last-first > 15 {
+		t.Fatalf("window size = %d, want <= 15 (must stay viewport-sized)", last-first)
+	}
+
+	// Scrolled to the very bottom: last clamps to n-1.
+	bottom := m.total() - 200
+	first, last = virtualWindow(m, m.count(), 2, 200, bottom)
+	assertEqualI(t, last, 99_999, "last bottom")
+	if first >= last {
+		t.Fatalf("first %d >= last %d at bottom", first, last)
+	}
+}
+
+func TestVirtualWindowEmpty(t *testing.T) {
+	m := newFixedHeightModel(20)
+	first, last := virtualWindow(m, 0, 2, 200, 0)
+	assertEqualI(t, first, 0, "first")
+	assertEqualI(t, last, -1, "last (empty -> last < first)")
+}
+
+func TestVirtualWindowShorterThanViewport(t *testing.T) {
+	m := newFixedHeightModel(20)
+	m.setCount(3) // 60px of content in a 200px viewport
+	first, last := virtualWindow(m, m.count(), 2, 200, 0)
+	assertEqualI(t, first, 0, "first")
+	assertEqualI(t, last, 2, "last (clamps to final row)")
+}
+
+func TestVirtualWindowVariableHeights(t *testing.T) {
+	m := newPrefixHeightModel(10)
+	m.setCount(5)
+	m.setHeight(0, 30) // tops: 0,30,40,140,150 ; total 160
+	m.setHeight(2, 100)
+
+	// Viewport [35,135) -> rows 1 and 2, overscan 0.
+	first, last := virtualWindow(m, m.count(), 0, 100, 35)
+	assertEqualI(t, first, 1, "first") // indexAt(35)=1
+	assertEqualI(t, last, 2, "last")   // indexAt(135)=2
+}


### PR DESCRIPTION
* Added VirtualList a vertically-scrolling list that only materializes the rows currently in view
* Added ability to show/hide the scrollbar `SetScrollbarsVisible`
* Added a `documentModel` line-based text buffer that works with the VirtualList and TextArea to handle fast rendering of massive amounts of text data and allows an undo/redo buffer history as well.
* Refactored TextArea to use VirtualList and documentModel to speed up rendering of large text blocks that need lots of coloring