### PR TITLE
fix: address crash on osx w/intel chip

### DIFF
--- a/docs/engine/vulkan_validation_layers.md
+++ b/docs/engine/vulkan_validation_layers.md
@@ -1,0 +1,69 @@
+---
+title: Vulkan Validation Layers | Kaiju Engine
+---
+
+The renderer requests `VK_LAYER_KHRONOS_validation` automatically in `debug`
+builds (`useValidationLayers = build.Debug` in `src/rendering/vk_config.go`). When
+the layer is active, the Vulkan driver turns GPU misuse — a wrong image layout, a
+destroyed object still in use, an out-of-date swap chain — into a precise, logged
+`VUID-…` error. When it is **absent**, that same misuse instead surfaces as a raw
+`SIGSEGV`/`SIGBUS` deep inside the driver (`callVkQueueSubmit` and friends), which is
+far harder to diagnose.
+
+## macOS: routing through the Vulkan loader (required for layers)
+
+On macOS the engine loads **MoltenVK directly** by default (`-lMoltenVK`,
+`dlopen("libMoltenVK.dylib")`). That bypasses the Vulkan **loader**
+(`libvulkan.dylib`) — and **layers are inserted by the loader**, so they can never be
+enumerated on the direct path. You will see:
+
+```
+Could not find validation layer  layer=VK_LAYER_KHRONOS_validation
+```
+
+To run validation you must route through the loader. This is **opt-in** so the
+default/release path is unchanged — set `KAIJU_VULKAN_USE_LOADER=1`, which makes
+`getDefaultProcAddr` prefer `libvulkan.dylib` (and makes the engine request the
+`VK_KHR_portability_enumeration` instance extension the loader needs to expose
+MoltenVK; without it `vkCreateInstance` returns `VK_ERROR_INCOMPATIBLE_DRIVER`/`-9`).
+
+### Setup (Homebrew)
+
+```sh
+brew install vulkan-loader molten-vk vulkan-validationlayers vulkan-tools
+
+export KAIJU_VULKAN_USE_LOADER=1
+# point the loader at the MoltenVK ICD manifest (path from `find $(brew --prefix) -name MoltenVK_icd.json`)
+export VK_ICD_FILENAMES=/usr/local/etc/vulkan/icd.d/MoltenVK_icd.json
+# and at the validation layer manifest
+export VK_ADD_LAYER_PATH="$(brew --prefix)/share/vulkan/explicit_layer.d"
+# optional, if dlopen can't find libvulkan.dylib:
+# export DYLD_LIBRARY_PATH="$(brew --prefix)/lib"
+```
+
+Verify the loader+ICD first with `vulkaninfo` (it should list your GPU, no `-9`).
+Then run a `debug` build of the app from the same shell — startup logs
+`enabling the validation layers` instead of the warning, and `VUID-…` errors print
+before any crash. (On Windows/Linux the loader is used already; just install the SDK
+and set `VK_ADD_LAYER_PATH`.)
+
+## Reproducing GPU bugs
+
+With validation active, drive the scenario under test (e.g. rapidly drag-resize the
+window). Misuse is reported by VUID, object handle, and call site instead of crashing
+— for example the depth/stencil resize crash was found this way:
+
+```
+VUID-VkImageMemoryBarrier-image-03320: depth/stencil image (D24_UNORM_S8_UINT)
+  transitioned with aspectMask = DEPTH_BIT only
+VUID-vkCmdDraw-None-09600: vkQueueSubmit … expects VkImage (aspectMask = STENCIL_BIT)
+  to be DEPTH_STENCIL_ATTACHMENT_OPTIMAL — instead current layout is UNDEFINED
+```
+
+## macOS: Metal API Validation (complementary)
+
+Metal API Validation catches Metal-level misuse the Vulkan layers can't see (e.g.
+`CAMetalLayer`/drawable threading). It needs no loader setup — run with
+`MTL_DEBUG_LAYER=1 METAL_DEVICE_WRAPPER_TYPE=1` (or enable it in the Xcode scheme).
+It is what first surfaced the climbing `spvDescriptorSet0` buffer offset that pointed
+at the descriptor-pool growth during resize.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
     - FBX importer: engine/fbx_importer.md
     - Physics constraints: engine/physics_constraints.md
     - Performance profiling: engine/performance_profiling.md
+    - Vulkan validation layers: engine/vulkan_validation_layers.md
     - Building new fonts: engine/fonts/building_fonts.md
     - UI:
       - Writing: engine/ui/writing.md

--- a/src/engine/render_frame.go
+++ b/src/engine/render_frame.go
@@ -119,8 +119,21 @@ func (host *Host) renderCapturedFrame(frame RenderFrame) {
 	if !host.hasValidRenderer() || !host.Drawings.HasDrawings() {
 		return
 	}
+	// While AppKit performs a live (interactive) window resize it mutates the
+	// CAMetalLayer on the main thread. Pause rendering entirely for the duration so
+	// the render thread never acquires/submits/presents to the layer concurrently —
+	// the macOS resize race. The swap chain rebuilds on the first frame after the
+	// drag ends (acquire returns out-of-date). No-op off macOS.
+	if host.Window.IsInLiveResize() {
+		return
+	}
 	gpuInstance := host.Window.GpuInstance
 	gpuDevice := gpuInstance.PrimaryDevice()
+	// Serialize the entire acquire/submit/present span against AppKit's main-thread
+	// CAMetalLayer resize (no-op off macOS). The drawable acquired by ReadyFrame
+	// must stay valid through present, so the lock spans the whole frame.
+	host.Window.RenderLock()
+	defer host.Window.RenderUnlock()
 	if gpuDevice.ReadyFrame(gpuInstance, frame.Window, frame.PrimaryCamera,
 		frame.UICamera, frame.Lights, frame.Runtime, frame.Views) {
 		host.Drawings.Render(gpuDevice, frame.Lights, frame.Views)

--- a/src/platform/windowing/cocoa_window.h
+++ b/src/platform/windowing/cocoa_window.h
@@ -80,6 +80,20 @@ bool cocoa_get_caps_lock_toggle_key_state(void);
 
 void cocoa_run_app(void);
 
+// Render/resize serialization. AppKit mutates the view's CAMetalLayer on the main
+// thread during a live resize while the render goroutine submits/presents to it
+// via MoltenVK on another thread. CAMetalLayer is not safe for that concurrent
+// access (a race that only manifests on the fast path — validation-layer overhead
+// hides it). The render side brackets a frame with lock/unlock; the view brackets
+// its layer geometry change with the same lock.
+void cocoa_render_lock(void* nsView);
+void cocoa_render_unlock(void* nsView);
+
+// Nonzero while AppKit is performing a live (interactive) window resize. The render
+// loop pauses while this is set so it never renders to the CAMetalLayer concurrently
+// with AppKit resizing it.
+int cocoa_in_live_resize(void);
+
 // File drop (drag-and-drop from Finder)
 #if KAIJU_ENABLE_FILEDROP
 void cocoa_set_file_drop_enabled(void* nsView, bool enabled);

--- a/src/platform/windowing/cocoa_window.m
+++ b/src/platform/windowing/cocoa_window.m
@@ -18,6 +18,28 @@ extern void goProcessFileDropDarwin(uint64_t goWindow, int32_t x, int32_t y, voi
 static inline SharedMem* getSharedMem(NSWindow* window);
 #endif
 
+#pragma mark - Render/resize serialization
+
+// Binary semaphore (value 1) used as a cross-thread mutex between the AppKit main
+// thread (resizing the CAMetalLayer) and the render goroutine (submitting/presenting
+// via MoltenVK). dispatch_semaphore is used rather than os_unfair_lock/pthread_mutex
+// because a Go goroutine may migrate OS threads between the lock and unlock cgo
+// calls, and those lock types require release on the acquiring thread.
+static dispatch_semaphore_t renderSemaphore(void) {
+	static dispatch_semaphore_t sem;
+	static dispatch_once_t once;
+	dispatch_once(&once, ^{ sem = dispatch_semaphore_create(1); });
+	return sem;
+}
+
+// Set on the main thread for the duration of an AppKit live resize (window-edge
+// drag). While set, the render loop skips acquiring/submitting/presenting entirely,
+// so it never touches the CAMetalLayer concurrently with AppKit's resize. Plain
+// volatile int: a single-word flag written on the main thread and read on the render
+// thread; the exact frame the transition lands on does not matter.
+static volatile int g_inLiveResize = 0;
+int cocoa_in_live_resize(void) { return g_inLiveResize; }
+
 #pragma mark - Metal View
 
 @interface MetalView : NSView
@@ -42,6 +64,29 @@ static inline SharedMem* getSharedMem(NSWindow* window);
 }
 - (CALayer*)makeBackingLayer { return [[CAMetalLayer alloc] init]; }
 - (BOOL)wantsUpdateLayer { return YES; }
+
+// AppKit resizes the backing CAMetalLayer inside this call. Bracket it with the
+// render lock so it cannot run concurrently with a MoltenVK submit/present on the
+// render goroutine (which would corrupt the layer's drawable state and fault).
+- (void)setFrameSize:(NSSize)newSize {
+	dispatch_semaphore_t sem = renderSemaphore();
+	dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+	[super setFrameSize:newSize];
+	dispatch_semaphore_signal(sem);
+}
+
+// AppKit drives a live window-edge resize between these two calls (main thread). The
+// render loop pauses while the flag is set so it cannot touch the CAMetalLayer while
+// AppKit is mutating it; a single swap-chain rebuild happens on the first frame after
+// the drag ends (the acquire returns out-of-date).
+- (void)viewWillStartLiveResize {
+	[super viewWillStartLiveResize];
+	g_inLiveResize = 1;
+}
+- (void)viewDidEndLiveResize {
+	[super viewDidEndLiveResize];
+	g_inLiveResize = 0;
+}
 
 #if KAIJU_ENABLE_FILEDROP
 - (NSDragOperation)draggingEntered:(id<NSDraggingInfo>)sender {
@@ -421,6 +466,16 @@ void* cocoa_create_window(const char* title,
 }
 
 void cocoa_poll_events(void* nsWindow) { (void)nsWindow; /* intentionally empty */ }
+
+void cocoa_render_lock(void* nsView) {
+	(void)nsView;
+	dispatch_semaphore_wait(renderSemaphore(), DISPATCH_TIME_FOREVER);
+}
+
+void cocoa_render_unlock(void* nsView) {
+	(void)nsView;
+	dispatch_semaphore_signal(renderSemaphore());
+}
 
 void cocoa_destroy_window(void* nsWindow) {
 	if (!nsWindow) return;

--- a/src/platform/windowing/window.go
+++ b/src/platform/windowing/window.go
@@ -211,7 +211,7 @@ func (w *Window) Poll() {
 	w.poll()
 	w.fileDrop.processQueuedFileDrops()
 	if w.resizedFromNativeAPI {
-		slog.Info("window resize has been requested")
+		slog.Debug("window resize has been requested")
 		w.resizedFromNativeAPI = false
 		w.OnResize.Execute()
 	}

--- a/src/platform/windowing/window_renderlock_darwin.go
+++ b/src/platform/windowing/window_renderlock_darwin.go
@@ -1,0 +1,29 @@
+/******************************************************************************/
+/* window_renderlock_darwin.go                                                */
+/******************************************************************************/
+/* MIT License, Copyright (c) 2015-present Brent Farris, (John 4:13-14)       */
+/******************************************************************************/
+
+//go:build darwin && !ios
+
+package windowing
+
+/*
+#include "cocoa_window.h"
+*/
+import "C"
+
+// RenderLock / RenderUnlock serialize the render goroutine's GPU work against
+// AppKit's main-thread resize of the window's CAMetalLayer. MoltenVK and
+// CAMetalLayer are not safe for that concurrent access, so the render loop
+// brackets a frame (acquire/submit/present) with these and the MetalView brackets
+// its layer geometry change with the same underlying dispatch_semaphore (no thread
+// ownership, so it stays correct even if the goroutine migrates OS threads between
+// the paired cgo calls).
+func (w *Window) RenderLock()   { C.cocoa_render_lock(w.handle) }
+func (w *Window) RenderUnlock() { C.cocoa_render_unlock(w.handle) }
+
+// IsInLiveResize reports whether AppKit is mid live (interactive) window resize. The
+// render loop skips rendering while true so it never touches the CAMetalLayer
+// concurrently with AppKit's main-thread resize of it.
+func (w *Window) IsInLiveResize() bool { return C.cocoa_in_live_resize() != 0 }

--- a/src/platform/windowing/window_renderlock_other.go
+++ b/src/platform/windowing/window_renderlock_other.go
@@ -1,0 +1,19 @@
+/******************************************************************************/
+/* window_renderlock_other.go                                                 */
+/******************************************************************************/
+/* MIT License, Copyright (c) 2015-present Brent Farris, (John 4:13-14)       */
+/******************************************************************************/
+
+//go:build !darwin || ios
+
+package windowing
+
+// RenderLock / RenderUnlock are a no-op off macOS. The render/resize
+// serialization they provide is only needed for AppKit + CAMetalLayer + MoltenVK;
+// other backends do not resize the rendering surface from a separate thread while
+// the render loop runs.
+func (w *Window) RenderLock()   {}
+func (w *Window) RenderUnlock() {}
+
+// IsInLiveResize is always false off macOS (no AppKit live-resize concept).
+func (w *Window) IsInLiveResize() bool { return false }

--- a/src/rendering/gpu_config.go
+++ b/src/rendering/gpu_config.go
@@ -23,3 +23,15 @@ func depthStencilFormatCandidates() []GPUFormat {
 		GPUFormatD32SfloatS8Uint, GPUFormatD16UnormS8Uint,
 	}
 }
+
+// formatHasStencil reports whether the format carries a stencil component, i.e.
+// it is one of the combined depth/stencil formats. Such images must always have
+// their stencil aspect transitioned alongside depth.
+func formatHasStencil(f GPUFormat) bool {
+	switch f {
+	case GPUFormatD24UnormS8Uint, GPUFormatD32SfloatS8Uint, GPUFormatD16UnormS8Uint:
+		return true
+	default:
+		return false
+	}
+}

--- a/src/rendering/gpu_device_image_vulkan.go
+++ b/src/rendering/gpu_device_image_vulkan.go
@@ -133,12 +133,19 @@ func (g *GPUDevice) transitionImageLayoutImpl(vt *TextureId, newLayout GPUImageL
 	if aspectMask == 0 {
 		if newLayout == GPUImageLayoutDepthStencilAttachmentOptimal {
 			aspectMask = GPUImageAspectDepthBit
-			if vt.Format == GPUFormatD32SfloatS8Uint || vt.Format == GPUFormatD24UnormS8Uint {
-				aspectMask |= GPUImageAspectStencilBit
-			}
 		} else {
 			aspectMask = GPUImageAspectColorBit
 		}
+	}
+	// A combined depth/stencil image must transition BOTH aspects together
+	// (separateDepthStencilLayouts is not enabled). This must hold for every
+	// caller, not just the aspectMask==0 auto-detect: render-pass attachment
+	// transitions pass GPUImageAspectDepthBit explicitly, and if the stencil
+	// aspect is left in VK_IMAGE_LAYOUT_UNDEFINED, any later use of the image is
+	// undefined behavior — which MoltenVK turns into a GPU fault (the resize
+	// crash). VUID-VkImageMemoryBarrier-image-03320 / VUID-vkCmdDraw-None-09600.
+	if aspectMask&GPUImageAspectDepthBit != 0 && formatHasStencil(vt.Format) {
+		aspectMask |= GPUImageAspectStencilBit
 	}
 	commandBuffer := cmd
 	if cmd == nil {

--- a/src/rendering/gpu_instance_vulkan.go
+++ b/src/rendering/gpu_instance_vulkan.go
@@ -45,7 +45,8 @@ func (g *GPUInstance) setupImpl(window RenderingContainer, app *GPUApplication) 
 	validationLayers := validationLayers()
 	if len(validationLayers) > 0 {
 		if !checkValidationLayerSupport(validationLayers) {
-			slog.Warn("Expected to have validation layers for debugging, but didn't find them")
+			slog.Warn("Expected to have validation layers for debugging, but didn't find them; " +
+				"see docs/engine/vulkan_validation_layers.md to enable them on macOS")
 		} else {
 			slog.Info("enabling the validation layers")
 			createInfo.SetEnabledLayerNames(validationLayers)

--- a/src/rendering/gpu_logical_device_vulkan.go
+++ b/src/rendering/gpu_logical_device_vulkan.go
@@ -55,7 +55,6 @@ func (g *GPULogicalDevice) setupImpl(inst *GPUApplicationInstance, physicalDevic
 		ShaderDrawParameters: vulkan_const.True,
 	}
 	extensions := requiredDeviceExtensions()
-	validationLayers := validationLayers()
 	createInfo := &vk.DeviceCreateInfo{
 		SType:                vulkan_const.StructureTypeDeviceCreateInfo,
 		PQueueCreateInfos:    &queueCreateInfos[:qFamCount][0],
@@ -63,7 +62,9 @@ func (g *GPULogicalDevice) setupImpl(inst *GPUApplicationInstance, physicalDevic
 		PEnabledFeatures:     &deviceFeatures,
 		PNext:                unsafe.Pointer(&drawFeatures),
 	}
-	createInfo.SetEnabledLayerNames(validationLayers)
+	// Device layers are deprecated and must not be set (enabledLayerCount must be
+	// 0, VUID-VkDeviceCreateInfo-enabledLayerCount-12384). Validation layers are
+	// enabled at the instance level instead.
 	createInfo.SetEnabledExtensionNames(extensions)
 	defer createInfo.Free()
 	var device vk.Device

--- a/src/rendering/vk_render_pass.go
+++ b/src/rendering/vk_render_pass.go
@@ -591,8 +591,24 @@ func (p *RenderPass) Destroy(device *GPUDevice) {
 		p.textures[i].RenderId = TextureId{}
 	}
 	for i := range p.subpasses {
-		for j := range len(p.subpasses[i].cmd) {
-			p.subpasses[i].cmd[j].Destroy(device)
+		sp := &p.subpasses[i]
+		// setupSubpass allocates a descriptor set + pool for every render-pass
+		// (re)construction. Without freeing them here, each swap-chain remake
+		// (which reconstructs every render pass) leaks one descriptor set per
+		// subpass — the combine/composite subpass in particular — growing the
+		// descriptor pool's backing argument buffer until a draw binds past its
+		// end and the Metal driver faults (the climbing spvDescriptorSet0 offset).
+		if sp.descriptorPool.IsValid() || len(validDescriptorSets(sp.descriptorSets)) > 0 {
+			device.LogicalDevice.bufferTrash.Add(bufferTrash{
+				delay: maxFramesInFlight,
+				pool:  sp.descriptorPool,
+				sets:  sp.descriptorSets,
+			})
+		}
+		sp.descriptorPool = GPUDescriptorPool{}
+		sp.descriptorSets = [maxFramesInFlight]GPUDescriptorSet{}
+		for j := range len(sp.cmd) {
+			sp.cmd[j].Destroy(device)
 		}
 	}
 	for frame := range p.viewCmds {

--- a/src/rendering/vulkan.apple.go
+++ b/src/rendering/vulkan.apple.go
@@ -9,6 +9,8 @@
 package rendering
 
 import (
+	"os"
+
 	vk "kaijuengine.com/rendering/vulkan"
 	"kaijuengine.com/rendering/vulkan_const"
 )
@@ -28,8 +30,17 @@ func vkColorSpace(_ GPUSurfaceFormat) vulkan_const.ColorSpace {
 }
 
 func vkInstanceExtensions() []string {
-	// VK_KHR_portability_enumeration is enabled via VK_INSTANCE_CREATE_ENUMERATE_PORTABILITY_BIT_KHR flag (vkInstanceFlags = 1)
-	// Don't request it as an extension, just use the flag
+	// The portability-enumeration flag (vkInstanceFlags = 1) alone is tolerated by
+	// MoltenVK reached directly (the default path). But when routing through the
+	// real Vulkan loader so validation layers can be injected (opt-in via
+	// KAIJU_VULKAN_USE_LOADER, matching vk_default_loader.c), the loader hides the
+	// MoltenVK portability ICD unless VK_KHR_portability_enumeration is actually
+	// enabled — otherwise vkCreateInstance returns VK_ERROR_INCOMPATIBLE_DRIVER
+	// (-9). Only request it in that opt-in mode so the default/release path is
+	// unchanged.
+	if os.Getenv("KAIJU_VULKAN_USE_LOADER") != "" {
+		return []string{"VK_KHR_portability_enumeration\x00"}
+	}
 	return []string{}
 }
 

--- a/src/rendering/vulkan/vk_default_loader.c
+++ b/src/rendering/vulkan/vk_default_loader.c
@@ -1,5 +1,6 @@
 #include "vk_default_loader.h"
 #include "kaiju_vulkan.h"
+#include <stdlib.h> // getenv
 
 #if defined(_WIN32)
     #include <windows.h>
@@ -34,8 +35,23 @@ void* getDefaultProcAddr() {
         }
         return &loaderWrap;
     #elif defined(__APPLE__) && defined(__MACH__)
-        // On macOS, try to load MoltenVK (which includes the Vulkan loader)
-        void* libvulkan = dlopen("libMoltenVK.dylib", RTLD_NOW | RTLD_LOCAL);
+        // Default: load MoltenVK directly (unchanged release behavior). Opt-in via
+        // KAIJU_VULKAN_USE_LOADER: prefer the real Vulkan loader (libvulkan.dylib),
+        // which loads MoltenVK as its ICD AND inserts explicit layers such as
+        // VK_LAYER_KHRONOS_validation (configured via VK_ADD_LAYER_PATH /
+        // VK_ICD_FILENAMES). dlopening MoltenVK directly bypasses the loader, so
+        // layers can never be enumerated; the loader is therefore required to run
+        // validation. See docs/engine/vulkan_validation_layers.md.
+        void* libvulkan = NULL;
+        if (getenv("KAIJU_VULKAN_USE_LOADER")) {
+            libvulkan = dlopen("libvulkan.dylib", RTLD_NOW | RTLD_LOCAL);
+            if (libvulkan == NULL) {
+                libvulkan = dlopen("libvulkan.1.dylib", RTLD_NOW | RTLD_LOCAL);
+            }
+        }
+        if (libvulkan == NULL) {
+            libvulkan = dlopen("libMoltenVK.dylib", RTLD_NOW | RTLD_LOCAL);
+        }
         if (libvulkan == NULL) {
             return NULL;
         }


### PR DESCRIPTION
fixes: #803 
fixes: #804 

# AI Crash Fix Summary — macOS window-resize crash

## TL;DR

Rapidly resizing a game window on macOS (MoltenVK) crashed the process inside
`vkQueueSubmit` (`SIGSEGV`/`SIGBUS`, varying addresses). There were **two independent
bugs**, both of which had to be fixed:

1. **Depth/stencil layout (deterministic).** The depth buffer uses a *combined*
   depth+stencil format (`VK_FORMAT_D24_UNORM_S8_UINT`), but image-layout transitions
   only moved the **DEPTH** aspect — the **STENCIL** aspect was left in
   `VK_IMAGE_LAYOUT_UNDEFINED`. Using an image with an undefined-layout aspect is
   undefined behavior; the depth buffer is recreated every frame during a live drag,
   so it fired constantly. The Vulkan validation layers named it precisely.

2. **CAMetalLayer resize race (timing).** AppKit mutates the view's `CAMetalLayer` on
   the main thread during a live resize while the render goroutine submits/presents to
   it via MoltenVK — concurrent access `CAMetalLayer` does not allow. This one only
   manifests on the *fast* path: it crashes within a few seconds of resizing without
   validation, but the per-call overhead of the validation layers slows the render
   thread enough to hide it, so a validation run looks "stable."

The rest of the diff is the validation-layer tooling that was required to *find* bug
1 on macOS, made opt-in so the default/release path is unchanged.

---

## How it was found (and why the diff includes tooling)

The crash was undiagnosable by inspection — the faulting address was garbage and
changed every run:

```
SIGSEGV: segmentation violation
PC=0x7ff80e73ad59 ... addr=0x1e
signal arrived during cgo execution
goroutine 34 ...
  _Cfunc_callVkQueueSubmit(...)
  rendering.QueuedCommandSubmitter.submitStage ... queued_command_submitter_vulkan.go
  rendering.(*GPUDevice).swapFrameImpl ... gpu_device_vulkan.go
  ... renderCapturedFrame -> Host.Render (rapid window resize)
```

On macOS the engine loads **MoltenVK directly**, bypassing the Vulkan **loader**, so
the validation layers (which the loader injects) never loaded — every run printed
`Could not find validation layer`. Two diagnostic tools cracked it:

1. **Metal API Validation** first showed a descriptor-pool buffer offset *climbing*
   every remake (a real but secondary leak — see change 3):

   ```
   ... the offset into the buffer spvDescriptorSet0 ... must be a multiple of 32
       but was set to 33864
   ... 34056 ... 34248 ... 35592 ... 36168   (grows ~192 bytes per resize)
   ```

2. After routing through the loader (change 5) the **Vulkan validation layers**
   named the actual crash precisely:

   ```
   VUID-VkImageMemoryBarrier-image-03320:
     vkCmdPipelineBarrier(): image (VkImage ...) has depth/stencil format
     VK_FORMAT_D24_UNORM_S8_UINT, but its aspectMask is VK_IMAGE_ASPECT_DEPTH_BIT.

   VUID-vkCmdDraw-None-09600:
     vkQueueSubmit(): command buffer expects VkImage ...
     (subresource: aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT) to be in layout
     VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL
     -- instead, current layout is VK_IMAGE_LAYOUT_UNDEFINED.
   ```

3. With bug 1 fixed, a validation run was stable — but a **non-validation** run still
   `SIGSEGV`d in `vkQueueSubmit` within ~3s of resizing (one wild address, goroutine 1
   sitting in the AppKit runloop). A crash that only appears once the per-call
   validation overhead is removed is a **timing race** — the CAMetalLayer being mutated
   on the main thread concurrently with MoltenVK submit/present on the render thread
   (bug 2).

---

## Changes (every change, justified)

### 1. THE FIX — always transition the stencil aspect with depth (combined formats)

**Files:** `rendering/gpu_device_image_vulkan.go`, `rendering/gpu_config.go`

`transitionImageLayoutImpl` only auto-added the stencil aspect when the caller passed
`aspectMask == 0`, and even then only for two of the three combined formats. Render-pass
attachment transitions pass `GPUImageAspectDepthBit` **explicitly**, so the stencil
aspect of the depth buffer was never transitioned out of `UNDEFINED`.

Now, for *every* caller, if the aspect includes depth and the format carries stencil,
the stencil bit is OR-ed in:

```go
if aspectMask&GPUImageAspectDepthBit != 0 && formatHasStencil(vt.Format) {
    aspectMask |= GPUImageAspectStencilBit
}
```

`formatHasStencil` (new, `gpu_config.go`) covers all three combined formats
(`D24S8`, `D32S8`, `D16S8`) — the old inline check missed `D16UnormS8Uint`.

**Justification:** directly resolves `VUID-…image-03320` and `VUID-…None-09600` above.
A combined depth/stencil image must transition both aspects together
(`separateDepthStencilLayouts` is not enabled). This is the first crash.

### 2. THE OTHER FIX — don't render during a live resize (the timing race)

**Files:** `platform/windowing/cocoa_window.{h,m}`,
`platform/windowing/window_renderlock_{darwin,other}.go`, `engine/render_frame.go`

AppKit mutates the `MetalView`'s backing `CAMetalLayer` on the main thread while the
render goroutine runs `vkAcquireNextImage`/`vkQueueSubmit`/`vkQueuePresent` on it —
concurrent access `CAMetalLayer` does not allow. Two complementary guards:

- **Pause rendering during live resize (the definitive fix).** `MetalView`'s
  `viewWillStartLiveResize` / `viewDidEndLiveResize` set a flag
  (`cocoa_in_live_resize` → `Window.IsInLiveResize()`); `renderCapturedFrame` returns
  early while it is set, so the render thread issues **no** Vulkan calls to the layer
  for the whole drag. The swap chain rebuilds on the first frame after the drag ends
  (acquire returns out-of-date). This eliminates the race regardless of which AppKit
  call touches the layer.
- **Render lock (boundary guard).** A process-wide `dispatch_semaphore` brackets
  `-setFrameSize:`'s layer mutation and the render frame
  (`Window.RenderLock`/`RenderUnlock`), so the one frame that may already be in flight
  when the drag starts/ends completes before the layer is touched. (`dispatch_semaphore`
  rather than `os_unfair_lock`/`pthread_mutex`: a goroutine may migrate OS threads
  between the paired lock/unlock cgo calls, which those lock types forbid.)

Both are no-ops off macOS.

**Justification:** without these, a non-validation build `SIGSEGV`s within seconds of
rapid resizing (bug 2 / discovery 3 above) at a *different address each run*; a
Vulkan validation build is "stable" only because its per-call overhead reshapes the race
window. Trade-off: window contents freeze on the last frame during an active drag and
snap to the final size on release — standard for an off-main-thread Metal renderer.

### 3. Real secondary leak — free subpass descriptor sets on render-pass destroy

**File:** `rendering/vk_render_pass.go`

`setupSubpass` allocates a descriptor set + pool per subpass, but `RenderPass.Destroy`
freed only the subpass *command buffers*. Every swap-chain remake reconstructs all
render passes, so the composite/combine subpass leaked one descriptor set per resize —
the climbing `spvDescriptorSet0` offset (33864 → 36168 …) in the Metal-validation log,
which on its own eventually overflows the descriptor pool's backing buffer and crashes.

`Destroy` now returns the subpass sets to the pool via the existing `bufferTrash`
mechanism (identical to the draw-instance-group path):

```go
device.LogicalDevice.bufferTrash.Add(bufferTrash{delay: maxFramesInFlight,
    pool: sp.descriptorPool, sets: sp.descriptorSets})
```

**Justification:** a genuine allocate-without-free bug, observed directly as the
climbing offset; fixing it made that offset bounded. Independent of the depth/stencil
crash but real.

### 4. Remove deprecated device-layer enabling

**File:** `rendering/gpu_logical_device_vulkan.go`

Validation flagged:

```
VUID-VkDeviceCreateInfo-enabledLayerCount-12384:
  pCreateInfo->enabledLayerCount is 1 (not zero). Device Layers have never worked
  since Vulkan 1.0 ... enabledLayerCount must be 0.
```

Removed `createInfo.SetEnabledLayerNames(...)` from device creation. Validation layers
are enabled at the **instance** level (`gpu_instance_vulkan.go`), which is correct.

**Justification:** a spec violation (one-line removal of deprecated, ignored API), and
it spammed the validation log, obscuring real errors.

### 5. Make the Vulkan loader usable on macOS — opt-in, for validation

**Files:** `rendering/vulkan/vk_default_loader.c`, `rendering/vulkan.apple.go`,
`rendering/gpu_instance_vulkan.go`, `docs/engine/vulkan_validation_layers.md`,
`mkdocs.yml`

The engine `dlopen`s `libMoltenVK.dylib` directly, bypassing the loader, so validation
layers can never load on macOS. To enable diagnosis, `getDefaultProcAddr` now prefers
`libvulkan.dylib` **only when `KAIJU_VULKAN_USE_LOADER` is set**, and the
`VK_KHR_portability_enumeration` instance extension is requested **only in that same
mode** (the loader returns `VK_ERROR_INCOMPATIBLE_DRIVER` / `-9` without it):

```
ERROR: [Loader Message] vkCreateInstance: Found no drivers!
... ERROR_INCOMPATIBLE_DRIVER
```

`gpu_instance_vulkan.go`'s "layers not found" warning now points to the doc.

**Justification:** the *only* way to run Vulkan validation on this engine on macOS —
the capability that found the root cause and guards against regressions. Gated behind
an env var so the **default and release paths are byte-for-byte unchanged** (still
direct MoltenVK, no extra extension). Zero production risk. See the doc for setup.

### 6. Quieter resize logging

**File:** `platform/windowing/window.go`

`Window.Poll` logged `"window resize has been requested"` at **INFO** on every native
resize event. The `Update` loop keeps running during a live-resize drag (only
rendering is paused), so this spammed dozens of lines per second. Downgraded to
`slog.Debug`. (The per-remake swap-chain logs are unaffected — with the live-resize
pause they now fire only once, when the drag ends.)

---

## Verifying

1. Run a `debug` build with validation on (doc: `engine/vulkan_validation_layers.md`):
   ```
   export KAIJU_VULKAN_USE_LOADER=1
   export VK_ICD_FILENAMES=/usr/local/etc/vulkan/icd.d/MoltenVK_icd.json
   export VK_ADD_LAYER_PATH="$(brew --prefix)/share/vulkan/explicit_layer.d"
   ```
2. Rapidly drag-resize the window. Expected: **no `VUID-…image-03320` / `…None-09600`
   errors and no crash**.