### PR TITLE
fix: make sure the x and y scroll is set properly

### DIFF
--- a/src/platform/windowing/window.go
+++ b/src/platform/windowing/window.go
@@ -588,8 +588,7 @@ func (w *Window) processMouseButtonEvent(evt *MouseButtonWindowEvent) {
 func (w *Window) processMouseScrollEvent(evt *MouseScrollWindowEvent) {
 	defer tracing.NewRegion("Window.processMouseScrollEvent").End()
 	s := w.Mouse.Scroll()
-	w.Mouse.SetScroll(s.X(), s.Y()+float32(evt.deltaX))
-	w.Mouse.SetScroll(s.X(), s.Y()+float32(evt.deltaY))
+	w.Mouse.SetScroll(s.X()+float32(evt.deltaX), s.Y()+float32(evt.deltaY))
 }
 
 func (w *Window) processKeyboardButtonEvent(evt *KeyboardButtonWindowEvent) {


### PR DESCRIPTION
The trackpad horizontal scroll gesture was not working for two reasons
1. The deltaX was set on Y
2. w.Mouse.SetScroll is absolute so setting the X & Y needs to be made in a single call