### PR TITLE
Minor F64 build prep changes

### DIFF
--- a/src/editor/editor_stage_manager/editor_stage_view/stage_camera_preview.go
+++ b/src/editor/editor_stage_manager/editor_stage_view/stage_camera_preview.go
@@ -108,8 +108,8 @@ func (v *StageView) updateCameraPreview(entity *editor_stage_manager.StageEntity
 }
 
 func (v *StageView) cameraPreviewProjectionSize(data *entity_data_binding.EntityDataEntry) (float32, float32) {
-	width := cameraPreviewFieldFloat32(data, "Width", 0)
-	height := cameraPreviewFieldFloat32(data, "Height", 0)
+	width := cameraPreviewFieldFloat(data, "Width", 0)
+	height := cameraPreviewFieldFloat(data, "Height", 0)
 	if width <= 0 {
 		width = cameraPreviewFallbackWidth
 		if v.host != nil && v.host.Window != nil && v.host.Window.Width() > 0 {
@@ -195,9 +195,9 @@ func cameraPreviewCameraFromBinding(entity *editor_stage_manager.StageEntity, da
 		camera = cameras.NewStandardCamera(width, height, viewWidth, viewHeight, position)
 	}
 	camera.SetProperties(
-		cameraPreviewFieldFloat32(data, "FOV", 60),
-		cameraPreviewFieldFloat32(data, "NearPlane", 0.01),
-		cameraPreviewFieldFloat32(data, "FarPlane", 500),
+		cameraPreviewFieldFloat(data, "FOV", 60),
+		cameraPreviewFieldFloat(data, "NearPlane", 0.01),
+		cameraPreviewFieldFloat(data, "FarPlane", 500),
 		width,
 		height,
 	)
@@ -249,7 +249,7 @@ func (v *StageView) hideCameraPreview() {
 	v.cameraPreview.data = nil
 }
 
-func cameraPreviewFieldFloat32(data *entity_data_binding.EntityDataEntry, name string, fallback float32) float32 {
+func cameraPreviewFieldFloat(data *entity_data_binding.EntityDataEntry, name string, fallback matrix.Float) matrix.Float {
 	if data == nil {
 		return fallback
 	}
@@ -258,12 +258,12 @@ func cameraPreviewFieldFloat32(data *entity_data_binding.EntityDataEntry, name s
 		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
 			return fallback
 		}
-		return v
+		return matrix.Float(v)
 	case float64:
 		if math.IsNaN(v) || math.IsInf(v, 0) {
 			return fallback
 		}
-		return float32(v)
+		return matrix.Float(v)
 	default:
 		return fallback
 	}

--- a/src/engine/render_frame.go
+++ b/src/engine/render_frame.go
@@ -22,7 +22,7 @@ type RenderFrame struct {
 	UICamera      cameras.Camera
 	Views         []rendering.RenderViewFrame
 	Lights        rendering.LightsForRender
-	Runtime       float32
+	Runtime       matrix.Float
 	Width         int32
 	Height        int32
 }
@@ -66,7 +66,7 @@ func (host *Host) captureRenderFrame() RenderFrame {
 		},
 		PrimaryCamera: primaryCamera,
 		UICamera:      uiCamera,
-		Runtime:       float32(host.Runtime()),
+		Runtime:       matrix.Float(host.Runtime()),
 		Width:         width,
 		Height:        height,
 	}
@@ -135,7 +135,7 @@ func (host *Host) renderCapturedFrame(frame RenderFrame) {
 	host.Window.RenderLock()
 	defer host.Window.RenderUnlock()
 	if gpuDevice.ReadyFrame(gpuInstance, frame.Window, frame.PrimaryCamera,
-		frame.UICamera, frame.Lights, frame.Runtime, frame.Views) {
+		frame.UICamera, frame.Lights, float32(frame.Runtime), frame.Views) {
 		host.Drawings.Render(gpuDevice, frame.Lights, frame.Views)
 		if host.Window.SwapBuffersWithContainer(frame.Window, frame.Width, frame.Height) {
 			host.runAfterRenderCallbacks(gpuDevice, frame)

--- a/src/engine/terrain/terrain.go
+++ b/src/engine/terrain/terrain.go
@@ -930,13 +930,13 @@ func (t *Terrain) RayHitLocal(ray graviton.Ray) (TerrainRayHit, bool) {
 		entry = 0
 	}
 	lastDistance := entry
-	lastPoint := ray.Point(float32(lastDistance))
+	lastPoint := ray.Point(lastDistance)
 	lastDelta := lastPoint.Y() - t.HeightAtLocal(lastPoint.XZ())
 	if lastDelta <= 0 {
 		return t.localHit(lastPoint, ray.Origin), true
 	}
 	for distance := entry + step; distance <= exit+matrix.Tiny; distance += step {
-		point := ray.Point(float32(matrix.Min(distance, exit)))
+		point := ray.Point(matrix.Min(distance, exit))
 		delta := point.Y() - t.HeightAtLocal(point.XZ())
 		if delta <= 0 {
 			hitPoint := t.refineRayHit(ray, lastDistance, matrix.Min(distance, exit))
@@ -953,14 +953,14 @@ func (t *Terrain) RayHitLocal(ray graviton.Ray) (TerrainRayHit, bool) {
 func (t *Terrain) refineRayHit(ray graviton.Ray, low, high matrix.Float) matrix.Vec3 {
 	for i := 0; i < 12; i++ {
 		mid := (low + high) * 0.5
-		point := ray.Point(float32(mid))
+		point := ray.Point(mid)
 		if point.Y() > t.HeightAtLocal(point.XZ()) {
 			low = mid
 		} else {
 			high = mid
 		}
 	}
-	return ray.Point(float32(high))
+	return ray.Point(high)
 }
 
 func (t *Terrain) localHit(localPoint, rayOrigin matrix.Vec3) TerrainRayHit {

--- a/src/main.test.go
+++ b/src/main.test.go
@@ -93,7 +93,7 @@ func (g *Game) Launch(host *engine.Host) {
 	g.cube = engine.NewEntity(host.WorkGroup())
 	g.cube.Transform.SetPosition(matrix.NewVec3(2, 0, -5))
 	g.cube.Transform.SetRotation(matrix.NewVec3(-20, 20, 20))
-	sd = shader_data_registry.Create("cube")
+	sd = shader_data_registry.Create("basic")
 	sd.(*shader_data_registry.ShaderDataStandard).Color = matrix.ColorBlue()
 	host.Drawings.AddDrawing(rendering.Drawing{
 		Material:   mat.CreateInstance([]*rendering.Texture{tex}),

--- a/src/rendering/global_shader_data.go
+++ b/src/rendering/global_shader_data.go
@@ -56,7 +56,13 @@ func globalShaderDataForCamera(camera cameras.Camera, uiCamera cameras.Camera, l
 		ubo.Projection = camera.Projection()
 		ubo.CameraPosition = camera.Position().AsVec4WithW(camOrtho)
 		ubo.CascadeCount = int32(camera.NumCSMCascades())
-		ubo.CascadePlaneDistances = camera.CSMCascadeDistances()
+		csmCascadeDistances := camera.CSMCascadeDistances()
+		ubo.CascadePlaneDistances = [4]float32{
+			float32(csmCascadeDistances[0]),
+			float32(csmCascadeDistances[1]),
+			float32(csmCascadeDistances[2]),
+			float32(csmCascadeDistances[3]),
+		}
 	}
 	if uiCamera != nil {
 		ubo.UIView = uiCamera.View()

--- a/src/rendering/gpu_device_drawing_vulkan.go
+++ b/src/rendering/gpu_device_drawing_vulkan.go
@@ -153,10 +153,10 @@ func (g *GPUDevice) blitTargetsImpl(passes []*RenderPass) {
 	region.SrcOffsets[1].X = int32(extentWidth)
 	region.SrcOffsets[1].Y = int32(extentHeight)
 	region.SrcOffsets[1].Z = 1
-	region.DstOffsets[0].X = int32(float32(extentWidth) * area[0])
-	region.DstOffsets[0].Y = int32(float32(extentHeight) * area[1])
-	region.DstOffsets[1].X = int32(float32(extentWidth) * area[2])
-	region.DstOffsets[1].Y = int32(float32(extentHeight) * area[3])
+	region.DstOffsets[0].X = int32(matrix.Float(extentWidth) * area[0])
+	region.DstOffsets[0].Y = int32(matrix.Float(extentHeight) * area[1])
+	region.DstOffsets[1].X = int32(matrix.Float(extentWidth) * area[2])
+	region.DstOffsets[1].Y = int32(matrix.Float(extentHeight) * area[3])
 	region.DstOffsets[1].Z = 1
 	region.DstSubresource.AspectMask = vk.ImageAspectFlags(vulkan_const.ImageAspectColorBit)
 	region.DstSubresource.LayerCount = 1

--- a/src/rendering/gpu_device_texture_vulkan.go
+++ b/src/rendering/gpu_device_texture_vulkan.go
@@ -551,10 +551,10 @@ func (g *GPUDevice) textureReadPixelImpl(texture *Texture, x, y int) matrix.Colo
 		g.TransitionImageLayout(id, origLayout, GPUImageAspectColorBit, origAccess, nil)
 	}
 	return matrix.Color{
-		float32(raw[0]) / 255.0,
-		float32(raw[1]) / 255.0,
-		float32(raw[2]) / 255.0,
-		float32(raw[3]) / 255.0,
+		matrix.Float(raw[0]) / 255.0,
+		matrix.Float(raw[1]) / 255.0,
+		matrix.Float(raw[2]) / 255.0,
+		matrix.Float(raw[3]) / 255.0,
 	}
 }
 

--- a/src/rendering/light.go
+++ b/src/rendering/light.go
@@ -148,8 +148,8 @@ func NewLight(device *GPUDevice, assetDb assets.Database, materialCache *Materia
 		quadratic:   0.000007,
 		direction:   matrix.Vec3Down(),
 		lightType:   lightType,
-		cutoff:      matrix.Cos(matrix.Deg2Rad(32.5)),
-		outerCutoff: matrix.Cos(matrix.Deg2Rad(50.5)),
+		cutoff:      float32(matrix.Cos(matrix.Deg2Rad(32.5))),
+		outerCutoff: float32(matrix.Cos(matrix.Deg2Rad(50.5))),
 		reset:       true,
 		device:      device,
 	}
@@ -271,8 +271,8 @@ func (l *Light) transformToGPULightInfo() GPULightInfo {
 		Linear:      l.linear,
 		Specular:    l.specular,
 		Quadratic:   l.quadratic,
-		NearPlane:   l.camera.NearPlane(),
-		FarPlane:    l.camera.FarPlane(),
+		NearPlane:   float32(l.camera.NearPlane()),
+		FarPlane:    float32(l.camera.FarPlane()),
 		Type:        int32(l.lightType),
 	}
 }

--- a/src/rendering/loaders/gltf.go
+++ b/src/rendering/loaders/gltf.go
@@ -1019,7 +1019,7 @@ func gltfAnimationFrame(anim *load_result.Animation, time matrix.Float) *load_re
 	}
 	anim.Frames = append(anim.Frames, load_result.AnimKeyFrame{
 		Bones: make([]load_result.AnimBone, 0),
-		Time:  time,
+		Time:  float32(time),
 	})
 	return &anim.Frames[len(anim.Frames)-1]
 }

--- a/src/rendering/vfx/emitter.go
+++ b/src/rendering/vfx/emitter.go
@@ -260,6 +260,6 @@ func (e *Emitter) spawn(transform *matrix.Transform) {
 	p.Velocity.Position = dir.Normal().Scale(v)
 }
 
-func randomFloat32InRange(r *rand.Rand, minMax matrix.Vec2) float32 {
-	return minMax.X() + r.Float32()*(minMax.Y()-minMax.X())
+func randomFloat32InRange(r *rand.Rand, minMax matrix.Vec2) matrix.Float {
+	return minMax.X() + matrix.Float(r.Float32())*(minMax.Y()-minMax.X())
 }


### PR DESCRIPTION
Fix for some minor but non-trivial (i.e. not just replacing `float32` with `matrix.Float`) `F64` build errors. #858 

These changes, in combination with swapping `float32` for `matrix.Float` over a curated set of packages, makes the `F64` build compile and run `*` `**`.  

The big swap isn't part of this PR. Honestly I think it's best if you Brent do that since there are so many files involved, close to 200. Here are my replacement tools for that: 

`replace.sh`:
```bash
PACKAGE=$1
if [[ $PACKAGE  == *go ]]
then
    # Note the "case". Don't want to mess up switch statements (don't replace if "case" precedes)
    perl -i -pe 's/(?<!case )float32/matrix.Float/g' ${PACKAGE} 
else
    perl -i -pe 's/(?<!case )float32/matrix.Float/g' ${PACKAGE}/*.go
fi
goimports -w ${PACKAGE} # To make sure matrix package is added as import
``` 

`replace-all.sh` (the curated set):
```bash
# Packages (or individual files) 
./replace.sh engine/
./replace.sh engine/ui
./replace.sh engine/ui/markup/css/properties
# ./replace.sh rendering <-- Don't run full replace here 
./replace.sh rendering/font.go
./replace.sh rendering/mesh.go

./replace.sh editor/editor_stage_manager/editor_stage_view/transform_tools
./replace.sh engine/cameras
./replace.sh editor/editor_controls
./replace.sh engine/graviton
./replace.sh engine/systems/tweening
./replace.sh engine/systems/visual2d/sprite
./replace.sh integration_testing
./replace.sh editor/editor_workspace/stage_workspace
./replace.sh editor/editor_overlay/color_picker
./replace.sh editor/editor_stage_manager/editor_stage_view
./replace.sh framework
./replace.sh editor/editor_workspace/ui_workspace
./replace.sh editor/editor_workspace/render_graph_workspace
./replace.sh rendering/vfx
./replace.sh editor/editor_stage_manager/editor_stage_view/select_tool
./replace.sh platform/hid
./replace.sh editor/editor_stage_manager/data_binding_renderer
./replace.sh editor/editor_overlay/context_menu
./replace.sh engine_entity_data/engine_entity_data_tween_transform
./replace.sh engine_entity_data/engine_entity_data_camera
./replace.sh editor/editor_workspace/content_workspace
./replace.sh editor/codegen/reflect_helpers
./replace.sh platform/windowing
./replace.sh platform/steam
./replace.sh engine/ui/markup/css/functions
./replace.sh engine/ui/markup/css/rules
./replace.sh engine/ui/markup/document
./replace.sh engine/systems/console
./replace.sh editor/editor_workspace/terrain_workspace
./replace.sh engine_entity_data/engine_entity_data_skin_animation
./replace.sh engine/lighting
./replace.sh editor/project/project_database/content_previews
./replace.sh editor/global_interface/status_bar
./replace.sh editor/global_interface/menu_bar
./replace.sh editor/editor_workspace/vfx_workspace
./replace.sh .

./replace.sh editor/editor_settings
./replace.sh engine/ui/markup/css/helpers
./replace.sh editor/codegen/entity_data_binding
./replace.sh editor/editor_workspace/vulkan_workspace/shader_designer
./replace.sh editor/editor_workspace/settings_workspace
```


`*`: Running the  `F64` `main.test.go` with the changes in this PR + the big replacement builds and runs, but the game window is just blank. No errors in console though, strangely. Probably due to there being no (yet) full consideration for places like the one Brent mentioned in #858  https://github.com/KaijuEngine/kaiju/blob/master/src/registry/shader_data_registry/shader_data_pbr.go#L20-L21

`**`: There are a few manual edits required after running the replacement scripts to make it build 