### PR TITLE
feat: allow full unloading of texture/mesh

### DIFF
--- a/src/rendering/mesh_cache.go
+++ b/src/rendering/mesh_cache.go
@@ -19,6 +19,7 @@ type MeshCache struct {
 	assetDatabase assets.Database
 	meshes        map[string]*Mesh
 	pendingMeshes []*Mesh
+	pendingFree   []MeshId
 	mutex         sync.Mutex
 }
 
@@ -28,6 +29,7 @@ func NewMeshCache(device *GPUDevice, assetDatabase assets.Database) MeshCache {
 		assetDatabase: assetDatabase,
 		meshes:        make(map[string]*Mesh),
 		pendingMeshes: make([]*Mesh, 0),
+		pendingFree:   make([]MeshId, 0),
 		mutex:         sync.Mutex{},
 	}
 }
@@ -56,10 +58,36 @@ func (m *MeshCache) FindMesh(key string) (*Mesh, bool) {
 	}
 }
 
+// RemoveMesh evicts a mesh from the cache and reclaims its GPU memory. The
+// mesh handle (if it has already been created) is queued into pendingFree so
+// CreatePending destroys it on the next frame, and any still-queued creation
+// for the mesh is dropped so an evicted mesh is never created after removal.
+// Callers must ensure no live Drawing still references the mesh.
 func (m *MeshCache) RemoveMesh(key string) {
 	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	mesh, ok := m.meshes[key]
+	if !ok {
+		return
+	}
+	if mesh.MeshId.IsValid() {
+		m.pendingFree = append(m.pendingFree, mesh.MeshId)
+	}
+	m.removePendingMeshLocked(mesh)
 	delete(m.meshes, key)
-	m.mutex.Unlock()
+}
+
+// removePendingMeshLocked drops any queued creation referencing the given mesh
+// so a mesh that is evicted before its deferred creation runs is not created
+// after removal.
+func (m *MeshCache) removePendingMeshLocked(mesh *Mesh) {
+	for i := 0; i < len(m.pendingMeshes); {
+		if m.pendingMeshes[i] == mesh {
+			m.pendingMeshes = klib.RemoveUnordered(m.pendingMeshes, i)
+		} else {
+			i++
+		}
+	}
 }
 
 func (m *MeshCache) Mesh(key string, verts []Vertex, indexes []uint32) *Mesh {
@@ -109,6 +137,10 @@ func (m *MeshCache) CreatePending() {
 	defer tracing.NewRegion("MeshCache.CreatePending").End()
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
+	for i := range m.pendingFree {
+		m.device.destroyMeshHandle(m.pendingFree[i])
+	}
+	m.pendingFree = klib.WipeSlice(m.pendingFree)
 	for _, mesh := range m.pendingMeshes {
 		mesh.DelayedCreate(m.device)
 	}

--- a/src/rendering/mesh_cache_test.go
+++ b/src/rendering/mesh_cache_test.go
@@ -42,6 +42,55 @@ func TestMeshCacheAddFindRemove(t *testing.T) {
 	}
 }
 
+func TestMeshCacheRemoveMeshQueuesCreatedHandleForFree(t *testing.T) {
+	cache := NewMeshCache(nil, nil)
+	mesh := NewMesh("mesh", testVerts(), []uint32{0, 1})
+	cache.AddMesh(mesh)
+	// Simulate a mesh whose GPU handle has already been created.
+	mesh.MeshId = testReadyMeshID()
+	// Drop it from the pending-create queue as CreatePending would have.
+	cache.pendingMeshes = cache.pendingMeshes[:0]
+
+	cache.RemoveMesh("mesh")
+
+	if _, ok := cache.FindMesh("mesh"); ok {
+		t.Fatalf("RemoveMesh did not remove mesh from cache")
+	}
+	if len(cache.pendingFree) != 1 {
+		t.Fatalf("pendingFree = %d, want 1", len(cache.pendingFree))
+	}
+	if !cache.pendingFree[0].IsValid() {
+		t.Fatalf("pendingFree handle is not valid")
+	}
+}
+
+func TestMeshCacheRemovePendingMeshDropsCreation(t *testing.T) {
+	cache := NewMeshCache(nil, nil)
+	mesh := NewMesh("mesh", testVerts(), []uint32{0, 1})
+	cache.AddMesh(mesh)
+	// Mesh was never created (no valid MeshId) and is still queued for creation.
+	if len(cache.pendingMeshes) != 1 {
+		t.Fatalf("pendingMeshes = %d, want 1 before remove", len(cache.pendingMeshes))
+	}
+
+	cache.RemoveMesh("mesh")
+
+	if len(cache.pendingMeshes) != 0 {
+		t.Fatalf("pendingMeshes = %d, want 0 after remove", len(cache.pendingMeshes))
+	}
+	if len(cache.pendingFree) != 0 {
+		t.Fatalf("pendingFree = %d, want 0 for a never-created mesh", len(cache.pendingFree))
+	}
+}
+
+func TestMeshCacheRemoveMissingMeshIsNoop(t *testing.T) {
+	cache := NewMeshCache(nil, nil)
+	cache.RemoveMesh("nope")
+	if len(cache.pendingFree) != 0 {
+		t.Fatalf("pendingFree = %d, want 0", len(cache.pendingFree))
+	}
+}
+
 func TestMeshCacheMeshReusesExistingKey(t *testing.T) {
 	cache := NewMeshCache(nil, nil)
 	first := cache.Mesh("mesh", testVerts(), []uint32{0, 1})

--- a/src/rendering/texture_cache.go
+++ b/src/rendering/texture_cache.go
@@ -227,9 +227,22 @@ func (t *TextureCache) InsertImageTextureWithPriority(key string, imageData []by
 	return tex, nil
 }
 
+// ForceRemoveTexture evicts a texture from the cache and reclaims its GPU
+// memory. The texture's RenderId (if it has already been uploaded) is queued
+// into pendingFree so CreatePending frees it on the next frame, and any
+// still-queued upload for the texture is dropped so an evicted texture is
+// never uploaded after removal.
 func (t *TextureCache) ForceRemoveTexture(key string, filter TextureFilter) {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
+	texture, ok := t.textures[filter][key]
+	if !ok {
+		return
+	}
+	if texture.RenderId.IsValid() {
+		t.pendingFree = append(t.pendingFree, texture.RenderId)
+	}
+	t.removePendingUploadLocked(texture)
 	delete(t.textures[filter], key)
 }
 
@@ -281,6 +294,19 @@ func (t *TextureCache) queuePendingLocked(texture *Texture, priority TextureUplo
 		priority: priority,
 		sequence: t.uploadSequence,
 	})
+}
+
+// removePendingUploadLocked drops any queued upload referencing the given
+// texture so a texture that is evicted before its deferred upload runs is not
+// uploaded after removal.
+func (t *TextureCache) removePendingUploadLocked(texture *Texture) {
+	for i := 0; i < len(t.pendingTextures); {
+		if t.pendingTextures[i].texture == texture {
+			t.pendingTextures = klib.RemoveUnordered(t.pendingTextures, i)
+		} else {
+			i++
+		}
+	}
 }
 
 func (t *TextureCache) promotePendingLocked(texture *Texture, priority TextureUploadPriority) {

--- a/src/rendering/texture_cache_test.go
+++ b/src/rendering/texture_cache_test.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 	"testing"
 	"time"
+	"unsafe"
 
 	"kaijuengine.com/engine/assets"
 )
@@ -88,6 +89,64 @@ func testPendingTexture(key string, bytes int) *Texture {
 		pendingData: &TextureData{
 			Mem: make([]byte, bytes),
 		},
+	}
+}
+
+var testReadyTextureHandle byte
+
+func testReadyTextureID() TextureId {
+	ptr := unsafe.Pointer(&testReadyTextureHandle)
+	return TextureId{Image: GPUImage{GPUHandle{handle: ptr}}}
+}
+
+func TestTextureCacheForceRemoveQueuesUploadedTextureForFree(t *testing.T) {
+	cache := NewTextureCache(nil, assets.NewMockDB(map[string][]byte{}))
+	tex := &Texture{Key: "tex", Filter: TextureFilterLinear, RenderId: testReadyTextureID()}
+	cache.mutex.Lock()
+	cache.textures[TextureFilterLinear][tex.Key] = tex
+	cache.mutex.Unlock()
+
+	cache.ForceRemoveTexture("tex", TextureFilterLinear)
+
+	if _, ok := cache.Find("tex", TextureFilterLinear); ok {
+		t.Fatalf("ForceRemoveTexture did not remove texture from cache")
+	}
+	if len(cache.pendingFree) != 1 {
+		t.Fatalf("pendingFree = %d, want 1", len(cache.pendingFree))
+	}
+	if !cache.pendingFree[0].IsValid() {
+		t.Fatalf("pendingFree handle is not valid")
+	}
+}
+
+func TestTextureCacheForceRemoveDropsPendingUpload(t *testing.T) {
+	cache := NewTextureCache(nil, assets.NewMockDB(map[string][]byte{}))
+	// Texture inserted but not yet uploaded: no valid RenderId, still queued.
+	tex := testPendingTexture("tex", 1)
+	tex.Filter = TextureFilterLinear
+	cache.mutex.Lock()
+	cache.textures[TextureFilterLinear][tex.Key] = tex
+	cache.queuePendingLocked(tex, TextureUploadPriorityNormal)
+	cache.mutex.Unlock()
+
+	cache.ForceRemoveTexture("tex", TextureFilterLinear)
+
+	if _, ok := cache.Find("tex", TextureFilterLinear); ok {
+		t.Fatalf("ForceRemoveTexture did not remove texture from cache")
+	}
+	if len(cache.pendingTextures) != 0 {
+		t.Fatalf("pendingTextures = %d, want 0 after removal", len(cache.pendingTextures))
+	}
+	if len(cache.pendingFree) != 0 {
+		t.Fatalf("pendingFree = %d, want 0 for a never-uploaded texture", len(cache.pendingFree))
+	}
+}
+
+func TestTextureCacheForceRemoveMissingTextureIsNoop(t *testing.T) {
+	cache := NewTextureCache(nil, assets.NewMockDB(map[string][]byte{}))
+	cache.ForceRemoveTexture("nope", TextureFilterLinear)
+	if len(cache.pendingFree) != 0 {
+		t.Fatalf("pendingFree = %d, want 0", len(cache.pendingFree))
 	}
 }
 


### PR DESCRIPTION
Found that when textures/meshes are scene/zone specific, they stay in memory, and I wanted a way to clear the old ones to manage memory better.