### PR TITLE
fix(mac): stop AppKit terminate racing Vulkan teardown (#876)

### DIFF
--- a/src/main.darwin.go
+++ b/src/main.darwin.go
@@ -18,6 +18,8 @@ func main() {
 	runtime.LockOSThread()
 	go func() {
 		_main(nil)
+		// Teardown (including Vulkan destroy) is done; leave [NSApp run].
+		windowing.CocoaStopApp()
 	}()
-	windowing.CocoaRunApp() // blocks forever
+	windowing.CocoaRunApp()
 }

--- a/src/platform/windowing/cocoa_window.h
+++ b/src/platform/windowing/cocoa_window.h
@@ -86,6 +86,9 @@ bool cocoa_get_caps_lock_toggle_key_state(void);
 
 void cocoa_run_app(void);
 
+// Stop the NSApp run loop (call after Host.Teardown on the Go side).
+void cocoa_stop_app(void);
+
 // Render/resize serialization. AppKit mutates the view's CAMetalLayer on the main
 // thread during a live resize while the render goroutine submits/presents to it
 // via MoltenVK on another thread. CAMetalLayer is not safe for that concurrent

--- a/src/platform/windowing/cocoa_window.m
+++ b/src/platform/windowing/cocoa_window.m
@@ -159,9 +159,13 @@ int cocoa_in_live_resize(void) { return g_inLiveResize; }
 	return YES;
 }
 
+// Returning YES would terminate the process as soon as the last window
+// closes. The game loop runs on another thread and still needs to finish
+// Host.Teardown (Vulkan destroy). Window close is delivered to Go via
+// windowWillClose; main.darwin.go stops the run loop after teardown.
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
 	(void)sender;
-	return YES;
+	return NO;
 }
 @end
 
@@ -379,6 +383,25 @@ void cocoa_run_app(void) {
 
 		[NSApp run];
 	}
+}
+
+// Ends [NSApp run] after Go has finished Host.Teardown. Always hops to the
+// main queue so it is safe to call from the game-loop goroutine.
+void cocoa_stop_app(void) {
+	dispatch_async(dispatch_get_main_queue(), ^{
+		[NSApp stop:nil];
+		// stop: only applies after the next event is processed.
+		NSEvent* event = [NSEvent otherEventWithType:NSEventTypeApplicationDefined
+											location:NSMakePoint(0, 0)
+									   modifierFlags:0
+										   timestamp:0
+										windowNumber:0
+											 context:nil
+											 subtype:0
+											   data1:0
+											   data2:0];
+		[NSApp postEvent:event atStart:YES];
+	});
 }
 
 #pragma mark - Public API (unchanged)

--- a/src/platform/windowing/window.darwin.go
+++ b/src/platform/windowing/window.darwin.go
@@ -322,3 +322,9 @@ func (w *Window) cInstance() unsafe.Pointer { return w.instance }
 func CocoaRunApp() {
 	C.cocoa_run_app()
 }
+
+// CocoaStopApp ends the NSApp run loop. Call after Host.Teardown so Vulkan
+// cleanup finishes before process exit. Safe from non-main goroutines.
+func CocoaStopApp() {
+	C.cocoa_stop_app()
+}

--- a/src/rendering/gpu_device_mesh.go
+++ b/src/rendering/gpu_device_mesh.go
@@ -65,7 +65,7 @@ func (g *GPUDevice) CreateDynamicMesh(mesh *Mesh, verts []Vertex, indices []uint
 	id.indexBuffer, id.indexBufferMemory, _ = g.CreateIndexBuffer(indices)
 	runtime.AddCleanup(mesh, func(state MeshCleanup) {
 		d := state.device.Value()
-		if d == nil {
+		if d == nil || !d.LogicalDevice.IsValid() {
 			return
 		}
 		d.Painter.preRuns = append(d.Painter.preRuns, func() {
@@ -95,7 +95,7 @@ func (g *GPUDevice) CreateMesh(mesh *Mesh, verts []Vertex, indices []uint32) {
 	id.indexBuffer, id.indexBufferMemory, _ = g.CreateIndexBuffer(indices)  // TODO:  Don't discard
 	runtime.AddCleanup(mesh, func(state MeshCleanup) {
 		d := state.device.Value()
-		if d == nil {
+		if d == nil || !d.LogicalDevice.IsValid() {
 			return
 		}
 		d.Painter.preRuns = append(d.Painter.preRuns, func() {

--- a/src/rendering/gpu_device_shader.go
+++ b/src/rendering/gpu_device_shader.go
@@ -10,5 +10,8 @@ import "kaijuengine.com/platform/profiler/tracing"
 
 func (g *GPUDevice) DestroyShaderHandle(id ShaderId) {
 	defer tracing.NewRegion("GPUDevice.DestroyShaderHandle").End()
+	if !id.IsValid() {
+		return
+	}
 	g.destroyShaderHandleImpl(id)
 }

--- a/src/rendering/gpu_device_shader_vulkan.go
+++ b/src/rendering/gpu_device_shader_vulkan.go
@@ -157,7 +157,7 @@ func (g *GPUDevice) createGraphicsShader(shader *Shader, assetDB assets.Database
 	shader.pipelineInfo.ConstructPipeline(g, shader, shader.renderPass.Value(), stages)
 	runtime.AddCleanup(shader, func(state ShaderCleanup) {
 		d := state.device.Value()
-		if d == nil {
+		if d == nil || !d.LogicalDevice.IsValid() {
 			return
 		}
 		d.Painter.preRuns = append(d.Painter.preRuns, func() {

--- a/src/rendering/gpu_device_texture_vulkan.go
+++ b/src/rendering/gpu_device_texture_vulkan.go
@@ -179,7 +179,7 @@ func (g *GPUDevice) setupTextureImpl(texture *Texture, data *TextureData, batch 
 	}
 	runtime.AddCleanup(texture, func(state TextureCleanup) {
 		d := state.device.Value()
-		if d == nil {
+		if d == nil || !d.LogicalDevice.IsValid() {
 			return
 		}
 		ld := &d.LogicalDevice

--- a/src/rendering/shader_cache.go
+++ b/src/rendering/shader_cache.go
@@ -120,5 +120,8 @@ func (s *ShaderCache) destroyShaderTree(shader *Shader) {
 	for _, sub := range shader.subShaders {
 		s.destroyShaderTree(sub)
 	}
-	s.device.DestroyShaderHandle(shader.RenderId)
+	if shader.RenderId.IsValid() {
+		s.device.DestroyShaderHandle(shader.RenderId)
+		shader.RenderId = ShaderId{}
+	}
 }


### PR DESCRIPTION
## Summary

Fixes #876.

On macOS the game loop runs on a goroutine while `[NSApp run]` blocks the main thread. Returning `YES` from `applicationShouldTerminateAfterLastWindowClosed` made AppKit terminate the process as soon as the window closed, racing `Host.Teardown` Vulkan cleanup. With validation layers (`KAIJU_VULKAN_USE_LOADER=1`) that produced:

```
VALIDATION ERROR - The VkDevice dispatch handle was not found and Validation will crash.
If you are using exit() you need to make sure to not call any Vulkan calls in your atexit() function...
```

### Changes

1. `applicationShouldTerminateAfterLastWindowClosed` returns `NO` so close only signals Go (existing `windowWillClose` path).
2. After `_main` / `Host.Teardown` completes, `cocoa_stop_app` ends the NSApp run loop.
3. Align shader destroy with mesh destroy (`RenderId.IsValid`), and skip `runtime.AddCleanup` GPU free when the logical device is already gone.

No new dependencies. Comments kept short and within the project style.

## Test plan

macOS + Homebrew Vulkan validation layers:

```sh
export KAIJU_VULKAN_USE_LOADER=1
export VK_ICD_FILENAMES="$(brew --prefix)/etc/vulkan/icd.d/MoltenVK_icd.json"
export VK_LAYER_PATH="$(brew --prefix)/opt/vulkan-validationlayers/share/vulkan/explicit_layer.d"
export DYLD_LIBRARY_PATH="$(brew --prefix)/lib"

cd src
CGO_LDFLAGS="-L$(brew --prefix)/lib -lMoltenVK -Wl,-rpath,$(brew --prefix)/lib" \
  go build -tags="debug,editor,filedrop" -o ../bin/kaiju ./
../bin/kaiju
# Close the Editor window — expect clean exit, no dispatch-handle validation error
```

Verified on darwin/arm64: multiple close cycles, no validation error, exit 0. `go test ./rendering/` passes.