### PR TITLE
Prevent editor from freezing during project load and added loading overlay

### DIFF
--- a/src/editor/editor.go
+++ b/src/editor/editor.go
@@ -228,58 +228,65 @@ func (ed *Editor) effectiveRefreshRate(status platformPower.Status) int32 {
 	return klib.Clamp(refreshRate, 0, 320)
 }
 
-func (ed *Editor) postProjectLoad() {
+func (ed *Editor) postProjectLoad(onComplete func()) {
 	defer tracing.NewRegion("Editor.lateLoadUI").End()
 	ed.settings.AddRecentProject(ed.project.FileSystem().FullPath(""))
 	slog.Info("compiling the project to get things ready")
-	{
-		// Read the project source synchronosly for now, if not, any stage loading
-		// before this is complete will have issues.
+	
+	go func() {
+		// Read the project source asynchronously so we don't freeze the UI
 		ed.project.ReadSourceCode()
-	}
-	editorContent := ed.host.AssetDatabase().(*editor_embedded_content.EditorContent)
-	editorContent.Pfs = ed.project.FileSystem()
-	editorContent.SetProjectContentIndex(ed.project.CacheDatabase().List())
-	ed.events.OnContentAdded.Add(func(ids []string) {
-		editorContent.IndexProjectContentIDs(ed.project.CacheDatabase(), ids)
-	})
-	ed.events.OnContentRemoved.Add(editorContent.RemoveProjectContentIDs)
-	ed.host.TextureCache().SetUploadBudget(rendering.TextureUploadBudget{
-		MaxCreatesPerFrame: launchMaxTextureCreatesPerFrame,
-		MaxBytesPerFrame:   launchMaxTextureBytesPerFrame,
-	})
-	ed.setupWindowActivity()
-	ed.activeWorkspaces = map[string]editor_workspace.Workspace{}
-	ed.initializedWorkspaces = map[string]struct{}{}
-	ed.reconcileWorkspaces()
-	ed.initializeWorkspaces()
-	ed.rebuildMenuBarTabs()
-	ed.connectFileDropRouter()
-	if id := ed.firstSelectableWorkspaceID(); id != WorkspaceStateNone {
-		ed.setWorkspaceState(id)
-	}
-	// goroutine
-	go ed.project.CompileDebug()
-	if build.Debug && ed.initAutoTest() {
-		ed.updateId = ed.host.Updater.AddUpdate(ed.runAutoTest)
-	} else {
-		ed.updateId = ed.host.Updater.AddUpdate(ed.update)
-	}
-	for k, v := range editorPluginRegistry {
-		if err := v.Launch(ed); err != nil {
-			slog.Error("failed to launch plugin", "key", k, "error", err)
-			continue
-		}
-		ed.plugins = append(ed.plugins, v)
-	}
-	// A plugin's Launch may have called RegisterWorkspace late. Pick up any
-	// new entries, initialize them, and refresh the menu bar.
-	if ed.reconcileWorkspaces() {
-		ed.initializeWorkspaces()
-		ed.rebuildMenuBarTabs()
-	}
-	// Pre-warm the, quite large, material icons PNG file
-	ed.host.TextureCache().Texture("MaterialIcons-Regular.png", textures.TextureFilterLinear)
+		
+		ed.host.RunOnMainThread(func() {
+			editorContent := ed.host.AssetDatabase().(*editor_embedded_content.EditorContent)
+			editorContent.Pfs = ed.project.FileSystem()
+			editorContent.SetProjectContentIndex(ed.project.CacheDatabase().List())
+			ed.events.OnContentAdded.Add(func(ids []string) {
+				editorContent.IndexProjectContentIDs(ed.project.CacheDatabase(), ids)
+			})
+			ed.events.OnContentRemoved.Add(editorContent.RemoveProjectContentIDs)
+			ed.host.TextureCache().SetUploadBudget(rendering.TextureUploadBudget{
+				MaxCreatesPerFrame: launchMaxTextureCreatesPerFrame,
+				MaxBytesPerFrame:   launchMaxTextureBytesPerFrame,
+			})
+			ed.setupWindowActivity()
+			ed.activeWorkspaces = map[string]editor_workspace.Workspace{}
+			ed.initializedWorkspaces = map[string]struct{}{}
+			ed.reconcileWorkspaces()
+			ed.initializeWorkspaces()
+			ed.rebuildMenuBarTabs()
+			ed.connectFileDropRouter()
+			if id := ed.firstSelectableWorkspaceID(); id != WorkspaceStateNone {
+				ed.setWorkspaceState(id)
+			}
+			// goroutine
+			go ed.project.CompileDebug()
+			if build.Debug && ed.initAutoTest() {
+				ed.updateId = ed.host.Updater.AddUpdate(ed.runAutoTest)
+			} else {
+				ed.updateId = ed.host.Updater.AddUpdate(ed.update)
+			}
+			for k, v := range editorPluginRegistry {
+				if err := v.Launch(ed); err != nil {
+					slog.Error("failed to launch plugin", "key", k, "error", err)
+					continue
+				}
+				ed.plugins = append(ed.plugins, v)
+			}
+			// A plugin's Launch may have called RegisterWorkspace late. Pick up any
+			// new entries, initialize them, and refresh the menu bar.
+			if ed.reconcileWorkspaces() {
+				ed.initializeWorkspaces()
+				ed.rebuildMenuBarTabs()
+			}
+			// Pre-warm the, quite large, material icons PNG file
+			ed.host.TextureCache().Texture("MaterialIcons-Regular.png", textures.TextureFilterLinear)
+			
+			if onComplete != nil {
+				onComplete()
+			}
+		})
+	}()
 }
 
 // defaultWorkspaceOrder is the canonical first-time ordering of the built-in

--- a/src/editor/editor_embedded_content/editor_content/editor/ui/overlay/new_project_overlay.go.html
+++ b/src/editor/editor_embedded_content/editor_content/editor/ui/overlay/new_project_overlay.go.html
@@ -376,6 +376,37 @@
 			.hidden {
 				display: none;
 			}
+			
+			.loadingOverlay {
+				position: absolute;
+				left: 0;
+				top: 0;
+				width: 100%;
+				height: 100%;
+				z-index: 99;
+			}
+			
+			.loadingModal {
+				position: absolute;
+				left: 50%;
+				top: 50%;
+				width: 16em;
+				height: 5em;
+				transform: translate(-50%, -50%);
+				background-color: #202020;
+				border: 1px solid #3A3A3D;
+			}
+
+			.loadingText {
+				position: absolute;
+				top: 50%;
+				left: 50%;
+				transform: translate(-50%, -50%);
+				color: #E0E0E0;
+				font-size: 1.1em;
+				font-weight: bold;
+				letter-spacing: 0.02em;
+			}
 		</style>
 	</head>
 	<body>
@@ -443,6 +474,11 @@
 							<button class="createBtn" onclick="createProject">Create Project</button>
 						</div>
 					</div>
+				</div>
+			</div>
+			<div id="loadingOverlay" class="loadingOverlay hidden">
+				<div class="loadingModal">
+					<div class="loadingText">Loading...</div>
 				</div>
 			</div>
 		</div>

--- a/src/editor/editor_game_interface.go
+++ b/src/editor/editor_game_interface.go
@@ -71,7 +71,7 @@ func (EditorGame) Launch(host *engine.Host) {
 		ed.BlurInterface()
 		if build.Debug && engine.LaunchParams.AutoTest {
 			// Auto-test mode: create a temporary test project automatically
-			ed.createProject("AutoTest", "autotestproject", "")
+			ed.createProject("AutoTest", "autotestproject", "", nil)
 			return
 		}
 		// validateCompiledPlugins inspects plugin.json vs the compiled-in

--- a/src/editor/editor_overlay/new_project/new_project_overlay.go
+++ b/src/editor/editor_overlay/new_project/new_project_overlay.go
@@ -26,6 +26,7 @@ type NewProject struct {
 	templatePathElm  *document.Element
 	clearTemplateBtn *document.Element
 	errorBox         *document.Element
+	loadingOverlay   *document.Element
 	config           Config
 	templatePath     string
 }
@@ -33,11 +34,11 @@ type NewProject struct {
 type Config struct {
 	// OnCreate will be called when the "Create" button is clicked, it will
 	// return the name that the developer typed in and the path they selected.
-	OnCreate func(name, path, templatePath string)
+	OnCreate func(name, path, templatePath string, close func())
 
 	// OnOpen will be called when the "Browse" button is clicked, it will return
 	// the path that was selected.
-	OnOpen func(string)
+	OnOpen func(path string, close func())
 
 	// Error will be used to print out an error to the developer in the window.
 	Error string
@@ -88,6 +89,7 @@ func Show(host *engine.Host, config Config) (*NewProject, error) {
 	np.templatePathElm, _ = np.doc.GetElementById("templatePath")
 	np.clearTemplateBtn, _ = np.doc.GetElementById("clearTemplateBtn")
 	np.errorBox, _ = np.doc.GetElementById("errorBox")
+	np.loadingOverlay, _ = np.doc.GetElementById("loadingOverlay")
 	
 	if np.nameInput != nil && np.nameInput.UI != nil {
 		np.nameInput.UI.ToInput().Focus()
@@ -188,12 +190,15 @@ func (np *NewProject) createProject(e *document.Element) {
 		np.showError("Project folder was not set.")
 		return
 	}
-	np.Close()
+	if np.loadingOverlay != nil {
+		np.doc.SetElementClasses(np.loadingOverlay, "loadingOverlay")
+	}
 	if np.config.OnCreate == nil {
 		slog.Error("nothing bound to OnCreate, doing nothing")
+		np.Close()
 		return
 	}
-	np.config.OnCreate(name, folder, np.templatePath)
+	np.config.OnCreate(name, folder, np.templatePath, np.Close)
 }
 
 func (np *NewProject) showError(msg string) {
@@ -232,10 +237,13 @@ func (np *NewProject) openRecentProject(e *document.Element) {
 }
 
 func (np *NewProject) openProjectFolder(path string) {
-	np.Close()
+	if np.loadingOverlay != nil {
+		np.doc.SetElementClasses(np.loadingOverlay, "loadingOverlay")
+	}
 	if np.config.OnOpen == nil {
 		slog.Error("nothing bound to OnOpen, doing nothing")
+		np.Close()
 		return
 	}
-	np.config.OnOpen(path)
+	np.config.OnOpen(path, np.Close)
 }

--- a/src/editor/editor_project_setup.go
+++ b/src/editor/editor_project_setup.go
@@ -66,71 +66,105 @@ func (ed *Editor) retryNewProjectOverlay(err error) {
 	})
 }
 
-func (ed *Editor) createProject(name, path, templatePath string) {
+func (ed *Editor) createProject(name, path, templatePath string, closeFunc func()) {
 	defer tracing.NewRegion("Editor.createProject").End()
-	err := ed.project.Initialize(path, templatePath, EditorVersion)
-	if err != nil && !klib.ErrorIs[project.ConfigLoadError](err) {
-		slog.Error("failed to create the project", "error", err)
-		ed.retryNewProjectOverlay(err)
-		return
-	}
-	ed.setProjectName(name)
-	ed.postProjectLoad()
-	ed.FocusInterface()
+	go func() {
+		err := ed.project.Initialize(path, templatePath, EditorVersion)
+		ed.host.RunOnMainThread(func() {
+			if err != nil && !klib.ErrorIs[project.ConfigLoadError](err) {
+				slog.Error("failed to create the project", "error", err)
+				if closeFunc != nil {
+					closeFunc()
+				}
+				ed.retryNewProjectOverlay(err)
+				return
+			}
+			ed.setProjectName(name)
+			ed.postProjectLoad(func() {
+				if closeFunc != nil {
+					closeFunc()
+				}
+				ed.FocusInterface()
+			})
+		})
+	}()
 }
 
-func (ed *Editor) openProject(path string) {
+func (ed *Editor) openProject(path string, closeFunc func()) {
 	defer tracing.NewRegion("Editor.openProject").End()
-	if err := ed.project.Open(path); err != nil {
-		slog.Error("failed to open the project", "error", err)
-		lastCount := len(ed.settings.RecentProjects)
-		ed.settings.RecentProjects = klib.SlicesRemoveElement(ed.settings.RecentProjects, path)
-		if len(ed.settings.RecentProjects) != lastCount {
-			ed.settings.Save()
-		}
-		ed.retryNewProjectOverlay(err)
-		return
-	}
-	projectVersion := ed.project.Settings.EditorVersion
-	finishLoad := func() {
-		ed.setProjectName(ed.project.Name())
-		ed.postProjectLoad()
-		ed.FocusInterface()
-	}
-	hasEngineSource := ed.project.FileSystem().HasEngineCode()
-	// This is a special hidden feature for editor/engine developers to be able
-	// to force updating engine code in projects. This makes it easier than
-	// bumping the engine version to do the same thing (or deleting kaiju src)
-	kb := &ed.host.Window.Keyboard
-	forceReplace := kb.HasShift() || kb.HasCtrlOrMeta()
-	if projectVersion != EditorVersion || !hasEngineSource || forceReplace {
-		title := "Upgrade project"
-		description := "Your project is for an older version of the editor, would you like to upgrade it? Please make sure you've backed up your project (with VCS for example) before proceeding."
-		cancelMsg := "Project upgrade refused, unable to open project"
-		if projectVersion == EditorVersion {
-			title = "Import engine code"
-			description = "Your project doesn't have the engine source, would you like to import it? This is typical if you don't commit the `kaiju` folder to your repository."
-			cancelMsg = "Engine source import refused, unable to open project"
-		}
-		confirm_prompt.Show(ed.host, confirm_prompt.Config{
-			Title:       title,
-			Description: description,
-			ConfirmText: "Yes",
-			CancelText:  "Cancel",
-			OnConfirm: func() {
-				if err := ed.project.TryUpgrade(); err != nil {
-					ed.retryNewProjectOverlay(err)
-				} else {
-					ed.project.Settings.EditorVersion = EditorVersion
-					ed.project.Settings.Save(ed.ProjectFileSystem())
-					finishLoad()
+	go func() {
+		err := ed.project.Open(path)
+		ed.host.RunOnMainThread(func() {
+			if err != nil {
+				slog.Error("failed to open the project", "error", err)
+				lastCount := len(ed.settings.RecentProjects)
+				ed.settings.RecentProjects = klib.SlicesRemoveElement(ed.settings.RecentProjects, path)
+				if len(ed.settings.RecentProjects) != lastCount {
+					ed.settings.Save()
 				}
-			},
-			OnCancel: func() {
-				ed.retryNewProjectOverlay(errors.New(cancelMsg))
-			},
+				if closeFunc != nil {
+					closeFunc()
+				}
+				ed.retryNewProjectOverlay(err)
+				return
+			}
+			projectVersion := ed.project.Settings.EditorVersion
+			finishLoad := func() {
+				ed.setProjectName(ed.project.Name())
+				ed.postProjectLoad(func() {
+					if closeFunc != nil {
+						closeFunc()
+					}
+					ed.FocusInterface()
+				})
+			}
+			hasEngineSource := ed.project.FileSystem().HasEngineCode()
+			// This is a special hidden feature for editor/engine developers to be able
+			// to force updating engine code in projects. This makes it easier than
+			// bumping the engine version to do the same thing (or deleting kaiju src)
+			kb := &ed.host.Window.Keyboard
+			forceReplace := kb.HasShift() || kb.HasCtrlOrMeta()
+			if projectVersion != EditorVersion || !hasEngineSource || forceReplace {
+				title := "Upgrade project"
+				description := "Your project is for an older version of the editor, would you like to upgrade it? Please make sure you've backed up your project (with VCS for example) before proceeding."
+				cancelMsg := "Project upgrade refused, unable to open project"
+				if projectVersion == EditorVersion {
+					title = "Import engine code"
+					description = "Your project doesn't have the engine source, would you like to import it? This is typical if you don't commit the `kaiju` folder to your repository."
+					cancelMsg = "Engine source import refused, unable to open project"
+				}
+				confirm_prompt.Show(ed.host, confirm_prompt.Config{
+					Title:       title,
+					Description: description,
+					ConfirmText: "Yes",
+					CancelText:  "Cancel",
+					OnConfirm: func() {
+						go func() {
+							err := ed.project.TryUpgrade()
+							ed.host.RunOnMainThread(func() {
+								if err != nil {
+									if closeFunc != nil {
+										closeFunc()
+									}
+									ed.retryNewProjectOverlay(err)
+								} else {
+									ed.project.Settings.EditorVersion = EditorVersion
+									ed.project.Settings.Save(ed.ProjectFileSystem())
+									finishLoad()
+								}
+							})
+						}()
+					},
+					OnCancel: func() {
+						if closeFunc != nil {
+							closeFunc()
+						}
+						ed.retryNewProjectOverlay(errors.New(cancelMsg))
+					},
+				})
+			} else {
+				finishLoad()
+			}
 		})
-	} else {
-		finishLoad()
-	}
+	}()
 }

--- a/src/integration_testing/integration_test_new_project_overlay.go
+++ b/src/integration_testing/integration_test_new_project_overlay.go
@@ -32,8 +32,8 @@ func IntegrationTestNewProjectOverlay(host *engine.Host) {
 			`C:\KaijuProjects\physics_mesh`,
 			`C:\KaijuProjects\Sudoku`,
 		},
-		OnCreate: func(name, path, templatePath string) {},
-		OnOpen:   func(path string) {},
+		OnCreate: func(name, path, templatePath string, close func()) {},
+		OnOpen:   func(path string, close func()) {},
 	}); err != nil {
 		slog.Error("failed to show new project overlay", "error", err)
 		os.Exit(1)


### PR DESCRIPTION
 • Asynchronous Loading: Moved ed.project.Open(), ed.project.Initialize(), and ed.project.TryUpgrade() inside editor_project_setup.go into background Goroutines.
  • Main Thread Synchronization: Once the heavy file operations and parsing are complete, execution is handed back to the UI thread via ed.host. RunOnMainThread() to safely finalize the engine state and UI setup.
  • Loading UI Indicator: Added a clean, non-intrusive loading modal (.loadingModal) to the new_project_overlay.go.html template. It safely blocks interactions (like duplicate clicks on "Create Project") by using an invisible .loadingOverlay shield that covers the panel until the background Go routines invoke the close() callback.