### PR TITLE
Prevent panic from empty line in .obj file

### DIFF
--- a/src/rendering/loaders/obj_loader.go
+++ b/src/rendering/loaders/obj_loader.go
@@ -71,6 +71,10 @@ const (
 )
 
 func objDecipherLine(str string) objLineType {
+	str = strings.TrimSpace(str)
+	if str == "" {
+		return objLineTypeNotSupported
+	}
 	runes := []rune(str)
 	switch runes[0] {
 	case '#':

--- a/src/rendering/loaders/obj_loader.go
+++ b/src/rendering/loaders/obj_loader.go
@@ -71,8 +71,7 @@ const (
 )
 
 func objDecipherLine(str string) objLineType {
-	str = strings.TrimSpace(str)
-	if str == "" {
+	if len(str) == 0 {
 		return objLineTypeNotSupported
 	}
 	runes := []rune(str)

--- a/src/rendering/loaders/obj_loader_test.go
+++ b/src/rendering/loaders/obj_loader_test.go
@@ -175,3 +175,72 @@ f 1/1/1 2/2/2 3/3/3`
 		t.Fatalf("mesh should contain 3 indexes, got %d", len(mesh.Indexes))
 	}
 }
+
+func TestObjToRawIgnoresEmptyLines(t *testing.T) {
+	objData := `mtllib test.mtl
+# vertices
+v -176 -16 -64
+v -176 -16 144
+v -176 0 144
+v -176 0 -64
+v 48 0 144
+v 48 -16 144
+v 48 -16 -64
+v 48 0 -64
+
+# texture coordinates
+vt 1.9999999 -0.5
+vt -3.9999995 -0.5
+vt -3.9999995 0.5
+vt 1.9999999 0.5
+vt 1 0.5
+vt -6 0.5
+vt -6 -0.5
+vt 1 -0.5
+vt 1 -3.9999995
+vt -6 -3.9999995
+vt -6 1.9999999
+vt 1 1.9999999
+
+# normals
+vn -1 0 0
+vn 0 0 1
+vn 0 -1 -0
+vn -0 1 -0
+vn 0 -0 -1
+vn 1 0 0
+
+o entity0_brush0
+usemtl __TB_empty
+f  1/1/1  2/2/1  3/3/1  4/4/1
+usemtl __TB_empty
+f  5/5/2  3/6/2  2/7/2  6/8/2
+usemtl __TB_empty
+f  6/9/3  2/10/3  1/11/3  7/12/3
+usemtl __TB_empty
+f  8/12/4  4/11/4  3/10/4  5/9/4
+usemtl __TB_empty
+f  7/8/5  1/7/5  4/6/5  8/5/5
+usemtl __TB_empty
+f  8/4/6  5/3/6  6/2/6  7/1/6`
+
+	builders, library, err := ObjToRaw(objData)
+	if err != nil {
+		t.Fatalf("ObjToRaw returned error: %v", err)
+	}
+	if len(builders) != 1 {
+		t.Fatalf("expected 1 builder, got %d", len(builders))
+	}
+	if len(library.points) != 8 {
+		t.Fatalf("expected 8 points, got %d", len(library.points))
+	}
+	if len(library.uvs) != 12 {
+		t.Fatalf("expected 12 uvs, got %d", len(library.uvs))
+	}
+	if len(library.normals) != 6 {
+		t.Fatalf("expected 6 normals, got %d", len(library.normals))
+	}
+	if len(builders[0].vIndexes) != 36 {
+		t.Fatalf("expected 36 indexes, got %d", len(builders[0].vIndexes))
+	}
+}


### PR DESCRIPTION
Hello. This is my first contribution and I hope I'm following all the right rules. 

I've reported the issue #885 which I fixed in this pull request. I've also added a test that covers the reported issue with empty lines.

When a .obj file has an empty line in it it runs into an index out of range error and panics because it tries to access runes[0] in the obj_loader
